### PR TITLE
use buffers for pathJoin, to re-use buffers.

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1290,7 +1290,10 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		// instead of "copying" from source, we need the stream to be seekable
 		// to ensure that we can make fan-out calls concurrently.
 		buf := bytebufferpool.Get()
-		defer bytebufferpool.Put(buf)
+		defer func() {
+			buf.Reset()
+			bytebufferpool.Put(buf)
+		}()
 
 		md5w := md5.New()
 

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -49,6 +49,7 @@ import (
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/trie"
 	"github.com/minio/pkg/wildcard"
+	"github.com/valyala/bytebufferpool"
 	"golang.org/x/exp/slices"
 )
 
@@ -233,25 +234,25 @@ func pathsJoinPrefix(prefix string, elem ...string) (paths []string) {
 
 // pathJoin - like path.Join() but retains trailing SlashSeparator of the last element
 func pathJoin(elem ...string) string {
-	trailingSlash := ""
-	if len(elem) > 0 {
-		if hasSuffixByte(elem[len(elem)-1], SlashSeparatorChar) {
-			trailingSlash = SlashSeparator
-		}
-	}
-	return path.Join(elem...) + trailingSlash
+	sb := bytebufferpool.Get()
+	defer func() {
+		sb.Reset()
+		bytebufferpool.Put(sb)
+	}()
+
+	return pathJoinBuf(sb, elem...)
 }
 
 // pathJoinBuf - like path.Join() but retains trailing SlashSeparator of the last element.
 // Provide a string builder to reduce allocation.
-func pathJoinBuf(dst *bytes.Buffer, elem ...string) string {
+func pathJoinBuf(dst *bytebufferpool.ByteBuffer, elem ...string) string {
 	trailingSlash := len(elem) > 0 && hasSuffixByte(elem[len(elem)-1], SlashSeparatorChar)
 	dst.Reset()
 	added := 0
 	for _, e := range elem {
 		if added > 0 || e != "" {
 			if added > 0 {
-				dst.WriteRune(SlashSeparatorChar)
+				dst.WriteByte(SlashSeparatorChar)
 			}
 			dst.WriteString(e)
 			added += len(e)
@@ -266,7 +267,7 @@ func pathJoinBuf(dst *bytes.Buffer, elem ...string) string {
 		return s
 	}
 	if trailingSlash {
-		dst.WriteRune(SlashSeparatorChar)
+		dst.WriteByte(SlashSeparatorChar)
 	}
 	return dst.String()
 }

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -35,6 +36,38 @@ import (
 	"github.com/minio/minio/internal/crypto"
 	"github.com/minio/pkg/trie"
 )
+
+func pathJoinOld(elem ...string) string {
+	trailingSlash := ""
+	if len(elem) > 0 {
+		if hasSuffixByte(elem[len(elem)-1], SlashSeparatorChar) {
+			trailingSlash = SlashSeparator
+		}
+	}
+	return path.Join(elem...) + trailingSlash
+}
+
+func BenchmarkPathJoinOld(b *testing.B) {
+	b.Run("PathJoin", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			pathJoinOld("volume", "path/path/path")
+		}
+	})
+}
+
+func BenchmarkPathJoin(b *testing.B) {
+	b.Run("PathJoin", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			pathJoin("volume", "path/path/path")
+		}
+	})
+}
 
 // Wrapper
 func TestPathTraversalExploit(t *testing.T) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
use buffers for pathJoin, to re-use buffers.

## Motivation and Context
optimize pathJoin by re-using buffers

## How to test this PR?
Before and After

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkPathJoin/PathJoin-8     79.6          55.3          -30.53%

benchmark                        old allocs     new allocs     delta
BenchmarkPathJoin/PathJoin-8     2              1              -50.00%

benchmark                        old bytes     new bytes     delta
BenchmarkPathJoin/PathJoin-8     48            24            -50.00%
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
