### PR TITLE
Add session timeout env variable

### DIFF
--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -26,6 +26,7 @@ MINIO_IDENTITY_OPENID_CLIENT_SECRET*        (string)    secret for the unique pu
 MINIO_IDENTITY_OPENID_ROLE_POLICY           (string)    Set the IAM access policies applicable to this client application and IDP e.g. "app-bucket-write,app-bucket-list"
 MINIO_IDENTITY_OPENID_CLAIM_NAME            (string)    JWT canned policy claim name (default: 'policy')
 MINIO_IDENTITY_OPENID_SCOPES                (csv)       Comma separated list of OpenID scopes for server, defaults to advertised scopes from discovery document e.g. "email,admin"
+MINIO_IDENTITY_OPENID_SESSION_TIMEOUT       (string)    Set the session expiry in seconds
 MINIO_IDENTITY_OPENID_VENDOR                (string)    Specify vendor type for vendor specific behavior to checking validity of temporary credentials and service accounts on MinIO
 MINIO_IDENTITY_OPENID_CLAIM_USERINFO        (on|off)    Enable fetching claims from UserInfo Endpoint for authenticated user
 MINIO_IDENTITY_OPENID_KEYCLOAK_REALM        (string)    Specify Keycloak 'realm' name, only honored if vendor was set to 'keycloak' as value, if no realm is specified 'master' is default
@@ -91,7 +92,7 @@ For deployments with a load-balancer (LB), it is required that the LB is configu
 
 For deployments employing DNS round-robin on a single domain to all the MinIO servers, it is possible that after redirection the browser may land on a different MinIO server. For example, the domain `console.minio.example.org` may resolve to `console-X.minio.example.org`, where `X` is `1`, `2`, `3` or `4`. For the login to work, if the user first landed on `console-1.minio.example.org`, they must be redirected back to the same place after logging in at the OpenID provider's web-page. To ensure this, set the `MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC=on` parameter - this lets MinIO set the redirect URL based on the "Host" header of the (initial login) request.
 
-The **deprecated** parameter `MINIO_IDENTITY_OPENID_REDIRECT_URI` works similar to the `MINIO_BROWSER_REDIRECT_URL` but needs to include the `/oauth_callback` suffix. Please do not use it, as it is sufficient to the set the `MINIO_BROWSER_REDIRECT_URL` parameter (which is required anyway for most load-balancer based setups to work correctly). This deprecated parameter **will be removed** in a future release. 
+The **deprecated** parameter `MINIO_IDENTITY_OPENID_REDIRECT_URI` works similar to the `MINIO_BROWSER_REDIRECT_URL` but needs to include the `/oauth_callback` suffix. Please do not use it, as it is sufficient to the set the `MINIO_BROWSER_REDIRECT_URL` parameter (which is required anyway for most load-balancer based setups to work correctly). This deprecated parameter **will be removed** in a future release.
 
 ## Specifying Access Control with IAM Policies
 

--- a/internal/config/identity/openid/openid.go
+++ b/internal/config/identity/openid/openid.go
@@ -62,6 +62,8 @@ const (
 	// Removed params
 	JwksURL     = "jwks_url"
 	ClaimPrefix = "claim_prefix"
+
+	SessionTimeout = "session_timeout"
 )
 
 // DefaultKVS - default config for OpenID config
@@ -125,6 +127,10 @@ var (
 		},
 		config.KV{
 			Key:   KeyCloakAdminURL,
+			Value: "",
+		},
+		config.KV{
+			Key:   SessionTimeout,
 			Value: "",
 		},
 	}

--- a/internal/config/identity/openid/providercfg.go
+++ b/internal/config/identity/openid/providercfg.go
@@ -51,6 +51,8 @@ type providerCfg struct {
 
 	roleArn  arn.ARN
 	provider provider.Provider
+
+	SessionTimeout     string
 }
 
 func newProviderCfgFromConfig(getCfgVal func(cfgName string) string) providerCfg {
@@ -64,6 +66,7 @@ func newProviderCfgFromConfig(getCfgVal func(cfgName string) string) providerCfg
 		ClientID:           getCfgVal(ClientID),
 		ClientSecret:       getCfgVal(ClientSecret),
 		RolePolicy:         getCfgVal(RolePolicy),
+		SessionTimeout:     getCfgVal(SessionTimeout),
 	}
 }
 


### PR DESCRIPTION
## Description
Add `MINIO_IDENTITY_OPENID_SESSION_TIMEOUT` env var to override OP `exp` claim expiry.

## Motivation and Context
As can be read in issue https://github.com/minio/minio/issues/16308 and https://github.com/minio/minio/issues/16672 there is popular demand for overriding OP (IdP) `exp` claim value governing console session timeout.

Contrary to what @harshavardhana says, the RP (Relying Party or SP) session expiration is not governed by the OP `exp` claim value, this value is used to express the expiry of the token and should be treated as such.
See also https://github.com/minio/minio/issues/16308#issuecomment-1663475027

Even though Minio's interpretation of the OIDC spec is wrong, I left the original behaviour intact for backwards compatibility.

### Caveats
I didn't add the equivalent setting to the console Identity/OpenID Interface.
I'm unsure about the way I access the OIDC ProviderCfgs["_"].SessionTimout member in openid.Config.Validate()? Please correct me if I'm wrong.

## How to test this PR?
- Set env variable `MINIO_IDENTITY_OPENID_SESSION_TIMEOUT` to any integer representing timeout in seconds
- restart minio server
- login using OIDC Provider
- Experience session timeout longer than value set in `exp` claim

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
