### PR TITLE
Revert "Include SuccessorModTime for FileInfo quorum (#17732)"

### DIFF
--- a/buildscripts/resolve-right-versions.sh
+++ b/buildscripts/resolve-right-versions.sh
@@ -3,6 +3,7 @@
 set -E
 set -o pipefail
 set -x
+set -e
 
 WORK_DIR="$PWD/.verify-$RANDOM"
 MINIO_CONFIG_DIR="$WORK_DIR/.minio"

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -342,7 +342,6 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 		etagOnly := modTime.Equal(timeSentinel) && (etag != "" && etag == meta.Metadata["etag"])
 		mtimeValid := meta.ModTime.Equal(modTime)
 		if mtimeValid || etagOnly {
-			fmt.Fprint(h, meta.SuccessorModTime.Format(http.TimeFormat))
 			fmt.Fprintf(h, "%v", meta.XLV1)
 			if !etagOnly {
 				// Verify dataDir is same only when mtime is valid and etag is not considered.


### PR DESCRIPTION


## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Revert "Include SuccessorModTime for FileInfo quorum (#17732)"

## Motivation and Context
This reverts commit bf3901342cfe00d730edfdef8002fdb2d8bd6750.

This is to fix a regression caused when there are inconsistent 
versions, but one version is in quorum. SuccessorModTime issue 
must be fixed differently - this revert does not provide a solution.

## How to test this PR?
Modified healing script should detect the error, this was 
silently ignored.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
