### PR TITLE
Fix various poolmeta races

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -143,6 +143,12 @@ func newErasureServerPools(ctx context.Context, endpointServerPools EndpointServ
 
 	z.decommissionCancelers = make([]context.CancelFunc, len(z.serverPools))
 
+	// Initialize the pool meta, but set it to not save.
+	// When z.Init below has loaded the poolmeta will be initialized,
+	// and allowed to save.
+	z.poolMeta = newPoolMeta(z, poolMeta{})
+	z.poolMeta.dontSave = true
+
 	// initialize the object layer.
 	setObjectLayer(z)
 


### PR DESCRIPTION
## Description

Code huddle with @r-scheele reviewing the code.

Replaces https://github.com/minio/minio/pull/18222

There is a fundamental race condition in `newErasureServerPools`, where setObjectLayer is called before the poolMeta has been loaded/populated.

We add a placeholder value to this field, but disable all saving of the value, so we don't risk overwriting the value on disk. Once the value has been loaded or created, it is replaced with the proper value, which will also save.

Also fixes various accesses of `poolMeta` that was done without locks.

We make the `poolMeta.IsSuspended` return false, even if we shouldn't risk out-of-bounds reads any more.

## How to test this PR?

Races happen on startup with anything accessing the object layer between `setObjectLayer(z)` and `z.Init(ctx)` completing successfully. Insert a delay to trigger.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
