### PR TITLE
fix: always load ENVs from files first as soon as server starts

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -619,8 +619,6 @@ func loadEnvVarsFromFiles() {
 }
 
 func handleCommonEnvVars() {
-	loadEnvVarsFromFiles()
-
 	var err error
 	globalBrowserEnabled, err = config.ParseBool(env.Get(config.EnvBrowser, config.EnableOn))
 	if err != nil {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -579,6 +579,9 @@ func serverMain(ctx *cli.Context) {
 
 	setDefaultProfilerRates()
 
+	// Always load ENV variables from files first.
+	loadEnvVarsFromFiles()
+
 	// Handle all server command args.
 	bootstrapTrace("serverHandleCmdArgs", func() {
 		serverHandleCmdArgs(ctx)


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: always load ENVs from files first as soon as the server starts

## Motivation and Context
This is a regression from #18231, however, reading from ENV 
files must happen well before any parsing logic is invoked.

## How to test this PR?
To reproduce this you need minio/operator:v5.0.x quite simply
deployment fails with any operation v5.0.x

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
