### PR TITLE
fix: crash in globalTierJournal when TierConfig is not initialized

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -346,7 +346,7 @@ var (
 
 	globalTierConfigMgr *TierConfigMgr
 
-	globalTierJournal *tierJournal
+	globalTierJournal *TierJournal
 
 	globalConsoleSrv *restapi.Server
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -362,6 +362,7 @@ func initAllSubsystems(ctx context.Context) {
 
 	// Create new ILM tier configuration subsystem
 	globalTierConfigMgr = NewTierConfigMgr()
+	globalTierJournal = NewTierJournal()
 
 	globalTransitionState = newTransitionState(GlobalContext)
 	globalSiteResyncMetrics = newSiteResyncMetrics(GlobalContext)
@@ -798,14 +799,10 @@ func serverMain(ctx *cli.Context) {
 		go func() {
 			// Initialize transition tier configuration manager
 			bootstrapTrace("globalTierConfigMgr.Init")
-			err := globalTierConfigMgr.Init(GlobalContext, newObject)
-			if err != nil {
+			if err := globalTierConfigMgr.Init(GlobalContext, newObject); err != nil {
 				logger.LogIf(GlobalContext, err)
 			} else {
-				globalTierJournal, err = initTierDeletionJournal(GlobalContext)
-				if err != nil {
-					logger.FatalIf(err, "Unable to initialize remote tier pending deletes journal")
-				}
+				logger.FatalIf(globalTierJournal.Init(GlobalContext), "Unable to initialize remote tier pending deletes journal")
 			}
 		}()
 

--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -32,7 +32,7 @@ import (
 )
 
 //go:generate msgp -file $GOFILE -unexported
-//msgp:ignore tierJournal tierDiskJournal walkfn
+//msgp:ignore TierJournal tierDiskJournal walkfn
 
 type tierDiskJournal struct {
 	sync.RWMutex
@@ -40,7 +40,8 @@ type tierDiskJournal struct {
 	file     *os.File // active journal file
 }
 
-type tierJournal struct {
+// TierJournal holds an in-memory and an on-disk delete journal of tiered content.
+type TierJournal struct {
 	*tierDiskJournal // for processing legacy journal entries
 	*tierMemJournal  // for processing new journal entries
 }
@@ -62,24 +63,28 @@ func newTierDiskJournal() *tierDiskJournal {
 	return &tierDiskJournal{}
 }
 
-// initTierDeletionJournal intializes an in-memory journal built using a
-// buffered channel for new journal entries. It also initializes the on-disk
-// journal only to process existing journal entries made from previous versions.
-func initTierDeletionJournal(ctx context.Context) (*tierJournal, error) {
-	j := &tierJournal{
-		tierMemJournal:  newTierMemJoural(1000),
+// NewTierJournal initializes tier deletion journal
+func NewTierJournal() *TierJournal {
+	j := &TierJournal{
+		tierMemJournal:  newTierMemJournal(1000),
 		tierDiskJournal: newTierDiskJournal(),
 	}
+	return j
+}
 
+// Init intializes an in-memory journal built using a
+// buffered channel for new journal entries. It also initializes the on-disk
+// journal only to process existing journal entries made from previous versions.
+func (t *TierJournal) Init(ctx context.Context) error {
 	for _, diskPath := range globalEndpoints.LocalDisksPaths() {
-		j.diskPath = diskPath
+		t.diskPath = diskPath
 
-		go j.deletePending(ctx)  // for existing journal entries from previous MinIO versions
-		go j.processEntries(ctx) // for newer journal entries circa free-versions
-		return j, nil
+		go t.deletePending(ctx)  // for existing journal entries from previous MinIO versions
+		go t.processEntries(ctx) // for newer journal entries circa free-versions
+		return nil
 	}
 
-	return nil, errors.New("no local drive found")
+	return errors.New("no local drive found")
 }
 
 // rotate rotates the journal. If a read-only journal already exists it does

--- a/cmd/tier-mem-journal.go
+++ b/cmd/tier-mem-journal.go
@@ -28,7 +28,7 @@ type tierMemJournal struct {
 	entries chan jentry
 }
 
-func newTierMemJoural(nevents int) *tierMemJournal {
+func newTierMemJournal(nevents int) *tierMemJournal {
 	return &tierMemJournal{
 		entries: make(chan jentry, nevents),
 	}


### PR DESCRIPTION
## Description
fix: crash in globalTierJournal when TierConfig is not initialized

## Motivation and Context
fixes a crash

```
runtime.sigpanic()
runtime/signal_unix.go:839 +0x2f6 fp=0xc0382f8098 sp=0xc0382f8048 pc=0x451356
github.com/minio/minio/cmd.expireTransitionedObject({_, _}, {_, _}, _, {{0xc0e6d2fdc0, 0x38}, {0x0, 0x0}, {0x25ae66b4, ...}, ...}, ...)
github.com/minio/minio/cmd/bucket-lifecycle.go:405 +0x3fb fp=0xc0382f9600 sp=0xc0382f8098 pc=0x20b09fb
```

## How to test this PR?
Generate an error loading tierConfig

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
