### PR TITLE
Fix PutObjectExtract data races

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2124,12 +2124,12 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 		getObjectInfo = api.CacheAPI().GetObjectInfo
 	}
 
+	if sc == "" {
+		sc = storageclass.STANDARD
+	}
+
 	putObjectTar := func(reader io.Reader, info os.FileInfo, object string) error {
 		size := info.Size()
-
-		if sc == "" {
-			sc = storageclass.STANDARD
-		}
 
 		metadata := map[string]string{
 			xhttp.AmzStorageClass: sc, // save same storage-class as incoming stream.

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2124,6 +2124,12 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 		getObjectInfo = api.CacheAPI().GetObjectInfo
 	}
 
+	// These are static for all objects extracted.
+	reqParams := extractReqParams(r)
+	respElements := map[string]string{
+		"requestId": w.Header().Get(xhttp.AmzRequestID),
+		"nodeId":    w.Header().Get(xhttp.AmzRequestHostID),
+	}
 	if sc == "" {
 		sc = storageclass.STANDARD
 	}
@@ -2258,8 +2264,8 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 			EventName:    event.ObjectCreatedPut,
 			BucketName:   bucket,
 			Object:       objInfo,
-			ReqParams:    extractReqParams(r),
-			RespElements: extractRespElements(w),
+			ReqParams:    reqParams,
+			RespElements: respElements,
 			UserAgent:    r.UserAgent(),
 			Host:         handlers.GetSourceIP(r),
 		}


### PR DESCRIPTION
## Description

Several callers to putObjectTar may be fighting to set `sc`. Move the write out of the loop.

Fixes tests with -race:

```
WARNING: DATA RACE
Read at 0x00c01cd680e0 by goroutine 691354:
  github.com/minio/minio/cmd.objectAPIHandlers.PutObjectExtractHandler.func1()
      e:/gopath/src/github.com/minio/minio/cmd/object-handlers.go:2130 +0x149
  github.com/minio/minio/cmd.untar.func1()
      e:/gopath/src/github.com/minio/minio/cmd/untar.go:250 +0x2b6
  github.com/minio/minio/cmd.untar.func8()
      e:/gopath/src/github.com/minio/minio/cmd/untar.go:261 +0xa4

Previous write at 0x00c01cd680e0 by goroutine 691352:
  github.com/minio/minio/cmd.objectAPIHandlers.PutObjectExtractHandler.func1()
      e:/gopath/src/github.com/minio/minio/cmd/object-handlers.go:2131 +0x15d
  github.com/minio/minio/cmd.untar.func1()
      e:/gopath/src/github.com/minio/minio/cmd/untar.go:250 +0x2b6
  github.com/minio/minio/cmd.untar.func8()
      e:/gopath/src/github.com/minio/minio/cmd/untar.go:261 +0xa4
```

and

```
WARNING: DATA RACE
Write at 0x00c016727100 by goroutine 691352:
  net/http.(*response).Header()
      C:/go/src/net/http/server.go:1094 +0x11d
  github.com/minio/minio/internal/http.(*ResponseRecorder).Header()
      <autogenerated>:1 +0x43
  github.com/klauspost/compress/gzhttp.(*NoGzipResponseWriter).Header()
      e:/gopath/pkg/mod/github.com/klauspost/compress@v1.17.0/gzhttp/compress.go:985 +0x3a
  go:(*struct { net/http.ResponseWriter; net/http.Hijacker; net/http.Flusher; github.com/klauspost/compress/gzhttp.unwrapper }).Header()
      <autogenerated>:1 +0x43
  github.com/minio/minio/cmd.extractRespElements()
      e:/gopath/src/github.com/minio/minio/cmd/handler-utils.go:247 +0x68
  github.com/minio/minio/cmd.objectAPIHandlers.PutObjectExtractHandler.func1()
      e:/gopath/src/github.com/minio/minio/cmd/object-handlers.go:2262 +0x254f

Previous write at 0x00c016727100 by goroutine 691354:
  net/http.(*response).Header()
      C:/go/src/net/http/server.go:1094 +0x11d
  github.com/minio/minio/internal/http.(*ResponseRecorder).Header()
      <autogenerated>:1 +0x43
  github.com/klauspost/compress/gzhttp.(*NoGzipResponseWriter).Header()
      e:/gopath/pkg/mod/github.com/klauspost/compress@v1.17.0/gzhttp/compress.go:985 +0x3a
  go:(*struct { net/http.ResponseWriter; net/http.Hijacker; net/http.Flusher; github.com/klauspost/compress/gzhttp.unwrapper }).Header()
      <autogenerated>:1 +0x43
  github.com/minio/minio/cmd.extractRespElements()
      e:/gopath/src/github.com/minio/minio/cmd/handler-utils.go:247 +0x68
  github.com/minio/minio/cmd.objectAPIHandlers.PutObjectExtractHandler.func1()
      e:/gopath/src/github.com/minio/minio/cmd/object-handlers.go:2262 +0x254f
```

## How to test this PR?

Build with `-race`. Run mint tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
