### PR TITLE
introduce 'mc admin config set alias/ api odirect=on'

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -49,7 +49,7 @@ type apiConfig struct {
 	staleUploadsExpiry          time.Duration
 	staleUploadsCleanupInterval time.Duration
 	deleteCleanupInterval       time.Duration
-	disableODirect              bool
+	enableODirect               bool
 	gzipObjects                 bool
 	rootAccess                  bool
 	syncEvents                  bool
@@ -164,17 +164,17 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.staleUploadsExpiry = cfg.StaleUploadsExpiry
 	t.staleUploadsCleanupInterval = cfg.StaleUploadsCleanupInterval
 	t.deleteCleanupInterval = cfg.DeleteCleanupInterval
-	t.disableODirect = cfg.DisableODirect
+	t.enableODirect = cfg.EnableODirect
 	t.gzipObjects = cfg.GzipObjects
 	t.rootAccess = cfg.RootAccess
 	t.syncEvents = cfg.SyncEvents
 }
 
-func (t *apiConfig) isDisableODirect() bool {
+func (t *apiConfig) odirectEnabled() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	return t.disableODirect
+	return t.enableODirect
 }
 
 func (t *apiConfig) shouldGzipObjects() bool {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -284,7 +284,7 @@ func newXLStorage(ep Endpoint, cleanUp bool) (s *xlStorage, err error) {
 		s.formatLegacy = format.Erasure.DistributionAlgo == formatErasureVersionV2DistributionAlgoV1
 	}
 
-	if !globalAPIConfig.isDisableODirect() {
+	if globalAPIConfig.odirectEnabled() {
 		// Return an error if ODirect is not supported
 		// unless it is a single erasure disk mode
 		if err := s.checkODirectDiskSupport(); err == nil {
@@ -1480,7 +1480,7 @@ func (s *xlStorage) readAllData(ctx context.Context, volumeDir string, filePath 
 		return nil, time.Time{}, ctx.Err()
 	}
 
-	odirectEnabled := !globalAPIConfig.isDisableODirect() && s.oDirect
+	odirectEnabled := globalAPIConfig.odirectEnabled() && s.oDirect
 	var f *os.File
 	if odirectEnabled {
 		f, err = OpenFileDirectIO(filePath, readMode, 0o666)
@@ -1761,7 +1761,7 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 		return nil, err
 	}
 
-	odirectEnabled := !globalAPIConfig.isDisableODirect() && s.oDirect
+	odirectEnabled := globalAPIConfig.odirectEnabled() && s.oDirect
 
 	var file *os.File
 	if odirectEnabled {
@@ -1898,7 +1898,7 @@ func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSiz
 		return osErrToFileErr(err)
 	}
 
-	odirectEnabled := !globalAPIConfig.isDisableODirect() && s.oDirect
+	odirectEnabled := globalAPIConfig.odirectEnabled() && s.oDirect
 
 	var w *os.File
 	if odirectEnabled {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -143,7 +143,9 @@ transition_workers              (number)    set the number of transition workers
 stale_uploads_expiry            (duration)  set to expire stale multipart uploads older than this values (default: '24h')
 stale_uploads_cleanup_interval  (duration)  set to change intervals when stale multipart uploads are expired (default: '6h')
 delete_cleanup_interval         (duration)  set to change intervals when deleted objects are permanently deleted from ".trash" folder (default: '5m')
-disable_odirect                 (boolean)   set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing. (default: 'off')
+odirect                         (boolean)   set to enable or disable O_DIRECT for read and writes under special conditions. NOTE: do not disable O_DIRECT without prior testing (default: 'on')
+root_access                     (boolean)   turn 'off' root credential access for all API calls including s3, admin operations (default: 'on')
+sync_events                     (boolean)   set to enable synchronous bucket notifications (default: 'off')
 ```
 
 or environment variables
@@ -160,7 +162,9 @@ MINIO_API_TRANSITION_WORKERS              (number)    set the number of transiti
 MINIO_API_STALE_UPLOADS_EXPIRY            (duration)  set to expire stale multipart uploads older than this values (default: '24h')
 MINIO_API_STALE_UPLOADS_CLEANUP_INTERVAL  (duration)  set to change intervals when stale multipart uploads are expired (default: '6h')
 MINIO_API_DELETE_CLEANUP_INTERVAL         (duration)  set to change intervals when deleted objects are permanently deleted from ".trash" folder (default: '5m')
-MINIO_API_DISABLE_ODIRECT                 (boolean)   set to disable O_DIRECT for reads under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing. (default: 'off')
+MINIO_API_ODIRECT                         (boolean)   set to enable or disable O_DIRECT for read and writes under special conditions. NOTE: do not disable O_DIRECT without prior testing (default: 'on')
+MINIO_API_ROOT_ACCESS                     (boolean)   turn 'off' root credential access for all API calls including s3, admin operations (default: 'on')
+MINIO_API_SYNC_EVENTS                     (boolean)   set to enable synchronous bucket notifications (default: 'off')
 ```
 
 #### Notifications

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -93,8 +93,8 @@ var (
 			Type:        "duration",
 		},
 		config.HelpKV{
-			Key:         apiDisableODirect,
-			Description: "set to disable O_DIRECT for read and writes under special conditions. NOTE: it is not recommended to disable O_DIRECT without prior testing" + defaultHelpPostfix(apiDisableODirect),
+			Key:         apiODirect,
+			Description: "set to enable or disable O_DIRECT for read and writes under special conditions. NOTE: do not disable O_DIRECT without prior testing" + defaultHelpPostfix(apiODirect),
 			Optional:    true,
 			Type:        "boolean",
 		},


### PR DESCRIPTION
## Description
introduce 'mc admin config set alias/ api odirect=on'

## Motivation and Context
change disable_odirect=off -> odirect=on to make it
more easier to understand, instead of making it double
negative.

## How to test this PR?
Nothing surprising thing here, it simply re-imagines
disable_odirect=off/on -> odirect=on/off

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
