### PR TITLE
use syscall.Rename() directly instead of os.Rename()

### DIFF
--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -137,7 +137,7 @@ func MkdirAll(dirPath string, mode os.FileMode) (err error) {
 // Rename captures time taken to call os.Rename
 func Rename(src, dst string) (err error) {
 	defer updateOSMetrics(osMetricRename, src, dst)(err)
-	return os.Rename(src, dst)
+	return RenameSys(src, dst)
 }
 
 // OpenFile captures time taken to call os.OpenFile

--- a/cmd/os-rename_linux.go
+++ b/cmd/os-rename_linux.go
@@ -21,6 +21,8 @@
 package cmd
 
 import (
+	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -28,4 +30,9 @@ import (
 func Rename2(src, dst string) (err error) {
 	defer updateOSMetrics(osMetricRename2, src, dst)(err)
 	return unix.Renameat2(unix.AT_FDCWD, src, unix.AT_FDCWD, dst, uint(2)) // RENAME_EXCHANGE from 'man renameat2'
+}
+
+// RenameSys is low level call in case of Linux this uses syscall.Rename() directly.
+func RenameSys(src, dst string) (err error) {
+	return syscall.Rename(src, dst)
 }

--- a/cmd/os-rename_nolinux.go
+++ b/cmd/os-rename_nolinux.go
@@ -20,10 +20,18 @@
 
 package cmd
 
-import "errors"
+import (
+	"errors"
+	"os"
+)
 
 // Rename2 is not implemented in a non linux environment
 func Rename2(src, dst string) (err error) {
 	defer updateOSMetrics(osMetricRename2, src, dst)(errors.New("not implemented, skipping"))
 	return errSkipFile
+}
+
+// RenameSys is low level call in case of non-Linux this just uses os.Rename()
+func RenameSys(src, dst string) (err error) {
+	return os.Rename(src, dst)
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
use syscall.Rename() directly instead of os.Rename()

## Motivation and Context
os.Rename() seems to call os.Lstat() for both source and
destination directories to throw some user-friendly errors
However in real-world scenario, it would seem like this can
add "delays".

Instead we are incurring performance costs of Lstat()
as well as part of rename().

## How to test this PR?
Nothing should change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
