### PR TITLE
export cluster health as prometheus metrics

### DIFF
--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -138,8 +138,8 @@ func isServerResolvable(endpoint Endpoint, timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
-
-	req.Header.Set("x-minio-from-peer", "true")
+	// Indicate that the liveness check for a peer call
+	req.Header.Set(xhttp.MinIOPeerCall, "true")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -40,6 +40,8 @@ These metrics can be obtained from any MinIO server once per collection.
 | `minio_cluster_kms_uptime`                    | The time the KMS has been up and running in seconds.                                                            |
 | `minio_cluster_nodes_offline_total`           | Total number of MinIO nodes offline.                                                                            |
 | `minio_cluster_nodes_online_total`            | Total number of MinIO nodes online.                                                                             |
+| `minio_cluster_write_quorum`                  | Maximum write quorum across all pools and sets                                                                  |
+| `minio_cluster_health_status`                 | Get current cluster health status                                                                               |
 | `minio_heal_objects_errors_total`             | Objects for which healing failed in current self healing run.                                                   |
 | `minio_heal_objects_heal_total`               | Objects healed in current self healing run.                                                                     |
 | `minio_heal_objects_total`                    | Objects scanned in current self healing run.                                                                    |

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -152,6 +152,9 @@ const (
 	// Deployment id.
 	MinioDeploymentID = "x-minio-deployment-id"
 
+	// Peer call
+	MinIOPeerCall = "x-minio-from-peer"
+
 	// Server-Status
 	MinIOServerStatus = "x-minio-server-status"
 


### PR DESCRIPTION
## Description
export cluster health as prometheus metrics

## Motivation and Context
provides health status of the entire object layer

## How to test this PR?
`minio server /tmp/xl{1...4}` and change the permissions
on the disks to `root` or something. Causing the WRITE
quorum to fail. 

```
chown -R root /tmp/xl1
chown -R root /tmp/xl2

rm -rf /tmp/xl1/.minio.sys
rm -rf /tmp/xl2/.minio.sys
```

Then verify if the `cluster_health_status` shows '0'

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
