### PR TITLE
avoid repeated large allocations for large parts

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -248,9 +248,9 @@ func (e *metaCacheEntry) fileInfo(bucket string) (FileInfo, error) {
 				ModTime:  timeSentinel1970,
 			}, nil
 		}
-		return e.cached.ToFileInfo(bucket, e.name, "", false)
+		return e.cached.ToFileInfo(bucket, e.name, "", false, false)
 	}
-	return getFileInfo(e.metadata, bucket, e.name, "", false)
+	return getFileInfo(e.metadata, bucket, e.name, "", false, false)
 }
 
 // xlmeta returns the decoded metadata.
@@ -291,7 +291,7 @@ func (e *metaCacheEntry) fileInfoVersions(bucket string) (FileInfoVersions, erro
 		}, nil
 	}
 	// Too small gains to reuse cache here.
-	return getFileInfoVersions(e.metadata, bucket, e.name)
+	return getFileInfoVersions(e.metadata, bucket, e.name, false)
 }
 
 // metaCacheEntries is a slice of metacache entries.

--- a/cmd/xl-storage-format-utils_test.go
+++ b/cmd/xl-storage-format-utils_test.go
@@ -175,7 +175,7 @@ func TestGetFileInfoVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to serialize xlmeta %v", err)
 	}
-	fivs, err := getFileInfoVersions(buf, basefi.Volume, basefi.Name)
+	fivs, err := getFileInfoVersions(buf, basefi.Volume, basefi.Name, true)
 	if err != nil {
 		t.Fatalf("getFileInfoVersions failed: %v", err)
 	}

--- a/cmd/xl-storage-format_test.go
+++ b/cmd/xl-storage-format_test.go
@@ -485,7 +485,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 						b.Fatal(err)
 					}
 					// List...
-					_, err = xl.ToFileInfo("volume", "path", ids[rng.Intn(size)], false)
+					_, err = xl.ToFileInfo("volume", "path", ids[rng.Intn(size)], false, true)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -503,7 +503,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 						b.Fatal(err)
 					}
 					// List...
-					_, err = xl.ListVersions("volume", "path")
+					_, err = xl.ListVersions("volume", "path", true)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -518,7 +518,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 					if buf == nil {
 						b.Fatal("buf == nil")
 					}
-					_, err = buf.ToFileInfo("volume", "path", ids[rng.Intn(size)])
+					_, err = buf.ToFileInfo("volume", "path", ids[rng.Intn(size)], true)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -533,7 +533,7 @@ func BenchmarkXlMetaV2Shallow(b *testing.B) {
 					if buf == nil {
 						b.Fatal("buf == nil")
 					}
-					_, err = buf.ListVersions("volume", "path")
+					_, err = buf.ListVersions("volume", "path", true)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/cmd/xl-storage-free-version_test.go
+++ b/cmd/xl-storage-free-version_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (x xlMetaV2) listFreeVersions(volume, path string) ([]FileInfo, error) {
-	fivs, err := x.ListVersions(volume, path)
+	fivs, err := x.ListVersions(volume, path, true)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func TestFreeVersion(t *testing.T) {
 	}
 
 	for _, ft := range freeVersionsTests {
-		fi, err := xl.ToFileInfo(ft.vol, ft.name, "", ft.inclFreeVers)
+		fi, err := xl.ToFileInfo(ft.vol, ft.name, "", ft.inclFreeVers, true)
 		if err != nil && !errors.Is(err, ft.expectedErr) {
 			t.Fatalf("ToFileInfo failed due to %v", err)
 		}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -531,7 +531,7 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 		// Remove filename which is the meta file.
 		item.transformMetaDir()
 
-		fivs, err := getFileInfoVersions(buf, item.bucket, item.objectPath())
+		fivs, err := getFileInfoVersions(buf, item.bucket, item.objectPath(), false)
 		metaDataPoolPut(buf)
 		if err != nil {
 			res["err"] = err.Error()
@@ -1450,7 +1450,7 @@ func (s *xlStorage) ReadVersion(ctx context.Context, volume, path, versionID str
 		return fi, err
 	}
 
-	fi, err = getFileInfo(buf, volume, path, versionID, readData)
+	fi, err = getFileInfo(buf, volume, path, versionID, readData, true)
 	if err != nil {
 		return fi, err
 	}
@@ -2424,7 +2424,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	}
 
 	// Replace the data of null version or any other existing version-id
-	ofi, err := xlMeta.ToFileInfo(dstVolume, dstPath, reqVID, false)
+	ofi, err := xlMeta.ToFileInfo(dstVolume, dstPath, reqVID, false, false)
 	if err == nil && !ofi.Deleted {
 		if xlMeta.SharedDataDirCountStr(reqVID, ofi.DataDir) == 0 {
 			// Purge the destination path as we are not preserving anything


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
avoid repeated large allocations for large parts

## Motivation and Context
objects with 10,000 parts and many of them can
cause a large memory spike which can potentially
lead to OOM due to a lack of GC.

with the previous PR reducing the memory usage significantly 
in #17963, this PR reduces this further by 80% under 
repeated calls.

The scanner sub-system has no use for the slice of Parts(), it is better left empty.

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkToFileInfo/ToFileInfo-8     295658        188143        -36.36%

benchmark                            old allocs     new allocs     delta
BenchmarkToFileInfo/ToFileInfo-8     61             60             -1.64%

benchmark                            old bytes     new bytes     delta
BenchmarkToFileInfo/ToFileInfo-8     1097210       227255        -79.29%
```

## How to test this PR?
CI/CD should cover the scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
