### PR TITLE
fix site replication resync status

### DIFF
--- a/cmd/site-replication-utils.go
+++ b/cmd/site-replication-utils.go
@@ -198,9 +198,9 @@ func (sm *siteResyncMetrics) save(ctx context.Context) {
 }
 
 // update overall site resync state
-func (sm *siteResyncMetrics) updateState(s SiteResyncStatus) {
+func (sm *siteResyncMetrics) updateState(s SiteResyncStatus) error {
 	if !globalSiteReplicationSys.isEnabled() {
-		return
+		return nil
 	}
 	sm.Lock()
 	defer sm.Unlock()
@@ -213,9 +213,12 @@ func (sm *siteResyncMetrics) updateState(s SiteResyncStatus) {
 		if ok {
 			st.LastUpdate = s.LastUpdate
 			st.Status = s.Status
+			return nil
 		}
 		sm.resyncStatus[s.ResyncID] = st
+		return saveSiteResyncMetadata(GlobalContext, st, newObjectLayerFn())
 	}
+	return nil
 }
 
 // increment SyncedBuckets count

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -5157,8 +5157,7 @@ func (c *SiteReplicationSys) startResync(ctx context.Context, objAPI ObjectLayer
 		}
 	}()
 
-	globalSiteResyncMetrics.updateState(rs)
-	if err := saveSiteResyncMetadata(ctx, rs, objAPI); err != nil {
+	if err := globalSiteResyncMetrics.updateState(rs); err != nil {
 		return res, err
 	}
 
@@ -5408,6 +5407,9 @@ func loadSiteResyncMetadata(ctx context.Context, objAPI ObjectLayer, dID string)
 
 // save resync status of peer to resync/depl-id.meta
 func saveSiteResyncMetadata(ctx context.Context, ss SiteResyncStatus, objectAPI ObjectLayer) error {
+	if objectAPI == nil {
+		return errSRObjectLayerNotReady
+	}
 	data := make([]byte, 4, ss.Msgsize()+4)
 
 	// Initialize the resync meta header.

--- a/docs/site-replication/run-multi-site-ldap.sh
+++ b/docs/site-replication/run-multi-site-ldap.sh
@@ -247,7 +247,7 @@ if [ $? -ne 0 ]; then
 	echo "expecting object to be present. exiting.."
 	exit_1
 fi
-./mc tag set --version-id "${vID}" minio2/newbucket/README.md "k=v"
+./mc tag set --version-id "${vID}" minio2/newbucket/README.md "key=val"
 if [ $? -ne 0 ]; then
 	echo "expecting tag set to be successful. exiting.."
 	exit_1
@@ -351,6 +351,23 @@ diff -q <(./mc ls minio1) <(./mc ls minio2) 1>/dev/null
 if [ $? -ne 0 ]; then
 	echo "expected 'bucket2' delete and 'newbucket2' creation to have replicated, exiting..."
 	exit_1
+fi
+
+# force a resync after removing all site replication
+./mc admin replicate rm --all --force minio1
+./mc rb minio2 --force --dangerous
+./mc admin replicate add minio1 minio2
+./mc admin replicate resync start minio1 minio2
+sleep 30
+
+./mc ls -r --versions minio1/newbucket >/tmp/minio1.txt
+./mc ls -r --versions minio2/newbucket >/tmp/minio2.txt
+
+out=$(diff -qpruN /tmp/minio1.txt /tmp/minio2.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "BUG: expected no missing entries after replication resync: $out"
+	exit 1
 fi
 
 cleanup

--- a/docs/site-replication/run-multi-site-minio-idp.sh
+++ b/docs/site-replication/run-multi-site-minio-idp.sh
@@ -234,7 +234,7 @@ if [ $? -ne 0 ]; then
 	echo "expecting object to be present. exiting.."
 	exit_1
 fi
-./mc tag set --version-id "${vID}" minio2/newbucket/README.md "k=v"
+./mc tag set --version-id "${vID}" minio2/newbucket/README.md "key=val"
 if [ $? -ne 0 ]; then
 	echo "expecting tag set to be successful. exiting.."
 	exit_1
@@ -369,4 +369,21 @@ diff -q <(./mc ls minio1) <(./mc ls minio2) 1>/dev/null
 if [ $? -ne 0 ]; then
 	echo "expected 'bucket2' delete and 'newbucket2' creation to have replicated, exiting..."
 	exit_1
+fi
+
+# force a resync after removing all site replication
+./mc admin replicate rm --all --force minio1
+./mc rb minio2 --force --dangerous
+./mc admin replicate add minio1 minio2
+./mc admin replicate resync start minio1 minio2
+sleep 30
+
+./mc ls -r --versions minio1/newbucket >/tmp/minio1.txt
+./mc ls -r --versions minio2/newbucket >/tmp/minio2.txt
+
+out=$(diff -qpruN /tmp/minio1.txt /tmp/minio2.txt)
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "BUG: expected no missing entries after replication resync: $out"
+	exit 1
 fi


### PR DESCRIPTION
to persist status changes right away on disk.

Adding tests

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
continuing #18244 for site replication

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
