### PR TITLE
Fix distributed listing not able to resume

### DIFF
--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -129,7 +129,8 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 				return entries, io.EOF
 			}
 			if !errors.Is(err, context.DeadlineExceeded) {
-				o.debugln("listPath: got error", err)
+				// Report error once per bucket, but continue listing.
+				logger.LogOnceIf(ctx, err, "GetMetacacheListing:"+o.Bucket)
 			}
 			o.Transient = true
 			o.Create = false

--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -105,8 +105,9 @@ type ExpireDeleteMarker struct {
 
 // Boolean signifies a boolean XML struct with custom marshaling
 type Boolean struct {
-	val bool
-	set bool
+	val    bool
+	set    bool
+	Unused struct{} // Needed for GOB compatibility
 }
 
 // Expiration - expiration actions for a rule in lifecycle configuration.

--- a/internal/bucket/lifecycle/prefix.go
+++ b/internal/bucket/lifecycle/prefix.go
@@ -24,7 +24,8 @@ import (
 // Prefix holds the prefix xml tag in <Rule> and <Filter>
 type Prefix struct {
 	string
-	set bool
+	set    bool
+	Unused struct{} // Needed for GOB compatibility
 }
 
 // UnmarshalXML - decodes XML data.


### PR DESCRIPTION
## Description

Two fields in lifecycles made GOB encoding consistently fail with `gob: type lifecycle.Prefix has no exported fields`.

This meant that in distributed systems listings would never be able to continue and would restart on every call.

Fix issues and be sure to log these errors at least once per bucket. We may see some connectivity errors here, but we shouldn't hide them.

## How to test this PR?

Set `_MINIO_SERVER_DEBUG=on`. Observe if listings are reused.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
