### PR TITLE
fix: report bucket metrics for only existing buckets

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -300,7 +300,8 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 		globalHTTPStats.currentS3Requests.Inc(api)
 		defer globalHTTPStats.currentS3Requests.Dec(api)
 
-		if bucket != "" && bucket != minioReservedBucket {
+		_, err = globalBucketMetadataSys.Get(bucket) // check if this bucket exists.
+		if bucket != "" && bucket != minioReservedBucket && err == nil {
 			globalBucketHTTPStats.updateHTTPStats(bucket, api, nil)
 		}
 
@@ -316,7 +317,7 @@ func collectAPIStats(api string, f http.HandlerFunc) http.HandlerFunc {
 			globalConnStats.incS3InputBytes(int64(tc.RequestRecorder.Size()))
 			globalConnStats.incS3OutputBytes(int64(tc.ResponseRecorder.Size()))
 
-			if bucket != "" && bucket != minioReservedBucket {
+			if bucket != "" && bucket != minioReservedBucket && err == nil {
 				globalBucketConnStats.incS3InputBytes(bucket, int64(tc.RequestRecorder.Size()))
 				globalBucketConnStats.incS3OutputBytes(bucket, int64(tc.ResponseRecorder.Size()))
 				globalBucketHTTPStats.updateHTTPStats(bucket, api, tc.ResponseRecorder)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: report bucket metrics for only existing buckets

## Motivation and Context
Do not count for incoming bucket resources that are non
existent on the namespace, it is possible some virus
Scanners can generate random bucket names that do not
exist.

## How to test this PR?
Just do `curl https://endpoint/non-existent-bucket` after this
it would be reported under the bucket metrics endpoint.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
