### PR TITLE
fix: Add missing dependency 'ellipses' for reorder-disks tool

### DIFF
--- a/docs/debugging/reorder-disks/go.mod
+++ b/docs/debugging/reorder-disks/go.mod
@@ -3,3 +3,5 @@ module github.com/minio/minio/docs/debugging/reorder-disks
 go 1.19
 
 require github.com/minio/pkg v1.6.4
+
+require github.com/minio/pkg/v2 v2.0.1 // indirect

--- a/docs/debugging/reorder-disks/go.sum
+++ b/docs/debugging/reorder-disks/go.sum
@@ -1,2 +1,4 @@
 github.com/minio/pkg v1.6.4 h1:k6XlhyJ8zOn90PI4csuMeePx7BQrcX1jorKriR5J2fo=
 github.com/minio/pkg v1.6.4/go.mod h1:0iX1IuJGSCnMvIvrEJauk1GgQSX9JdU6Kh0P3EQRGkI=
+github.com/minio/pkg/v2 v2.0.1 h1:MI3xMGCxoN5EEBRp98uEU5J0LlaF+8fLPtL8oHTHLX0=
+github.com/minio/pkg/v2 v2.0.1/go.mod h1:6xTAr5M9yobpUroXAAaTrGJ9fhOZIqKYOT0I87u2yZ4=


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This fixes a bug that was introduced in
1c99fb106c3e1448ed92f8465d5695d055d432e7 when the additional dependency was introduced.

## Motivation and Context

The reorder-disks debug tool could no longer be built.

## How to test this PR?

```bash
cd docs/debugging/reorder-disks
go build ./...
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from 1c99fb106c3e1448ed92f8465d5695d055d432e7
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
