### PR TITLE
Add abandoned folder scanning to metrics

### DIFF
--- a/cmd/data-scanner-metric.go
+++ b/cmd/data-scanner-metric.go
@@ -66,10 +66,12 @@ const (
 	scannerMetricYield
 	scannerMetricCleanAbandoned
 	scannerMetricApplyNonCurrent
+	scannerMetricHealAbandonedVersion
 
 	// START Trace metrics:
 	scannerMetricStartTrace
 	scannerMetricScanObject // Scan object. All operations included.
+	scannerMetricHealAbandonedObject
 
 	// END realtime metrics:
 	scannerMetricLastRealtime

--- a/cmd/scannermetric_string.go
+++ b/cmd/scannermetric_string.go
@@ -20,19 +20,21 @@ func _() {
 	_ = x[scannerMetricYield-9]
 	_ = x[scannerMetricCleanAbandoned-10]
 	_ = x[scannerMetricApplyNonCurrent-11]
-	_ = x[scannerMetricStartTrace-12]
-	_ = x[scannerMetricScanObject-13]
-	_ = x[scannerMetricLastRealtime-14]
-	_ = x[scannerMetricScanFolder-15]
-	_ = x[scannerMetricScanCycle-16]
-	_ = x[scannerMetricScanBucketDrive-17]
-	_ = x[scannerMetricCompactFolder-18]
-	_ = x[scannerMetricLast-19]
+	_ = x[scannerMetricHealAbandonedVersion-12]
+	_ = x[scannerMetricStartTrace-13]
+	_ = x[scannerMetricScanObject-14]
+	_ = x[scannerMetricHealAbandonedObject-15]
+	_ = x[scannerMetricLastRealtime-16]
+	_ = x[scannerMetricScanFolder-17]
+	_ = x[scannerMetricScanCycle-18]
+	_ = x[scannerMetricScanBucketDrive-19]
+	_ = x[scannerMetricCompactFolder-20]
+	_ = x[scannerMetricLast-21]
 }
 
-const _scannerMetric_name = "ReadMetadataCheckMissingSaveUsageApplyAllApplyVersionTierObjSweepHealCheckILMCheckReplicationYieldCleanAbandonedApplyNonCurrentStartTraceScanObjectLastRealtimeScanFolderScanCycleScanBucketDriveCompactFolderLast"
+const _scannerMetric_name = "ReadMetadataCheckMissingSaveUsageApplyAllApplyVersionTierObjSweepHealCheckILMCheckReplicationYieldCleanAbandonedApplyNonCurrentHealAbandonedVersionStartTraceScanObjectHealAbandonedObjectLastRealtimeScanFolderScanCycleScanBucketDriveCompactFolderLast"
 
-var _scannerMetric_index = [...]uint8{0, 12, 24, 33, 41, 53, 65, 74, 77, 93, 98, 112, 127, 137, 147, 159, 169, 178, 193, 206, 210}
+var _scannerMetric_index = [...]uint8{0, 12, 24, 33, 41, 53, 65, 74, 77, 93, 98, 112, 127, 147, 157, 167, 186, 198, 208, 217, 232, 245, 249}
 
 func (i scannerMetric) String() string {
 	if i >= scannerMetric(len(_scannerMetric_index)-1) {


### PR DESCRIPTION
## Description

Include object and versions heal scan times when checking non-empty abandoned folders.

Furthermore don't add delay between healing versions, instead do one per object wait.

## Motivation and Context

Don't make the scanner appear idle, even when not. Sending mc update as well.

## How to test this PR?

Delete a prefix on a disk. Observe `mc admin scanner status --json ALIAS`.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
