### PR TITLE
fix: batch status reporting after complete

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -95,6 +95,9 @@ func init() {
 
 	initGlobalContext()
 
+	globalBatchJobsMetrics = batchJobMetrics{metrics: make(map[string]*batchJobInfo)}
+	go globalBatchJobsMetrics.purgeJobMetrics()
+
 	t, _ := minioVersionToReleaseTime(Version)
 	if !t.IsZero() {
 		globalVersionUnix = uint64(t.Unix())

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -399,6 +399,9 @@ var (
 
 	// Set last client perf extra time (get lock, and validate)
 	globalLastClientPerfExtraTime int64
+
+	// Captures all batch jobs metrics globally
+	globalBatchJobsMetrics batchJobMetrics
 	// Add new variable global values here.
 )
 


### PR DESCRIPTION


## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: batch status reporting after complete

## Motivation and Context
batch status can perpetually wait until after the completion 
due to a race between the MetricsHandler() returning 
the active metrics in intervals of 1sec and delete 
of metrics after job completion.

this PR ensures that we keep the 'status' around
for a while, i.e. upto 24hrs for all the batch jobs.

## How to test this PR?
You need to test this via `mc batch status` for lets say
key rotate job.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
