### PR TITLE
fix: avoid nil panic upon error in GetObjectNInfo via InnerGetObjectNInfoFn

### DIFF
--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -270,10 +270,11 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 			cacheReader.Close()
 			c.cacheStats.incMiss()
 			bReader, err := c.InnerGetObjectNInfoFn(ctx, bucket, object, rs, h, opts)
-			if bReader != nil {
-				bReader.ObjInfo.CacheLookupStatus = CacheHit
-				bReader.ObjInfo.CacheStatus = CacheMiss
+			if err != nil {
+				return nil, err
 			}
+			bReader.ObjInfo.CacheLookupStatus = CacheHit
+			bReader.ObjInfo.CacheStatus = CacheMiss
 			return bReader, err
 		}
 		// serve cached content without ETag verification if writeback commit is not yet complete

--- a/cmd/disk-cache.go
+++ b/cmd/disk-cache.go
@@ -270,8 +270,10 @@ func (c *cacheObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 			cacheReader.Close()
 			c.cacheStats.incMiss()
 			bReader, err := c.InnerGetObjectNInfoFn(ctx, bucket, object, rs, h, opts)
-			bReader.ObjInfo.CacheLookupStatus = CacheHit
-			bReader.ObjInfo.CacheStatus = CacheMiss
+			if bReader != nil {
+				bReader.ObjInfo.CacheLookupStatus = CacheHit
+				bReader.ObjInfo.CacheStatus = CacheMiss
+			}
 			return bReader, err
 		}
 		// serve cached content without ETag verification if writeback commit is not yet complete


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
function defined as 
```go
	InnerGetObjectNInfoFn          func(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, opts ObjectOptions) (gr *GetObjectReader, err error)
```
when We get error from `InnerGetObjectNInfoFn`.

```go
		bReader, err := c.InnerGetObjectNInfoFn(ctx, bucket, object, rs, h, opts)
		bReader.ObjInfo.CacheLookupStatus = CacheHit
		bReader.ObjInfo.CacheStatus = CacheMiss
```
That should be panic.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
