### PR TITLE
optimize mkdir calls to avoid base-dir `Mkdir` attempts

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -275,7 +275,7 @@ func formatErasureMigrateV2ToV3(data []byte, export, version string) ([]byte, er
 
 	tmpOld := pathJoin(export, minioMetaTmpDeletedBucket, mustGetUUID())
 	if err := renameAll(pathJoin(export, minioMetaMultipartBucket),
-		tmpOld); err != nil && err != errFileNotFound {
+		tmpOld, export); err != nil && err != errFileNotFound {
 		logger.LogIf(GlobalContext, fmt.Errorf("unable to rename (%s -> %s) %w, drive may be faulty please investigate",
 			pathJoin(export, minioMetaMultipartBucket),
 			tmpOld,

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -38,7 +38,7 @@ func renameAllBucketMetacache(epPath string) error {
 		if typ == os.ModeDir {
 			tmpMetacacheOld := pathutil.Join(epPath, minioMetaTmpDeletedBucket, mustGetUUID())
 			if err := renameAll(pathJoin(epPath, minioMetaBucket, metacachePrefixForID(name, slashSeparator)),
-				tmpMetacacheOld); err != nil && err != errFileNotFound {
+				tmpMetacacheOld, epPath); err != nil && err != errFileNotFound {
 				return fmt.Errorf("unable to rename (%s -> %s) %w",
 					pathJoin(epPath, minioMetaBucket+metacachePrefixForID(minioMetaBucket, slashSeparator)),
 					tmpMetacacheOld,

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -129,9 +129,9 @@ func Mkdir(dirPath string, mode os.FileMode) (err error) {
 }
 
 // MkdirAll captures time taken to call os.MkdirAll
-func MkdirAll(dirPath string, mode os.FileMode) (err error) {
+func MkdirAll(dirPath string, mode os.FileMode, baseDir string) (err error) {
 	defer updateOSMetrics(osMetricMkdirAll, dirPath)(err)
-	return osMkdirAll(dirPath, mode)
+	return osMkdirAll(dirPath, mode, baseDir)
 }
 
 // Rename captures time taken to call os.Rename

--- a/cmd/os-reliable_test.go
+++ b/cmd/os-reliable_test.go
@@ -29,15 +29,15 @@ func TestOSMkdirAll(t *testing.T) {
 		t.Fatalf("Unable to create xlStorage test setup, %s", err)
 	}
 
-	if err = mkdirAll("", 0o777); err != errInvalidArgument {
+	if err = mkdirAll("", 0o777, ""); err != errInvalidArgument {
 		t.Fatal("Unexpected error", err)
 	}
 
-	if err = mkdirAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), 0o777); err != errFileNameTooLong {
+	if err = mkdirAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), 0o777, ""); err != errFileNameTooLong {
 		t.Fatal("Unexpected error", err)
 	}
 
-	if err = mkdirAll(pathJoin(path, "success-vol", "success-object"), 0o777); err != nil {
+	if err = mkdirAll(pathJoin(path, "success-vol", "success-object"), 0o777, ""); err != nil {
 		t.Fatal("Unexpected error", err)
 	}
 }
@@ -50,25 +50,25 @@ func TestOSRenameAll(t *testing.T) {
 		t.Fatalf("Unable to create xlStorage test setup, %s", err)
 	}
 
-	if err = mkdirAll(pathJoin(path, "testvolume1"), 0o777); err != nil {
+	if err = mkdirAll(pathJoin(path, "testvolume1"), 0o777, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err = renameAll("", "foo"); err != errInvalidArgument {
+	if err = renameAll("", "foo", ""); err != errInvalidArgument {
 		t.Fatal(err)
 	}
-	if err = renameAll("foo", ""); err != errInvalidArgument {
+	if err = renameAll("foo", "", ""); err != errInvalidArgument {
 		t.Fatal(err)
 	}
-	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2")); err != nil {
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2"), ""); err != nil {
 		t.Fatal(err)
 	}
-	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2")); err != errFileNotFound {
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "testvolume2"), ""); err != errFileNotFound {
 		t.Fatal(err)
 	}
-	if err = renameAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), pathJoin(path, "testvolume2")); err != errFileNameTooLong {
+	if err = renameAll(pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), pathJoin(path, "testvolume2"), ""); err != errFileNameTooLong {
 		t.Fatal("Unexpected error", err)
 	}
-	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001")); err != errFileNameTooLong {
+	if err = renameAll(pathJoin(path, "testvolume1"), pathJoin(path, "my-obj-del-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"), ""); err != errFileNameTooLong {
 		t.Fatal("Unexpected error", err)
 	}
 }

--- a/cmd/os_other.go
+++ b/cmd/os_other.go
@@ -31,7 +31,8 @@ func access(name string) error {
 	return err
 }
 
-func osMkdirAll(dirPath string, perm os.FileMode) error {
+func osMkdirAll(dirPath string, perm os.FileMode, _ string) error {
+	// baseDir is not honored in plan9 and solaris platforms.
 	return os.MkdirAll(dirPath, perm)
 }
 

--- a/cmd/os_unix.go
+++ b/cmd/os_unix.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -47,7 +48,13 @@ func access(name string) error {
 // directories that MkdirAll creates.
 // If path is already a directory, MkdirAll does nothing
 // and returns nil.
-func osMkdirAll(dirPath string, perm os.FileMode) error {
+func osMkdirAll(dirPath string, perm os.FileMode, baseDir string) error {
+	if baseDir != "" {
+		if strings.HasPrefix(baseDir, dirPath) {
+			return nil
+		}
+	}
+
 	// Slow path: make sure parent exists and then call Mkdir for path.
 	i := len(dirPath)
 	for i > 0 && os.IsPathSeparator(dirPath[i-1]) { // Skip trailing path separator.
@@ -61,7 +68,7 @@ func osMkdirAll(dirPath string, perm os.FileMode) error {
 
 	if j > 1 {
 		// Create parent.
-		if err := osMkdirAll(dirPath[:j-1], perm); err != nil {
+		if err := osMkdirAll(dirPath[:j-1], perm, baseDir); err != nil {
 			return err
 		}
 	}

--- a/cmd/os_windows.go
+++ b/cmd/os_windows.go
@@ -31,7 +31,8 @@ func access(name string) error {
 	return err
 }
 
-func osMkdirAll(dirPath string, perm os.FileMode) error {
+func osMkdirAll(dirPath string, perm os.FileMode, _ string) error {
+	// baseDir is not honored in windows platform
 	return os.MkdirAll(dirPath, perm)
 }
 

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -85,14 +85,14 @@ func bgFormatErasureCleanupTmp(diskPath string) {
 	tmpID := mustGetUUID()
 	tmpOld := pathJoin(diskPath, minioMetaTmpBucket+"-old", tmpID)
 	if err := renameAll(pathJoin(diskPath, minioMetaTmpBucket),
-		tmpOld); err != nil && !errors.Is(err, errFileNotFound) {
+		tmpOld, diskPath); err != nil && !errors.Is(err, errFileNotFound) {
 		logger.LogIf(GlobalContext, fmt.Errorf("unable to rename (%s -> %s) %w, drive may be faulty please investigate",
 			pathJoin(diskPath, minioMetaTmpBucket),
 			tmpOld,
 			osErrToFileErr(err)))
 	}
 
-	if err := mkdirAll(pathJoin(diskPath, minioMetaTmpDeletedBucket), 0o777); err != nil {
+	if err := mkdirAll(pathJoin(diskPath, minioMetaTmpDeletedBucket), 0o777, diskPath); err != nil {
 		logger.LogIf(GlobalContext, fmt.Errorf("unable to create (%s) %w, drive may be faulty please investigate",
 			pathJoin(diskPath, minioMetaTmpBucket),
 			err))


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
optimize mkdir calls to avoid base-dir `Mkdir` attempts

## Motivation and Context
Currently, we have IOPs for these patterns

```
[OS] os.Mkdir play.min.io:9000 /disk1 2.718µs
[OS] os.Mkdir play.min.io:9000 /disk1/data 2.406µs
[OS] os.Mkdir play.min.io:9000 /disk1/data/.minio.sys 4.068µs
[OS] os.Mkdir play.min.io:9000 /disk1/data/.minio.sys/tmp 2.843µs
[OS] os.Mkdir play.min.io:9000 /disk1/data/.minio.sys/tmp/d89c8ceb-f8d1-4cc6-b483-280f87c4719f 20.152µs
```

It can be seen that we can save quite Nx levels such as if 
your drive is mounted at `/disk1/minio` you can simply skip 
sending an `Mkdir /disk1/` and `Mkdir /disk1/minio`.

Since they are expected to exist already, this PR adds a way 
for us to ignore all paths up to the mount or a directory 
which ever has been provided to MinIO setup.

## How to test this PR?
CI/CD should cover everything

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
