### PR TITLE
tier: Avoid doing versioned operations since not required anymore

### DIFF
--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -49,7 +49,7 @@ const probeObject = "probeobject"
 // to perform all operations defined in the WarmBackend interface.
 func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 	var empty bytes.Reader
-	rv, err := w.Put(ctx, probeObject, &empty, 0)
+	_, err := w.Put(ctx, probeObject, &empty, 0)
 	if err != nil {
 		if _, ok := err.(BackendDown); ok {
 			return err
@@ -60,7 +60,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 		}
 	}
 
-	r, err := w.Get(ctx, probeObject, rv, WarmBackendGetOpts{})
+	r, err := w.Get(ctx, probeObject, "", WarmBackendGetOpts{})
 	xhttp.DrainBody(r)
 	if err != nil {
 		if _, ok := err.(BackendDown); ok {
@@ -78,7 +78,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 			}
 		}
 	}
-	if err = w.Remove(ctx, probeObject, rv); err != nil {
+	if err = w.Remove(ctx, probeObject, ""); err != nil {
 		if _, ok := err.(BackendDown); ok {
 			return err
 		}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Currently, setting a new tiering target returns an error when 
a bucket is versioned and the tiering credentials does not 
have authorization to specify a version-id when reading or 
removing a specific version;

Since tiering does not require versioning anymore; avoid doing 
versioned operations when performing checklist ops while
adding a new tiering configuration.


## Motivation and Context
The doc doesn't require s3:GetObjectVersion and s3:DeleteObjectVersion, hence users
cannot add a bucket for tiering if the bucket is versioning (s3 or minio)

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
