### PR TITLE
Add single request timeouts

### DIFF
--- a/internal/grid/benchmark_test.go
+++ b/internal/grid/benchmark_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func BenchmarkGrid(b *testing.B) {
-	for n := 2; n <= 16; n++ {
+	for n := 2; n <= 32; n *= 2 {
 		b.Run("servers="+strconv.Itoa(n), func(b *testing.B) {
 			benchmarkGridServers(b, n)
 		})

--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -282,6 +282,7 @@ func (c *Subroute) newMuxClient(ctx context.Context) (*muxClient, error) {
 
 // Request allows to do a single remote request.
 // 'req' will not be used after the call and caller can reuse.
+// If no deadline is set on ctx, a 1-minute deadline will be added.
 func (c *Connection) Request(ctx context.Context, h HandlerID, req []byte) ([]byte, error) {
 	if !h.valid() {
 		return nil, ErrUnknownHandler
@@ -303,6 +304,7 @@ func (c *Connection) Request(ctx context.Context, h HandlerID, req []byte) ([]by
 
 // Request allows to do a single remote request.
 // 'req' will not be used after the call and caller can reuse.
+// If no deadline is set on ctx, a 1-minute deadline will be added.
 func (c *Subroute) Request(ctx context.Context, h HandlerID, req []byte) ([]byte, error) {
 	if !h.valid() {
 		return nil, ErrUnknownHandler

--- a/internal/grid/handlers.go
+++ b/internal/grid/handlers.go
@@ -308,6 +308,7 @@ type Requester interface {
 
 // Call the remove with the request and return the response.
 // The response should be returned with PutResponse when no error.
+// If no deadline is set, a 1-minute deadline is added.
 func (h *SingleHandler[Req, Resp]) Call(ctx context.Context, c Requester, req Req) (resp Resp, err error) {
 	payload, err := req.MarshalMsg(GetByteBuffer()[:0])
 	if err != nil {


### PR DESCRIPTION
## Description

* Add single request timeouts

Adds a 60 second deadline to []byte -> []byte calls.


## Motivation and Context

Avoid dead calls to remotes, that may have been dropped because of network issues, etc.

## How to test this PR?

Disconnect+reconnect nodes.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
