### PR TITLE
Return successorModTime in quorum when available

### DIFF
--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -393,14 +393,39 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 		return FileInfo{}, errErasureReadQuorum
 	}
 
+	// Find the successor mod time in quorum, otherwise leave the
+	// candidate's successor modTime as found
+	succModTimeMap := make(map[time.Time]int)
+	var candidate FileInfo
+	var found bool
 	for i, hash := range metaHashes {
 		if hash == maxHash {
 			if metaArr[i].IsValid() {
-				return metaArr[i], nil
+				if !found {
+					candidate = metaArr[i]
+					found = true
+				}
+				succModTimeMap[metaArr[i].SuccessorModTime]++
 			}
 		}
 	}
+	var succModTime time.Time
+	var smodTimeQuorum bool
+	for smodTime, count := range succModTimeMap {
+		if count >= quorum {
+			smodTimeQuorum = true
+			succModTime = smodTime
+			break
+		}
+	}
 
+	if found {
+		if smodTimeQuorum {
+			candidate.SuccessorModTime = succModTime
+			candidate.IsLatest = succModTime.IsZero()
+		}
+		return candidate, nil
+	}
 	return FileInfo{}, errErasureReadQuorum
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Return SuccessorModTime in quorum when available

## Motivation and Context
findFileInfoInQuorum function, prior to this change, picks a valid FileInfo which has several fields that are in quorum but leaves out SuccessorModTime. Leaving this out could lead to picking a FileInfo with invalid values in fields like IsLatest, SuccessorModTime leading to incorrect ILM policy evaluation.

## How to test this PR?
Unit tests added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
