### PR TITLE
replication resync: fix queueing

### DIFF
--- a/cmd/bucket-replication-utils.go
+++ b/cmd/bucket-replication-utils.go
@@ -720,6 +720,7 @@ type TargetReplicationResyncStatus struct {
 	// Last bucket/object replicated.
 	Bucket string `json:"-" msg:"bkt"`
 	Object string `json:"-" msg:"obj"`
+	Error  error  `json:"-" msg:"-"`
 }
 
 // BucketReplicationResyncStatus captures current replication resync status

--- a/cmd/site-replication-utils.go
+++ b/cmd/site-replication-utils.go
@@ -292,22 +292,22 @@ func siteResyncStatus(currSt ResyncStatusType, m map[string]ResyncStatusType) Re
 }
 
 // update resync metrics per object
-func (sm *siteResyncMetrics) updateMetric(roi ReplicateObjectInfo, success bool, resyncID string) {
+func (sm *siteResyncMetrics) updateMetric(r TargetReplicationResyncStatus, resyncID string) {
 	if !globalSiteReplicationSys.isEnabled() {
 		return
 	}
 	sm.Lock()
 	defer sm.Unlock()
 	s := sm.resyncStatus[resyncID]
-	if success {
+	if r.ReplicatedCount > 0 {
 		s.ReplicatedCount++
-		s.ReplicatedSize += roi.Size
+		s.ReplicatedSize += r.ReplicatedSize
 	} else {
 		s.FailedCount++
-		s.FailedSize += roi.Size
+		s.FailedSize += r.FailedSize
 	}
-	s.Bucket = roi.Bucket
-	s.Object = roi.Name
+	s.Bucket = r.Bucket
+	s.Object = r.Object
 	s.LastUpdate = UTCNow()
 	sm.resyncStatus[resyncID] = s
 }

--- a/docs/bucket/replication/setup_2site_existing_replication.sh
+++ b/docs/bucket/replication/setup_2site_existing_replication.sh
@@ -84,7 +84,7 @@ remote_arn=$(./mc replicate ls sitea/bucket --json | jq -r .rule.Destination.Buc
 sleep 1
 
 ./mc replicate resync start sitea/bucket/ --remote-bucket "${remote_arn}"
-sleep 30s ## sleep for 30s idea is that we give 300ms per object.
+sleep 10s ## sleep for 10s idea is that we give 100ms per object.
 
 count=$(./mc replicate resync status sitea/bucket --remote-bucket "${remote_arn}" --json | jq .resyncInfo.target[].replicationCount)
 


### PR DESCRIPTION
Assign resync of all versions of object to the same worker to avoid locking contention. Fixes parallel resync implementation in #16707

## Description


## Motivation and Context
replication of all versions of object need to serialize because of the need to acquire a replication namespace lock at the object level - assigning it to concurrent workers was causing slowness.

## How to test this PR?
CI/CD tests should not fail :)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
