### PR TITLE
allow disabling O_DIRECT for write ops

### DIFF
--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -94,7 +94,7 @@ var (
 		},
 		config.HelpKV{
 			Key:         apiDisableODirect,
-			Description: "set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing" + defaultHelpPostfix(apiDisableODirect),
+			Description: "set to disable O_DIRECT for read and writes under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing" + defaultHelpPostfix(apiDisableODirect),
 			Optional:    true,
 			Type:        "boolean",
 		},


### PR DESCRIPTION

## Description
allow disabling O_DIRECT for write ops

## Motivation and Context
on really slow systems, O_DIRECT simply kills the 
drives allowing for a way to disable them.

## How to test this PR?
You need terrible setups and questionable hardware. This change
simply makes all I/O page-cached which is okay with enough
erasure coding.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
