### PR TITLE
Fix tier addition validation

### DIFF
--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -49,7 +49,7 @@ const probeObject = "probeobject"
 // to perform all operations defined in the WarmBackend interface.
 func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 	var empty bytes.Reader
-	_, err := w.Put(ctx, probeObject, &empty, 0)
+	remoteVersionID, err := w.Put(ctx, probeObject, &empty, 0)
 	if err != nil {
 		if _, ok := err.(BackendDown); ok {
 			return err
@@ -78,7 +78,7 @@ func checkWarmBackend(ctx context.Context, w WarmBackend) error {
 			}
 		}
 	}
-	if err = w.Remove(ctx, probeObject, ""); err != nil {
+	if err = w.Remove(ctx, probeObject, remoteVersionID); err != nil {
 		if _, ok := err.(BackendDown); ok {
 			return err
 		}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
preliminary probe was not cleaning up the versioned content created on remote tier.

## Motivation and Context
Fix tier in use error

## How to test this PR?
```
 mc admin tier add minio sitea tier1 --endpoint http://localhost:9004 --access-key minio --secret-key minio123 --bucket bucket --prefix prefix6/
mc: <ERROR> Unable to configure remote tier target. Specified remote tier is already in use.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
