### PR TITLE
return an error in CopyAligned upon premature EOF

### DIFF
--- a/internal/ioutil/ioutil_test.go
+++ b/internal/ioutil/ioutil_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -20,8 +20,10 @@ package ioutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,5 +205,38 @@ func TestSameFile(t *testing.T) {
 	}
 	if SameFile(fi1, fi2) {
 		t.Fatal("Expected the files not to be same")
+	}
+}
+
+func TestCopyAligned(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Errorf("Error creating tmp file: %v", err)
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	r := strings.NewReader("hello world")
+
+	bufp := ODirectPoolSmall.Get().(*[]byte)
+	defer ODirectPoolSmall.Put(bufp)
+
+	written, err := CopyAligned(f, io.LimitReader(r, 5), *bufp, r.Size(), f)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("Expected io.ErrUnexpectedEOF, but got %v", err)
+	}
+	if written != 5 {
+		t.Errorf("Expected written to be '5', but got %v", written)
+	}
+
+	f.Seek(0, io.SeekStart)
+	r.Seek(0, io.SeekStart)
+
+	written, err = CopyAligned(f, r, *bufp, r.Size(), f)
+	if !errors.Is(err, nil) {
+		t.Errorf("Expected nil, but got %v", err)
+	}
+	if written != r.Size() {
+		t.Errorf("Expected written to be '%v', but got %v", r.Size(), written)
 	}
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
return an error in CopyAligned upon premature EOF

## Motivation and Context
just more protection for the implementation itself
such that the caller does not have to do double validation.

## How to test this PR?
CI/CD should cover this and also unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
