### PR TITLE
fix:replace context by timeout-context from parent-context when `selfSpeedTest`

### DIFF
--- a/cmd/perf-tests.go
+++ b/cmd/perf-tests.go
@@ -84,13 +84,8 @@ func selfSpeedTest(ctx context.Context, opts speedTestOpts) (SpeedTestResult, er
 
 	objCountPerThread := make([]uint64, opts.concurrency)
 
-	uploadsCtx, uploadsCancel := context.WithCancel(context.Background())
+	uploadsCtx, uploadsCancel := context.WithTimeout(ctx, opts.duration)
 	defer uploadsCancel()
-
-	go func() {
-		time.Sleep(opts.duration)
-		uploadsCancel()
-	}()
 
 	objNamePrefix := pathJoin(speedTest, mustGetUUID())
 
@@ -143,12 +138,8 @@ func selfSpeedTest(ctx context.Context, opts speedTestOpts) (SpeedTestResult, er
 		}, nil
 	}
 
-	downloadsCtx, downloadsCancel := context.WithCancel(context.Background())
+	downloadsCtx, downloadsCancel := context.WithTimeout(ctx, opts.duration)
 	defer downloadsCancel()
-	go func() {
-		time.Sleep(opts.duration)
-		downloadsCancel()
-	}()
 
 	gopts := minio.GetObjectOptions{}
 	gopts.Set(globalObjectPerfUserMetadata, "true") // Bypass S3 API freeze


### PR DESCRIPTION
## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

replace context by timeout-context.
we can remove two `go func(){}()` 

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
