### PR TITLE
with xlv2 format we never had to fill in checksumInfo()

### DIFF
--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -620,7 +620,7 @@ func TestDisksWithAllParts(t *testing.T) {
 	diskFailures[15] = "part.1"
 
 	for diskIndex, partName := range diskFailures {
-		for i := range partsMetadata[diskIndex].Erasure.Checksums {
+		for i := range partsMetadata[diskIndex].Parts {
 			if fmt.Sprintf("part.%d", i+1) == partName {
 				filePath := pathJoin(erasureDisks[diskIndex].String(), bucket, object, partsMetadata[diskIndex].DataDir, partName)
 				f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_SYNC, 0)

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -714,11 +714,6 @@ func (er *erasureObjects) healObject(ctx context.Context, bucket string, object 
 
 				partsMetadata[i].DataDir = dstDataDir
 				partsMetadata[i].AddObjectPart(partNumber, "", partSize, partActualSize, partModTime, partIdx, partChecksums)
-				partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{
-					PartNumber: partNumber,
-					Algorithm:  checksumAlgo,
-					Hash:       bitrotWriterSum(writers[i]),
-				})
 				if len(inlineBuffers) > 0 && inlineBuffers[i] != nil {
 					partsMetadata[i].Data = inlineBuffers[i].Bytes()
 					partsMetadata[i].SetInlineData()

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -41,17 +41,6 @@ const minIOErasureUpgraded = "x-minio-internal-erasure-upgraded"
 
 const erasureAlgorithm = "rs-vandermonde"
 
-// AddChecksumInfo adds a checksum of a part.
-func (e *ErasureInfo) AddChecksumInfo(ckSumInfo ChecksumInfo) {
-	for i, sum := range e.Checksums {
-		if sum.PartNumber == ckSumInfo.PartNumber {
-			e.Checksums[i] = ckSumInfo
-			return
-		}
-	}
-	e.Checksums = append(e.Checksums, ckSumInfo)
-}
-
 // GetChecksumInfo - get checksum of a part.
 func (e ErasureInfo) GetChecksumInfo(partNumber int) (ckSum ChecksumInfo) {
 	for _, sum := range e.Checksums {
@@ -60,7 +49,7 @@ func (e ErasureInfo) GetChecksumInfo(partNumber int) (ckSum ChecksumInfo) {
 			return sum
 		}
 	}
-	return ChecksumInfo{}
+	return ChecksumInfo{Algorithm: DefaultBitrotAlgorithm}
 }
 
 // ShardFileSize - returns final erasure size from original size.

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -960,11 +960,6 @@ func (er erasureObjects) putMetacacheObject(ctx context.Context, key string, r *
 		}
 		partsMetadata[i].Data = inlineBuffers[i].Bytes()
 		partsMetadata[i].AddObjectPart(1, "", n, data.ActualSize(), modTime, index, nil)
-		partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{
-			PartNumber: 1,
-			Algorithm:  DefaultBitrotAlgorithm,
-			Hash:       bitrotWriterSum(w),
-		})
 	}
 
 	// Fill all the necessary metadata.
@@ -1296,11 +1291,6 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 		}
 		// No need to add checksum to part. We already have it on the object.
 		partsMetadata[i].AddObjectPart(1, "", n, data.ActualSize(), modTime, compIndex, nil)
-		partsMetadata[i].Erasure.AddChecksumInfo(ChecksumInfo{
-			PartNumber: 1,
-			Algorithm:  DefaultBitrotAlgorithm,
-			Hash:       bitrotWriterSum(w),
-		})
 		partsMetadata[i].Versioned = opts.Versioned || opts.VersionSuspended
 	}
 

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -612,17 +612,9 @@ func (j xlMetaV2Object) ToFileInfo(volume, path string) (FileInfo, error) {
 			fi.Parts[i].Index = j.PartIndices[i]
 		}
 	}
-	fi.Erasure.Checksums = make([]ChecksumInfo, len(j.PartSizes))
-	for i := range fi.Parts {
-		fi.Erasure.Checksums[i].PartNumber = fi.Parts[i].Number
-		switch j.BitrotChecksumAlgo {
-		case HighwayHash:
-			fi.Erasure.Checksums[i].Algorithm = HighwayHash256S
-			fi.Erasure.Checksums[i].Hash = []byte{}
-		default:
-			return FileInfo{}, fmt.Errorf("unknown BitrotChecksumAlgo: %v", j.BitrotChecksumAlgo)
-		}
-	}
+	// fi.Erasure.Checksums - is left empty since we do not have any
+	// whole checksums for many years now, no need to allocate.
+
 	fi.Metadata = make(map[string]string, len(j.MetaUser)+len(j.MetaSys))
 	for k, v := range j.MetaUser {
 		// https://github.com/google/security-research/security/advisories/GHSA-76wf-9vgp-pj7w


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
With xlv2 format we never had to fill in checksumInfo()

## Motivation and Context
- this PR avoids sending a large ChecksumInfo slice when its not needed

- also for a file with XLV2 format there is no reason to allocate Checksum slice while reading

## How to test this PR?
CI/CD would handle this automatically

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
