### PR TITLE
delete replication: avoid overwriting replication decision

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -376,8 +376,10 @@ func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelet
 			} else {
 				// can be the case that other cluster is down and duplicate `mc rm --vid`
 				// is issued - this still needs to be replicated back to the other target
-				replicate = oi.VersionPurgeStatus == Pending || oi.VersionPurgeStatus == Failed
-				dsc.Set(newReplicateTargetDecision(tgtArn, replicate, sync))
+				if !oi.VersionPurgeStatus.Empty() {
+					replicate = oi.VersionPurgeStatus == Pending || oi.VersionPurgeStatus == Failed
+					dsc.Set(newReplicateTargetDecision(tgtArn, replicate, sync))
+				}
 				continue
 			}
 		}


### PR DESCRIPTION
from ObjectInfo unless version purge status is present. Otherwise there is potential to make incorrect replication decision if Stat returned an error

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
Avoid incorrect replication decisions.

## How to test this PR?
hard to repro - needs GetObjectInfo to return error during a delete 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
