### PR TITLE
Listbuckets: Check quorum for each bucket

### DIFF
--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -153,17 +153,18 @@ func (sys *S3PeerSys) ListBuckets(ctx context.Context, opts BucketOptions) (resu
 		return nil, err
 	}
 
-	bucketsMap := make(map[string]struct{})
+	bucketsCounter := make(map[string]int)
 	for idx, buckets := range nodeBuckets {
 		if errs[idx] != nil {
 			continue
 		}
 		for _, bi := range buckets {
-			_, ok := bucketsMap[bi.Name]
-			if !ok {
-				bucketsMap[bi.Name] = struct{}{}
+			n := bucketsCounter[bi.Name] + 1
+			if n == quorum {
+				// Add each as we reach quorum.
 				result = append(result, bi)
 			}
+			bucketsCounter[bi.Name] = n
 		}
 	}
 


### PR DESCRIPTION
## Description

Each host does it's own quorum calculation, across disks. This means that if a host can reach quorum, it alone decides if a bucket exists or not.

We switch to a similar quorum calculation like `GetBucketInfo`, where there has to be quorum for a bucket checked across hosts.

## Motivation and Context

If a node misses a bucket delete request, it will keep a "zombie" bucket alive, which cannot otherwise reach quorum.

## How to test this PR?

Disconnect a host. Delete a bucket. Reconnect the host. List buckets.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
