### PR TITLE
check if metadata headers/url values are equal with signed headers

### DIFF
--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -260,3 +260,28 @@ func signV4TrimAll(input string) string {
 	// unicode.IsSpace() internally here) to one space and return
 	return strings.Join(strings.Fields(input), " ")
 }
+
+// checkMetaHeaders will check if the metadata from header/url is the same with the one from signed headers
+func checkMetaHeaders(signedHeadersMap http.Header, r *http.Request) APIErrorCode {
+	// check values from http header
+	for k, val := range r.Header {
+		if stringsHasPrefixFold(k, "X-Amz-Meta-") {
+			if signedHeadersMap.Get(k) == val[0] {
+				continue
+			}
+			return ErrUnsignedHeaders
+		}
+	}
+
+	// check values from url, if no http header
+	for k, val := range r.Form {
+		if stringsHasPrefixFold(k, "x-amz-meta-") {
+			if signedHeadersMap.Get(http.CanonicalHeaderKey(k)) == val[0] {
+				continue
+			}
+			return ErrUnsignedHeaders
+		}
+	}
+
+	return ErrNone
+}

--- a/cmd/signature-v4-utils_test.go
+++ b/cmd/signature-v4-utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -337,5 +337,74 @@ func TestGetContentSha256Cksum(t *testing.T) {
 		if got != testCase.expected {
 			t.Errorf("Test %d: got:%s expected:%s", i+1, got, testCase.expected)
 		}
+	}
+}
+
+// Test TestCheckMetaHeaders tests the logic of checkMetaHeaders() function
+func TestCheckMetaHeaders(t *testing.T) {
+	signedHeadersMap := map[string][]string{
+		"X-Amz-Meta-Test":      {"test"},
+		"X-Amz-Meta-Extension": {"png"},
+		"X-Amz-Meta-Name":      {"imagepng"},
+	}
+	expectedMetaTest := "test"
+	expectedMetaExtension := "png"
+	expectedMetaName := "imagepng"
+	r, err := http.NewRequest(http.MethodPut, "http://play.min.io:9000", nil)
+	if err != nil {
+		t.Fatal("Unable to create http.Request :", err)
+	}
+
+	// Creating input http header.
+	inputHeader := r.Header
+	inputHeader.Set("X-Amz-Meta-Test", expectedMetaTest)
+	inputHeader.Set("X-Amz-Meta-Extension", expectedMetaExtension)
+	inputHeader.Set("X-Amz-Meta-Name", expectedMetaName)
+	// calling the function being tested.
+	errCode := checkMetaHeaders(signedHeadersMap, r)
+	if errCode != ErrNone {
+		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrNone, errCode)
+	}
+
+	// Add new metadata in inputHeader
+	inputHeader.Set("X-Amz-Meta-Clone", "fail")
+	// calling the function being tested.
+	errCode = checkMetaHeaders(signedHeadersMap, r)
+	if errCode != ErrUnsignedHeaders {
+		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrUnsignedHeaders, errCode)
+	}
+
+	// Delete extra metadata from header to don't affect other test
+	inputHeader.Del("X-Amz-Meta-Clone")
+	// calling the function being tested.
+	errCode = checkMetaHeaders(signedHeadersMap, r)
+	if errCode != ErrNone {
+		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrNone, errCode)
+	}
+
+	// Creating input url values
+	r, err = http.NewRequest(http.MethodPut, "http://play.min.io:9000?x-amz-meta-test=test&x-amz-meta-extension=png&x-amz-meta-name=imagepng", nil)
+	if err != nil {
+		t.Fatal("Unable to create http.Request :", err)
+	}
+
+	r.ParseForm()
+	// calling the function being tested.
+	errCode = checkMetaHeaders(signedHeadersMap, r)
+	if errCode != ErrNone {
+		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrNone, errCode)
+	}
+
+	// Add extra metadata in url values
+	r, err = http.NewRequest(http.MethodPut, "http://play.min.io:9000?x-amz-meta-test=test&x-amz-meta-extension=png&x-amz-meta-name=imagepng&x-amz-meta-clone=fail", nil)
+	if err != nil {
+		t.Fatal("Unable to create http.Request :", err)
+	}
+
+	r.ParseForm()
+	// calling the function being tested.
+	errCode = checkMetaHeaders(signedHeadersMap, r)
+	if errCode != ErrUnsignedHeaders {
+		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrUnsignedHeaders, errCode)
 	}
 }

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -227,6 +227,12 @@ func doesPresignedSignatureMatch(hashedPayload string, r *http.Request, region s
 	extractedSignedHeaders, errCode := extractSignedHeaders(pSignValues.SignedHeaders, r)
 	if errCode != ErrNone {
 		return errCode
+	}
+
+	// Check if the metadata headers are equal with signedheaders
+	errMetaCode := checkMetaHeaders(extractedSignedHeaders, r)
+	if errMetaCode != ErrNone {
+		return errMetaCode
 	}
 
 	// If the host which signed the request is slightly ahead in time (by less than globalMaxSkewTime) the


### PR DESCRIPTION


## Description
Check if metadata headers/url values are equal with signed headers

## Motivation and Context
Open a new PR  ( #17693 - closed )
MinIO should have the same behavior like S3.
As it was mention in this isssue https://github.com/minio/minio/issues/16917, MinIO will upload the file with the metadata header send in the request, even if this is not used when generating the signed URL, while AWS will return an error.

## How to test this PR?
Follow steps from https://github.com/minio/minio/issues/16917, with current version of minio and then with this version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
