### PR TITLE
perf net: Add the endpoint name related to the perf net error

### DIFF
--- a/cmd/perf-tests.go
+++ b/cmd/perf-tests.go
@@ -306,7 +306,7 @@ func netperf(ctx context.Context, duration time.Duration) madmin.NetperfNodeResu
 					defer wg.Done()
 					err := globalNotificationSys.peerClients[index].DevNull(ctx, r)
 					if err != nil {
-						errStr = err.Error()
+						errStr = fmt.Sprintf("error with %s: %s", globalNotificationSys.peerClients[index].String(), err.Error())
 					}
 				}()
 			}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
In a perf test, one node will run speed test with all nodes. 
If there is an error with a peer node, the peer node name is 
not included in the error hence confusing the user.

This commit will add the peer endpoint string to the netperf error.

## Motivation and Context
Better error reporting to the user

## How to test this PR?
Run 'mc support perf'  against a distributed cluster with an offline node

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
