### PR TITLE
remove generating presignedURLs with range header for lambda

### DIFF
--- a/cmd/object-lambda-handlers.go
+++ b/cmd/object-lambda-handlers.go
@@ -70,11 +70,8 @@ func getLambdaEventData(bucket, object string, cred auth.Credentials, r *http.Re
 			reqParams.Set(k, v)
 		}
 	}
-	extraHeaders := http.Header{}
-	if rng := r.Header.Get(xhttp.Range); rng != "" {
-		extraHeaders.Set(xhttp.Range, r.Header.Get(xhttp.Range))
-	}
 
+	extraHeaders := http.Header{}
 	u, err := clnt.PresignHeader(r.Context(), http.MethodGet, bucket, object, duration, reqParams, extraHeaders)
 	if err != nil {
 		return levent.Event{}, err


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
remove generating presignedURLs with range header for lambda

## Motivation and Context
unnecessary, the logic must be at the lambda layer

## How to test this PR?
Generate a presigned URL to invoke lambda function with Range header,
it would lead to an inconsistent presigned URL that gets relayed
to lambda function.

Avoid this and let the lambda function handle what is necessary
based on the userRequest headers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
