### PR TITLE
do not crash on invalid metric values

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -2953,7 +2953,7 @@ func (c *minioBucketCollector) Collect(out chan<- prometheus.Metric) {
 					continue
 				}
 				for k, v := range metric.Histogram {
-					out <- prometheus.MustNewConstMetric(
+					pmetric, err := prometheus.NewConstMetric(
 						prometheus.NewDesc(
 							prometheus.BuildFQName(string(metric.Description.Namespace),
 								string(metric.Description.Subsystem),
@@ -2965,6 +2965,11 @@ func (c *minioBucketCollector) Collect(out chan<- prometheus.Metric) {
 						prometheus.GaugeValue,
 						float64(v),
 						append(values, k)...)
+					if err != nil {
+						logger.LogOnceIf(GlobalContext, fmt.Errorf("unable to validate prometheus metric (%w) %v+%v", err, values, metric.Histogram), "bucket-metrics-histogram")
+					} else {
+						out <- pmetric
+					}
 				}
 				continue
 			}
@@ -2972,7 +2977,7 @@ func (c *minioBucketCollector) Collect(out chan<- prometheus.Metric) {
 			if metric.Description.Type == counterMetric {
 				metricType = prometheus.CounterValue
 			}
-			toPost := prometheus.MustNewConstMetric(
+			pmetric, err := prometheus.NewConstMetric(
 				prometheus.NewDesc(
 					prometheus.BuildFQName(string(metric.Description.Namespace),
 						string(metric.Description.Subsystem),
@@ -2984,7 +2989,11 @@ func (c *minioBucketCollector) Collect(out chan<- prometheus.Metric) {
 				metricType,
 				metric.Value,
 				values...)
-			out <- toPost
+			if err != nil {
+				logger.LogOnceIf(GlobalContext, fmt.Errorf("unable to validate prometheus metric (%w) %v", err, values), "bucket-metrics")
+			} else {
+				out <- pmetric
+			}
 		}
 	}
 
@@ -3024,7 +3033,7 @@ func (c *minioClusterCollector) Collect(out chan<- prometheus.Metric) {
 					continue
 				}
 				for k, v := range metric.Histogram {
-					out <- prometheus.MustNewConstMetric(
+					pmetric, err := prometheus.NewConstMetric(
 						prometheus.NewDesc(
 							prometheus.BuildFQName(string(metric.Description.Namespace),
 								string(metric.Description.Subsystem),
@@ -3036,6 +3045,11 @@ func (c *minioClusterCollector) Collect(out chan<- prometheus.Metric) {
 						prometheus.GaugeValue,
 						float64(v),
 						append(values, k)...)
+					if err != nil {
+						logger.LogOnceIf(GlobalContext, fmt.Errorf("unable to validate prometheus metric (%w) %v:%v", err, values, metric.Histogram), "cluster-metrics-histogram")
+					} else {
+						out <- pmetric
+					}
 				}
 				continue
 			}
@@ -3043,7 +3057,7 @@ func (c *minioClusterCollector) Collect(out chan<- prometheus.Metric) {
 			if metric.Description.Type == counterMetric {
 				metricType = prometheus.CounterValue
 			}
-			toPost := prometheus.MustNewConstMetric(
+			pmetric, err := prometheus.NewConstMetric(
 				prometheus.NewDesc(
 					prometheus.BuildFQName(string(metric.Description.Namespace),
 						string(metric.Description.Subsystem),
@@ -3055,7 +3069,11 @@ func (c *minioClusterCollector) Collect(out chan<- prometheus.Metric) {
 				metricType,
 				metric.Value,
 				values...)
-			out <- toPost
+			if err != nil {
+				logger.LogOnceIf(GlobalContext, fmt.Errorf("unable to validate prometheus metric (%w) %v", err, values), "cluster-metrics")
+			} else {
+				out <- pmetric
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
do not crash on invalid metric values

## Motivation and Context
```
minio[1032735]: panic: label value "\xc0.\xc0." is not valid UTF-8
minio[1032735]: goroutine 1781101 [running]:
minio[1032735]: github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
```
log such errors for investigation

## How to test this PR?
Nothing special requires an environment with some
non-UTF-8 values not sure how this is possible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
