### PR TITLE
kafka: Do not require key when sending a message

### DIFF
--- a/cmd/os-rename_nolinux.go
+++ b/cmd/os-rename_nolinux.go
@@ -22,7 +22,7 @@ package cmd
 
 import "errors"
 
-// Rename captures time taken to call os.Rename
+// Rename2 is not implemented in a non linux environment
 func Rename2(src, dst string) (err error) {
 	defer updateOSMetrics(osMetricRename2, src, dst)(errors.New("not implemented, skipping"))
 	return errSkipFile

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -27,14 +27,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/IBM/sarama"
 	saramatls "github.com/IBM/sarama/tools/tls"
-	"github.com/tidwall/gjson"
 
 	"github.com/minio/minio/internal/logger/target/types"
 	"github.com/minio/minio/internal/once"
@@ -241,14 +239,8 @@ func (h *Target) send(entry interface{}) error {
 	if err != nil {
 		return err
 	}
-	requestID := gjson.GetBytes(logJSON, "requestID").Str
-	if requestID == "" {
-		// unsupported data structure
-		return fmt.Errorf("unsupported data structure: %s must be either audit.Entry or log.Entry", reflect.TypeOf(entry))
-	}
 	msg := sarama.ProducerMessage{
 		Topic: h.kconfig.Topic,
-		Key:   sarama.StringEncoder(requestID),
 		Value: sarama.ByteEncoder(logJSON),
 	}
 	_, _, err = h.producer.SendMessage(&msg)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Keys are helpful to ensure strict ordering of messages, however 
currently the code uses a random request id for every log, hence 
using the request id as a kafka key is not serving any purpose;

This commit removes the usage of key, to also fix audit issue from
 internal subsystem that does not have a request id.

## Motivation and Context
Fix logging internal audit (decom, ILM, etc..)

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
