### PR TITLE
skip disks under scanning when healing disks

### DIFF
--- a/cmd/background-heal-ops.go
+++ b/cmd/background-heal-ops.go
@@ -75,9 +75,9 @@ func waitForLowIO(maxIO int, maxWait time.Duration, currentIO func() int) {
 		if tmpMaxWait > 0 {
 			if tmpMaxWait < waitTick {
 				time.Sleep(tmpMaxWait)
-			} else {
-				time.Sleep(waitTick)
+				return
 			}
+			time.Sleep(waitTick)
 			tmpMaxWait -= waitTick
 		}
 		if tmpMaxWait <= 0 {

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -325,7 +325,7 @@ func (er erasureObjects) getOnlineDisksWithHealing() (newDisks []StorageAPI, hea
 		}
 	}
 
-	// Add the disks being currently actively scanned to the
+	// Prefer new disks over disks which are currently being scanned. 
 	// end to avoid them to be consider for listing first.
 	newDisks = append(newDisks, scanningDisks...)
 

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -325,8 +325,7 @@ func (er erasureObjects) getOnlineDisksWithHealing() (newDisks []StorageAPI, hea
 		}
 	}
 
-	// Prefer new disks over disks which are currently being scanned. 
-	// end to avoid them to be consider for listing first.
+	// Prefer new disks over disks which are currently being scanned.
 	newDisks = append(newDisks, scanningDisks...)
 
 	return newDisks, healing

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -309,6 +309,7 @@ func (er erasureObjects) getOnlineDisksWithHealing() (newDisks []StorageAPI, hea
 	}
 	wg.Wait()
 
+	var scanningDisks []StorageAPI
 	for i, info := range infos {
 		// Check if one of the drives in the set is being healed.
 		// this information is used by scanner to skip healing
@@ -317,8 +318,16 @@ func (er erasureObjects) getOnlineDisksWithHealing() (newDisks []StorageAPI, hea
 			healing = true
 			continue
 		}
-		newDisks = append(newDisks, disks[i])
+		if !info.Scanning {
+			newDisks = append(newDisks, disks[i])
+		} else {
+			scanningDisks = append(scanningDisks, disks[i])
+		}
 	}
+
+	// Add the disks being currently actively scanned to the
+	// end to avoid them to be consider for listing first.
+	newDisks = append(newDisks, scanningDisks...)
 
 	return newDisks, healing
 }

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -192,7 +192,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 		tracker.setObject("")
 		tracker.setBucket(bucket)
 		// Heal current bucket again in case if it is failed
-		// in the being of erasure set healing
+		// in the beginning of erasure set healing
 		if _, err := er.HealBucket(ctx, bucket, madmin.HealOpts{
 			ScanMode: scanMode,
 		}); err != nil {

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -93,7 +93,7 @@ type xlStorageDiskIDCheck struct {
 
 func (p *xlStorageDiskIDCheck) getMetrics() DiskMetrics {
 	p.metricsCache.Once.Do(func() {
-		p.metricsCache.TTL = 100 * time.Millisecond
+		p.metricsCache.TTL = 1 * time.Second
 		p.metricsCache.Update = func() (interface{}, error) {
 			diskMetric := DiskMetrics{
 				LastMinute: make(map[string]AccElem, len(p.apiLatencies)),

--- a/internal/config/heal/heal.go
+++ b/internal/config/heal/heal.go
@@ -97,7 +97,7 @@ var DefaultKVS = config.KVS{
 	},
 	config.KV{
 		Key:   Sleep,
-		Value: "1s",
+		Value: "250ms",
 	},
 	config.KV{
 		Key:   IOCount,


### PR DESCRIPTION

## Description
skip disks under scanning when healing disks

## Motivation and Context
Bonus: avoid calling DiskInfo() calls when missing blocks 
instead heal the object using MRF operation.

## How to test this PR?
The main motivation here is to save on IOPs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
