### PR TITLE
logger: Avoid slow calls in http logger Send() function

### DIFF
--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -28,7 +28,6 @@ import (
 	"github.com/minio/minio/internal/mcontext"
 	"github.com/minio/pkg/logger/message/audit"
 
-	"github.com/minio/madmin-go/v3"
 	xhttp "github.com/minio/minio/internal/http"
 )
 
@@ -145,7 +144,7 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 	// Send audit logs only to http targets.
 	for _, t := range auditTgts {
 		if err := t.Send(ctx, entry); err != nil {
-			LogAlwaysIf(context.Background(), fmt.Errorf("event(%v) was not sent to Audit target (%v): %v", entry, t, err), madmin.LogKindAll)
+			LogOnceIf(ctx, fmt.Errorf("Unable to send an audit event to the target `%v`: %v", t, err), "send-audit-event-failure")
 		}
 	}
 }


### PR DESCRIPTION
## Description
Send() is synchronous and can affect the latency of S3 requests 
when the logger buffer is full.

Avoid checking if the http target is online or not and increase the 
workers anyway since the buffer is already full.

Also avoid logs flooding when the audit target is down.

## Motivation and Context
Address a possible outage when the audit is down and the logger http target has a high latency
Address reduced IO when the http target has a high latency and the logger buffer is always full


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
