### PR TITLE
Pass environment variable to control session length to console

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -175,6 +175,10 @@ func minioConfigToConsoleFeatures() {
 	if value := env.Get(config.EnvBrowserLoginAnimation, "on"); value != "" {
 		os.Setenv("CONSOLE_ANIMATED_LOGIN", value)
 	}
+	// Pass on the session duration environment variable, else we will default to 12 hours
+	if value := env.Get(config.EnvBrowserSessionDuration, ""); value != "" {
+		os.Setenv("CONSOLE_STS_DURATION", value)
+	}
 
 	os.Setenv("CONSOLE_MINIO_REGION", globalSite.Region)
 	os.Setenv("CONSOLE_CERT_PASSWD", env.Get("MINIO_CERT_PASSWD", ""))

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -61,10 +61,11 @@ const (
 	EnvMinIOCallhomeEnable    = "MINIO_CALLHOME_ENABLE"
 	EnvMinIOCallhomeFrequency = "MINIO_CALLHOME_FREQUENCY"
 
-	EnvMinIOServerURL        = "MINIO_SERVER_URL"
-	EnvBrowserRedirectURL    = "MINIO_BROWSER_REDIRECT_URL"
-	EnvRootDiskThresholdSize = "MINIO_ROOTDISK_THRESHOLD_SIZE"
-	EnvBrowserLoginAnimation = "MINIO_BROWSER_LOGIN_ANIMATION"
+	EnvMinIOServerURL         = "MINIO_SERVER_URL"
+	EnvBrowserRedirectURL     = "MINIO_BROWSER_REDIRECT_URL"
+	EnvRootDiskThresholdSize  = "MINIO_ROOTDISK_THRESHOLD_SIZE"
+	EnvBrowserLoginAnimation  = "MINIO_BROWSER_LOGIN_ANIMATION"
+	EnvBrowserSessionDuration = "MINIO_BROWSER_SESSION_DURATION"
 
 	EnvUpdate = "MINIO_UPDATE"
 


### PR DESCRIPTION
## Description
Introduces environment variable `MINIO_BROWSER_SESSION_DURATION` to allow to control the length of the sessions in the UI which right now defaults to 12 hours
Fixes: https://github.com/minio/console/issues/2511
## Motivation and Context
Some users wants longer lasting sessions, and console supports this via `CONSOLE_STS_DURATION`

## How to test this PR?
Checkout the code
Build the server
set `MINIO_BROWSER_SESSION_DURATION="1h"` and verify your session only last 1 hour

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
