### PR TITLE
fix: should call func globalOSMetrics.time(s)() when updateOSMetrics

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.1
+          go-version: 1.21.3
           check-latest: true
       - name: Get official govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -105,7 +105,8 @@ func osTrace(s osMetric, startTime time.Time, duration time.Duration, path strin
 
 func updateOSMetrics(s osMetric, paths ...string) func(err error) {
 	if globalTrace.NumSubscribers(madmin.TraceOS) == 0 {
-		return func(err error) { globalOSMetrics.time(s)() }
+		osAction := globalOSMetrics.time(s)
+		return func(err error) { osAction() }
 	}
 
 	startTime := time.Now()

--- a/cmd/os-instrumented.go
+++ b/cmd/os-instrumented.go
@@ -105,7 +105,7 @@ func osTrace(s osMetric, startTime time.Time, duration time.Duration, path strin
 
 func updateOSMetrics(s osMetric, paths ...string) func(err error) {
 	if globalTrace.NumSubscribers(madmin.TraceOS) == 0 {
-		return func(err error) { globalOSMetrics.time(s) }
+		return func(err error) { globalOSMetrics.time(s)() }
 	}
 
 	startTime := time.Now()

--- a/docs/debugging/pprofgoparser/go.mod
+++ b/docs/debugging/pprofgoparser/go.mod
@@ -1,3 +1,3 @@
 module github.com/minio/minio/docs/debugging/pprofgoparser
 
-go 1.21.1
+go 1.21.3

--- a/docs/debugging/s3-verify/go.mod
+++ b/docs/debugging/s3-verify/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/minio/docs/debugging/s3-verify
 
-go 1.21.1
+go 1.21.3
 
 require github.com/minio/minio-go/v7 v7.0.63
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: should call func when updateOSMetrics

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
