### PR TITLE
Delete API: return 204 if version not found

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2416,7 +2416,7 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 			return
 		}
-		if isErrObjectNotFound(err) {
+		if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
 			writeSuccessNoContent(w)
 			return
 		}


### PR DESCRIPTION
Continue from https://github.com/minio/minio/pull/17599/ that missed out setting 204 response if object version being deleted does not exist.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
Correctness as per S3 spec

## How to test this PR?
```
aws s3api delete-object --version-id null  --bucket bucket --key dir/optimize.yml --endpoint-url http://localhost:9001 --profile minio

An error occurred (NoSuchVersion) when calling the DeleteObject operation: The specified version does not exist.
```
should return 204 like aws

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) 17599
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
