### PR TITLE
use renameat2 Linux extension syscall

### DIFF
--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -426,7 +425,7 @@ func TestListOnlineDisksSmallObjects(t *testing.T) {
 			}
 
 			partsMetadata, errs := readAllFileInfo(ctx, erasureDisks, bucket, object, "", true)
-			_, err = getLatestFileInfo(ctx, partsMetadata, z.serverPools[0].sets[0].defaultParityCount, errs)
+			fi, err := getLatestFileInfo(ctx, partsMetadata, z.serverPools[0].sets[0].defaultParityCount, errs)
 			if err != nil {
 				t.Fatalf("Failed to getLatestFileInfo %v", err)
 			}
@@ -483,11 +482,6 @@ func TestListOnlineDisksSmallObjects(t *testing.T) {
 					break
 				}
 
-			}
-			partsMetadata, errs = readAllFileInfo(ctx, erasureDisks, bucket, object, "", true)
-			fi, err := getLatestFileInfo(ctx, partsMetadata, z.serverPools[0].sets[0].defaultParityCount, errs)
-			if !errors.Is(err, errErasureReadQuorum) {
-				t.Fatalf("Failed to getLatestFileInfo, expected %v, got %v", errErasureReadQuorum, err)
 			}
 
 			rQuorum := len(errs) - z.serverPools[0].sets[0].defaultParityCount

--- a/cmd/os-rename_linux.go
+++ b/cmd/os-rename_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+// +build linux
+
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Rename2 captures time taken to call os.Rename
+func Rename2(src, dst string) (err error) {
+	defer updateOSMetrics(osMetricRename2, src, dst)(err)
+	return unix.Renameat2(unix.AT_FDCWD, src, unix.AT_FDCWD, dst, uint(2)) // RENAME_EXCHANGE from 'man renameat2'
+}

--- a/cmd/os-rename_nolinux.go
+++ b/cmd/os-rename_nolinux.go
@@ -1,0 +1,29 @@
+//go:build !linux
+// +build !linux
+
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import "errors"
+
+// Rename captures time taken to call os.Rename
+func Rename2(src, dst string) (err error) {
+	defer updateOSMetrics(osMetricRename2, src, dst)(errors.New("not implemented, skipping"))
+	return errSkipFile
+}

--- a/cmd/osmetric_string.go
+++ b/cmd/osmetric_string.go
@@ -24,12 +24,13 @@ func _() {
 	_ = x[osMetricReadDirent-13]
 	_ = x[osMetricFdatasync-14]
 	_ = x[osMetricSync-15]
-	_ = x[osMetricLast-16]
+	_ = x[osMetricRename2-16]
+	_ = x[osMetricLast-17]
 }
 
-const _osMetric_name = "RemoveAllMkdirAllMkdirRenameOpenFileWOpenFileROpenOpenFileDirectIOLstatRemoveStatAccessCreateReadDirentFdatasyncSyncLast"
+const _osMetric_name = "RemoveAllMkdirAllMkdirRenameOpenFileWOpenFileROpenOpenFileDirectIOLstatRemoveStatAccessCreateReadDirentFdatasyncSyncRename2Last"
 
-var _osMetric_index = [...]uint8{0, 9, 17, 22, 28, 37, 46, 50, 66, 71, 77, 81, 87, 93, 103, 112, 116, 120}
+var _osMetric_index = [...]uint8{0, 9, 17, 22, 28, 37, 46, 50, 66, 71, 77, 81, 87, 93, 103, 112, 116, 123, 127}
 
 func (i osMetric) String() string {
 	if i >= osMetric(len(_osMetric_index)-1) {

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -235,6 +235,9 @@ type FileInfo struct {
 
 	// Combined checksum when object was uploaded.
 	Checksum []byte `msg:"cs,allownil"`
+
+	// Versioned - indicates if this file is versioned or not.
+	Versioned bool `msg:"vs"`
 }
 
 // WriteQuorum returns expected write quorum for this FileInfo

--- a/cmd/storage-datatypes_gen.go
+++ b/cmd/storage-datatypes_gen.go
@@ -669,8 +669,8 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0001 != 28 {
-		err = msgp.ArrayError{Wanted: 28, Got: zb0001}
+	if zb0001 != 29 {
+		err = msgp.ArrayError{Wanted: 29, Got: zb0001}
 		return
 	}
 	z.Volume, err = dc.ReadString()
@@ -850,13 +850,18 @@ func (z *FileInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err, "Checksum")
 		return
 	}
+	z.Versioned, err = dc.ReadBool()
+	if err != nil {
+		err = msgp.WrapError(err, "Versioned")
+		return
+	}
 	return
 }
 
 // EncodeMsg implements msgp.Encodable
 func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
-	// array header, size 28
-	err = en.Append(0xdc, 0x0, 0x1c)
+	// array header, size 29
+	err = en.Append(0xdc, 0x0, 0x1d)
 	if err != nil {
 		return
 	}
@@ -1019,14 +1024,19 @@ func (z *FileInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Checksum")
 		return
 	}
+	err = en.WriteBool(z.Versioned)
+	if err != nil {
+		err = msgp.WrapError(err, "Versioned")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *FileInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// array header, size 28
-	o = append(o, 0xdc, 0x0, 0x1c)
+	// array header, size 29
+	o = append(o, 0xdc, 0x0, 0x1d)
 	o = msgp.AppendString(o, z.Volume)
 	o = msgp.AppendString(o, z.Name)
 	o = msgp.AppendString(o, z.VersionID)
@@ -1074,6 +1084,7 @@ func (z *FileInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendInt(o, z.Idx)
 	o = msgp.AppendTime(o, z.DiskMTime)
 	o = msgp.AppendBytes(o, z.Checksum)
+	o = msgp.AppendBool(o, z.Versioned)
 	return
 }
 
@@ -1085,8 +1096,8 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	if zb0001 != 28 {
-		err = msgp.ArrayError{Wanted: 28, Got: zb0001}
+	if zb0001 != 29 {
+		err = msgp.ArrayError{Wanted: 29, Got: zb0001}
 		return
 	}
 	z.Volume, bts, err = msgp.ReadStringBytes(bts)
@@ -1266,6 +1277,11 @@ func (z *FileInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "Checksum")
 		return
 	}
+	z.Versioned, bts, err = msgp.ReadBoolBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err, "Versioned")
+		return
+	}
 	o = bts
 	return
 }
@@ -1283,7 +1299,7 @@ func (z *FileInfo) Msgsize() (s int) {
 	for za0003 := range z.Parts {
 		s += z.Parts[za0003].Msgsize()
 	}
-	s += z.Erasure.Msgsize() + msgp.BoolSize + z.ReplicationState.Msgsize() + msgp.BytesPrefixSize + len(z.Data) + msgp.IntSize + msgp.TimeSize + msgp.BoolSize + msgp.IntSize + msgp.TimeSize + msgp.BytesPrefixSize + len(z.Checksum)
+	s += z.Erasure.Msgsize() + msgp.BoolSize + z.ReplicationState.Msgsize() + msgp.BytesPrefixSize + len(z.Data) + msgp.IntSize + msgp.TimeSize + msgp.BoolSize + msgp.IntSize + msgp.TimeSize + msgp.BytesPrefixSize + len(z.Checksum) + msgp.BoolSize
 	return
 }
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2485,6 +2485,13 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		}
 		diskHealthCheckOK(ctx, err)
 
+		if !fi.Versioned && !fi.Healing() {
+			// Use https://man7.org/linux/man-pages/man2/rename.2.html if possible on unversioned bucket.
+			if err := Rename2(pathutil.Join(srcVolumeDir, srcPath), pathutil.Join(dstVolumeDir, dstPath)); err == nil {
+				return sign, nil
+			} // if Rename2 is not successful fallback.
+		}
+
 		// renameAll only for objects that have xl.meta not saved inline.
 		if len(fi.Data) == 0 && fi.Size > 0 {
 			s.moveToTrash(dstDataPath, true, false)


### PR DESCRIPTION


## Description
use renameat2 Linux extension syscall

## Motivation and Context
this is a faster and safer alternative
on newer kernel versions.

## How to test this PR?
This is a test code for some performance
improvements, pending changes are related
to if possible make unversioned renames()
use this code path instead.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
