### PR TITLE
fix: broken bucket versioning support in community helm chart

### DIFF
--- a/helm/minio/templates/_helper_create_bucket.txt
+++ b/helm/minio/templates/_helper_create_bucket.txt
@@ -85,7 +85,7 @@ if ! checkBucketExists $BUCKET ; then
 
 
   # set versioning for bucket if objectlocking is disabled or not set
-  if [ -z $OBJECTLOCKING ] ; then
+  if [ $OBJECTLOCKING = false ] ; then
   if [ ! -z $VERSIONING ] ; then
     if [ $VERSIONING = true ] ; then
         echo "Enabling versioning for '$BUCKET'"


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Hi,

this PR seeks to fix a bug in the community helm chart where buckets created by the post job weren't versioned after the introduction of parameter defaults in 00857f8.

Prior to this PR the only way to get bucket versioning is by enabling object locking.
With the change introduced by this PR, bucket versioning can be enabled independently of object locking again.

## Motivation and Context


## How to test this PR?

Apply the helm chart by adding a new bucket to be created by the post job via the values.yaml file or the `--set` parameter of the `helm install` command. E.g.:
```bash
helm install my-minio --set buckets[0].name=mybucket,buckets[0].versioning=true .
```
Observe the output "Enabling versioning for 'mybucket'" in the logs of the post job, or see versioning being enabled in the MinIO console.



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (00857f8)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
