### PR TITLE
Return cancelled storage calls as 499

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -64,6 +64,8 @@ func (s *storageRESTServer) writeErrorResponse(w http.ResponseWriter, err error)
 		w.WriteHeader(http.StatusNotFound)
 	case errInvalidAccessKeyID, errAccessKeyDisabled, errNoAuthToken, errMalformedAuth, errAuthentication, errSkewedAuthTime:
 		w.WriteHeader(http.StatusUnauthorized)
+	case context.Canceled, context.DeadlineExceeded:
+		w.WriteHeader(499)
 	default:
 		w.WriteHeader(http.StatusForbidden)
 	}


### PR DESCRIPTION
## Description

Make upstream cancels more visible - right now they are just reported as "forbidden".

## How to test this PR?

Observe traces.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
