### PR TITLE
fix: webhook notify endpoint with standard ports

### DIFF
--- a/internal/event/target/webhook.go
+++ b/internal/event/target/webhook.go
@@ -104,6 +104,8 @@ type WebhookTarget struct {
 	loggerOnce logger.LogOnce
 	cancel     context.CancelFunc
 	cancelCh   <-chan struct{}
+
+	addr string // full address ip/dns with a port number, e.g.  x.x.x.x:8080
 }
 
 // ID - returns target ID.
@@ -130,7 +132,7 @@ func (target *WebhookTarget) Store() event.TargetStore {
 }
 
 func (target *WebhookTarget) isActive() (bool, error) {
-	conn, err := net.DialTimeout("tcp", target.args.Endpoint.Host, 5*time.Second)
+	conn, err := net.DialTimeout("tcp", target.addr, 5*time.Second)
 	if err != nil {
 		if xnet.IsNetworkOrHostDown(err, false) {
 			return false, store.ErrNotConnected
@@ -289,6 +291,19 @@ func NewWebhookTarget(ctx context.Context, id string, args WebhookArgs, loggerOn
 		store:      queueStore,
 		cancel:     cancel,
 		cancelCh:   ctx.Done(),
+	}
+
+	// Calculate the webhook addr with the port number format
+	target.addr = args.Endpoint.Host
+	if _, _, err := net.SplitHostPort(args.Endpoint.Host); err != nil && strings.Contains(err.Error(), "missing port in address") {
+		switch strings.ToLower(args.Endpoint.Scheme) {
+		case "http":
+			target.addr += ":80"
+		case "https":
+			target.addr += ":443"
+		default:
+			return nil, errors.New("unsupported scheme")
+		}
 	}
 
 	if target.store != nil {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
If the endpoint in the notify webhook configuration does not contain 
any port number, the webhook will not work. This commit fixes it by 
adding :80 or :443 in the host; isActive() needs a port number to test 
if the webhook port is open or not.


## Motivation and Context
Fix webhook behavior when the port number is not provided in the endpoint

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
