### PR TITLE
fix:copy the req.body into io.Discard always when it need

### DIFF
--- a/internal/event/target/elasticsearch.go
+++ b/internal/event/target/elasticsearch.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -475,12 +474,10 @@ func (c *esClientV7) createIndex(args ElasticsearchArgs) error {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer DrainBody(resp.Body)
 		if resp.IsError() {
-			err := fmt.Errorf("Create index err: %s", res.String())
-			return err
+			return fmt.Errorf("Create index err: %s", res.String())
 		}
-		io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 	return nil
@@ -493,8 +490,7 @@ func (c *esClientV7) ping(ctx context.Context, _ ElasticsearchArgs) (bool, error
 	if err != nil {
 		return false, store.ErrNotConnected
 	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
+	DrainBody(resp.Body)
 	return !resp.IsError(), nil
 }
 
@@ -507,8 +503,7 @@ func (c *esClientV7) entryExists(ctx context.Context, index string, key string) 
 	if err != nil {
 		return false, err
 	}
-	io.Copy(io.Discard, res.Body)
-	res.Body.Close()
+	DrainBody(res.Body)
 	return !res.IsError(), nil
 }
 
@@ -523,8 +518,7 @@ func (c *esClientV7) removeEntry(ctx context.Context, index string, key string) 
 		if err != nil {
 			return err
 		}
-		defer res.Body.Close()
-		defer io.Copy(io.Discard, res.Body)
+		defer DrainBody(res.Body)
 		if res.IsError() {
 			return fmt.Errorf("Delete err: %s", res.String())
 		}
@@ -552,8 +546,7 @@ func (c *esClientV7) updateEntry(ctx context.Context, index string, key string, 
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
-	defer io.Copy(io.Discard, res.Body)
+	defer DrainBody(res.Body)
 	if res.IsError() {
 		return fmt.Errorf("Update err: %s", res.String())
 	}
@@ -579,8 +572,7 @@ func (c *esClientV7) addEntry(ctx context.Context, index string, eventData event
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
-	defer io.Copy(io.Discard, res.Body)
+	defer DrainBody(res.Body)
 	if res.IsError() {
 		return fmt.Errorf("Add err: %s", res.String())
 	}

--- a/internal/event/target/elasticsearch.go
+++ b/internal/event/target/elasticsearch.go
@@ -476,7 +476,7 @@ func (c *esClientV7) createIndex(args ElasticsearchArgs) error {
 		}
 		defer DrainBody(resp.Body)
 		if resp.IsError() {
-			return fmt.Errorf("Create index err: %s", res.String())
+			return fmt.Errorf("Create index err: %v", res)
 		}
 		return nil
 	}

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"io"
 	"net"
 	"net/http"
@@ -35,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/minio/minio/internal/event"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/once"

--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dustin/go-humanize"
 	"io"
 	"net"
 	"net/http"
@@ -313,6 +314,6 @@ func DrainBody(respBody io.ReadCloser) {
 		// the same connection for future uses.
 		//  - http://stackoverflow.com/a/17961593/4465767
 		defer respBody.Close()
-		io.Copy(io.Discard, respBody)
+		io.CopyN(io.Discard, respBody, 1*humanize.MiByte)
 	}
 }


### PR DESCRIPTION
## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

copy the req.body into io.Discard always.

the same as 
```golang
	        res, err := c.Delete(
			index,
			key,
			c.Delete.WithContext(ctx),
		)
		if err != nil {
			return err
		}
		defer res.Body.Close()
		defer io.Copy(io.Discard, res.Body)
		if res.IsError() {
			return fmt.Errorf("Delete err: %s", res.String())
		}
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
