### PR TITLE
add ReadFileStream deadline for disk call

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1885,6 +1885,10 @@ func (s *xlStorage) CreateFile(ctx context.Context, volume, path string, fileSiz
 }
 
 func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSize int64, r io.Reader, flags int) (err error) {
+	if contextCanceled(ctx) {
+		return ctx.Err()
+	}
+
 	// Create top level directories if they don't exist.
 	// with mode 0777 mkdir honors system umask.
 	parentFilePath := pathutil.Dir(filePath)
@@ -1939,6 +1943,10 @@ func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSiz
 }
 
 func (s *xlStorage) writeAll(ctx context.Context, volume string, path string, b []byte, sync bool) (err error) {
+	if contextCanceled(ctx) {
+		return ctx.Err()
+	}
+
 	volumeDir, err := s.getVolDir(volume)
 	if err != nil {
 		return err
@@ -2837,7 +2845,7 @@ func (s *xlStorage) CleanAbandonedData(ctx context.Context, volume string, path 
 			newBuf, err := xl.AppendTo(metaDataPoolGet())
 			if err == nil {
 				defer metaDataPoolPut(newBuf)
-				return s.writeAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf, false)
+				return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
 			}
 		}
 	}

--- a/internal/ioutil/ioutil.go
+++ b/internal/ioutil/ioutil.go
@@ -73,7 +73,54 @@ type ioret struct {
 	err error
 }
 
-// DeadlineWriter deadline writer with context
+// DeadlineReader deadline reader with timeout
+type DeadlineReader struct {
+	io.ReadCloser
+	timeout time.Duration
+	err     error
+}
+
+// NewDeadlineReader wraps a writer to make it respect given deadline
+// value per Write(). If there is a blocking write, the returned Reader
+// will return whenever the timer hits (the return values are n=0
+// and err=context.DeadlineExceeded.)
+func NewDeadlineReader(r io.ReadCloser, timeout time.Duration) io.ReadCloser {
+	return &DeadlineReader{ReadCloser: r, timeout: timeout}
+}
+
+func (r *DeadlineReader) Read(buf []byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	c := make(chan ioret, 1)
+	t := time.NewTimer(r.timeout)
+	go func() {
+		n, err := r.ReadCloser.Read(buf)
+		c <- ioret{n, err}
+		close(c)
+	}()
+
+	select {
+	case res := <-c:
+		if !t.Stop() {
+			<-t.C
+		}
+		r.err = res.err
+		return res.n, res.err
+	case <-t.C:
+		r.ReadCloser.Close()
+		r.err = context.DeadlineExceeded
+		return 0, context.DeadlineExceeded
+	}
+}
+
+// Close closer interface to close the underlying closer
+func (r *DeadlineReader) Close() error {
+	return r.ReadCloser.Close()
+}
+
+// DeadlineWriter deadline writer with timeout
 type DeadlineWriter struct {
 	io.WriteCloser
 	timeout time.Duration
@@ -119,15 +166,15 @@ func (d *DeadlineWorker) Run(work func() error) error {
 		d.err = r.err
 		return r.err
 	case <-t.C:
-		d.err = context.Canceled
-		return context.Canceled
+		d.err = context.DeadlineExceeded
+		return context.DeadlineExceeded
 	}
 }
 
 // NewDeadlineWriter wraps a writer to make it respect given deadline
 // value per Write(). If there is a blocking write, the returned Writer
 // will return whenever the timer hits (the return values are n=0
-// and err=context.Canceled.)
+// and err=context.DeadlineExceeded.)
 func NewDeadlineWriter(w io.WriteCloser, timeout time.Duration) io.WriteCloser {
 	return &DeadlineWriter{WriteCloser: w, timeout: timeout}
 }
@@ -154,8 +201,8 @@ func (w *DeadlineWriter) Write(buf []byte) (int, error) {
 		return r.n, r.err
 	case <-t.C:
 		w.WriteCloser.Close()
-		w.err = context.Canceled
-		return 0, context.Canceled
+		w.err = context.DeadlineExceeded
+		return 0, context.DeadlineExceeded
 	}
 }
 


### PR DESCRIPTION

## Description
add ReadFileStream deadline for disk call

## Motivation and Context
timeout the reader side if hung via disk max timeout

## How to test this PR?
Not easy, needs mock code. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
