### PR TITLE
fix: siteResyncMetrics init will make a deadlock when len(siteReplication) >= 3

### DIFF
--- a/cmd/site-replication-utils.go
+++ b/cmd/site-replication-utils.go
@@ -118,11 +118,11 @@ func (sm *siteResyncMetrics) load(ctx context.Context, objAPI ObjectLayer) error
 			return err
 		}
 		sm.Lock()
-		defer sm.Unlock()
 		if _, ok := sm.peerResyncMap[peer.DeploymentID]; !ok {
 			sm.peerResyncMap[peer.DeploymentID] = resyncState{resyncID: rs.ResyncID, LastSaved: time.Time{}}
 			sm.resyncStatus[rs.ResyncID] = rs
 		}
+		sm.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: siteResyncMetrics init will make a deadlock when len(siteReplication) >= 3

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
