### PR TITLE
fix: env depend the flag

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -579,13 +579,13 @@ func serverMain(ctx *cli.Context) {
 
 	setDefaultProfilerRates()
 
-	// Handle all server environment vars.
-	serverHandleEnvVars()
-
 	// Handle all server command args.
 	bootstrapTrace("serverHandleCmdArgs", func() {
 		serverHandleCmdArgs(ctx)
 	})
+
+	// Handle all server environment vars.
+	serverHandleEnvVars()
 
 	// Initialize globalConsoleSys system
 	bootstrapTrace("newConsoleLogger", func() {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: env depend the flag
fix https://github.com/minio/minio/issues/18229

serverHandleCmdArgs->handleCommonCmdArgs->**set** globalMinioPort
serverHandleEnvVars->handleCommonEnvVars->updateDomainIPs(domainIPs)->**use** globalMinioPort

sr will get `endpoint:9000` always.
```
func (c *CoreDNS) Get(bucket string) ([]SrvRecord, error) {
	var srvRecords []SrvRecord
	for _, domainName := range c.domainNames {
		key := msg.Path(fmt.Sprintf("%s.%s.", bucket, domainName), c.prefixPath)
		records, err := c.list(key, false)
		if err != nil {
			return nil, err
		}
		// Make sure we have record.Key is empty
		// this can only happen when record.Key
		// has bucket entry with exact prefix
		// match any record.Key which do not
		// match the prefixes we skip them.
		for _, record := range records {
			if record.Key != "" {
				continue
			}
			srvRecords = append(srvRecords, record)
		}
	}
	if len(srvRecords) == 0 {
		return nil, ErrNoEntriesFound
	}
	return srvRecords, nil
}
```

https://github.com/minio/minio/blob/6d20ec3bea756e6fb75564f950221b93dcc8d30a/cmd/generic-handlers.go#L497-L510
`globalDomainIPs.Intersection(set.CreateStringSet(getHostsSlice(sr)...)).IsEmpty()` is always true for `--address :9010`
so make a globalForwarder.ServeHTTP always.

## Motivation and Context


## How to test this PR?

minio start with `MINIO_ETCD_ENDPOINTS=endporints --address :9010`
upload anything will get error like the issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
