### PR TITLE
if object is a delete marker it must skip tags filter in ILM

### DIFF
--- a/docs/bucket/lifecycle/README.md
+++ b/docs/bucket/lifecycle/README.md
@@ -134,7 +134,11 @@ Note: This rule has an implicit zero NoncurrentDays, which makes the expiry of t
 #### 3.2.b Automatic removal of all versions (MinIO only extension)
 
 This is available only on MinIO as an extension to the Expiration feature. The following rule makes it possible to remove all versions of an object under 
-the prefix `user-uploads/` as soon as the latest object satisfies the expiration criteria.
+the prefix `user-uploads/` as soon as the latest object satisfies the expiration criteria. 
+
+> NOTE: If the latest object is a delete marker then filtering based on `Filter.Tags` is ignored and 
+> if the DELETE marker modTime satisfies the `Expiration.Days` then all versions of the object are 
+> immediately purged.
 
 ```
 {

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -261,7 +261,7 @@ func (lc Lifecycle) FilterRules(obj ObjectOpts) []Rule {
 		if !strings.HasPrefix(obj.Name, rule.GetPrefix()) {
 			continue
 		}
-		if !rule.Filter.TestTags(obj.UserTags) {
+		if !obj.DeleteMarker && !rule.Filter.TestTags(obj.UserTags) {
 			continue
 		}
 		rules = append(rules, rule)


### PR DESCRIPTION
## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
if object is a delete marker it must skip tags filter in ILM

## Motivation and Context
With the following rule if the latest version is a DEL marker then the object is not
purged via ExpiredObjectAllVersions at all due to the fact that tags filter out the
rule.

```json
      {
        "Expiration": {
          "Days": 3,
          "ExpiredObjectAllVersions": true
        },
        "ID": "TTL 90",
        "Filter": {
          "Tag": {
            "Key": "ttl",
            "Value": "3"
          }
        },
        "Status": "Enabled"
      },
```

DELETE markers must not be considered with tags since they do not have any.

## How to test this PR?
Requires the above behavior ^^

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
