### PR TITLE
Fix panic on double unfreezeServices

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -104,11 +104,11 @@ func unfreezeServices() {
 	// Close when we reach 0
 	globalServiceFreezeCnt--
 	if globalServiceFreezeCnt <= 0 {
-		// Ensure we only close once.
-		if val := globalServiceFreeze.Load(); val != nil {
-			var _ch chan struct{}
-			if ch, ok := val.(chan struct{}); ok {
-				globalServiceFreeze.Store(_ch)
+		// Set to a nil channel.
+		var _ch chan struct{}
+		if val := globalServiceFreeze.Swap(_ch); val != nil {
+			if ch, ok := val.(chan struct{}); ok && ch != nil {
+				// Close previous non-nil channel.
 				close(ch)
 			}
 		}


### PR DESCRIPTION
## Description

Calling unfreezeServices twice results in panic:

```
panic: "POST /minio/peer/v32/signalservice?signal=4&sub-sys=": close of nil channel
goroutine 14703 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x65
github.com/minio/minio/cmd.setCriticalErrorHandler.func1.1()
	github.com/minio/minio/cmd/generic-handlers.go:549 +0x8e
panic({0x27c3020, 0x4c9b370})
	runtime/panic.go:884 +0x212
github.com/minio/minio/cmd.unfreezeServices()
	github.com/minio/minio/cmd/service.go:112 +0xc7
github.com/minio/minio/cmd.(*peerRESTServer).SignalServiceHandler(0x0?, {0x4cb6af0, 0xc010b96420}, 0xc01affab00)
	github.com/minio/minio/cmd/peer-rest-server.go:837 +0x13a
net/http.HandlerFunc.ServeHTTP(...)
```

If the function was called a second time `val` would not be nil, but the returned channel `ch` would be, causing the panic.

Check the channel isn't nil and also use Swap for an atomic swap instead of 2 separate operations (though we are in a mutex).

## How to test this PR?

Call rest endpoint twice.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
