### PR TITLE
allow scanner key cycle to be empty

### DIFF
--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -127,7 +127,11 @@ func lookupDeprecatedScannerConfig(kvs config.KVS) (cfg Config, err error) {
 	if err != nil {
 		return cfg, err
 	}
-	cfg.Cycle, err = time.ParseDuration(env.Get(EnvCycle, kvs.GetWithDefault(Cycle, DefaultKVS)))
+	cycle := env.Get(EnvCycle, kvs.GetWithDefault(Cycle, DefaultKVS))
+	if cycle == "" {
+		cycle = "1m"
+	}
+	cfg.Cycle, err = time.ParseDuration(cycle)
 	if err != nil {
 		return cfg, err
 	}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow scanner key cycle to be empty

## Motivation and Context
configs from 2020 server throws an
error due to deprecation of the keys
however an attempt is made to parse
them, we should have chosen existing
defaults - this PR fixes that.

## How to test this PR?
Just try to import the following

```conf
subnet license= api_key= proxy= 
# callhome enable=off frequency=24h 
site name= region= 
api requests_max=0 requests_deadline=10s cluster_deadline=10s cors_allow_origin=* remote_transport_deadline=2h list_quorum=strict replication_priority=auto transition_workers=100 stale_uploads_cleanup_interval=6h stale_uploads_expiry=24h delete_cleanup_interval=5m odirect=on gzip_objects=off root_access=on sync_events=off 
scanner delay=10 max_wait=15s speed=default 
```

```
mc admin config import alias/ < /tmp/conf
```

returns 
```
mc: <ERROR> Unable to set server config: time: invalid duration "".
```

without this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
