### PR TITLE
Allow OpenID ARN resource ID to start with a `-`

### DIFF
--- a/internal/arn/arn.go
+++ b/internal/arn/arn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -60,7 +60,7 @@ type ARN struct {
 
 // Allows english letters, numbers, '.', '-', '_' and '/'. Starts with a
 // letter or digit. At least 1 character long.
-var validResourceIDRegex = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_/\.-]*$`)
+var validResourceIDRegex = regexp.MustCompile(`[A-Za-z0-9_/\.-]+$`)
 
 // NewIAMRoleARN - returns an ARN for a role in MinIO.
 func NewIAMRoleARN(resourceID, serverRegion string) (ARN, error) {

--- a/internal/arn/arn_test.go
+++ b/internal/arn/arn_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// # This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package arn
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewIAMRoleARN(t *testing.T) {
+	testCases := []struct {
+		resourceID    string
+		serverRegion  string
+		expectedARN   string
+		isErrExpected bool
+	}{
+		{
+			resourceID:    "myrole",
+			serverRegion:  "us-east-1",
+			expectedARN:   "arn:minio:iam:us-east-1::role/myrole",
+			isErrExpected: false,
+		},
+		{
+			resourceID:    "myrole",
+			serverRegion:  "",
+			expectedARN:   "arn:minio:iam:::role/myrole",
+			isErrExpected: false,
+		},
+		{
+			// Resource ID can start with a hyphen
+			resourceID:    "-myrole",
+			serverRegion:  "",
+			expectedARN:   "arn:minio:iam:::role/-myrole",
+			isErrExpected: false,
+		},
+		{
+			resourceID:    "",
+			serverRegion:  "",
+			expectedARN:   "",
+			isErrExpected: true,
+		},
+	}
+	for i, testCase := range testCases {
+		arn, err := NewIAMRoleARN(testCase.resourceID, testCase.serverRegion)
+		fmt.Println(arn, err)
+		if err != nil {
+			if !testCase.isErrExpected {
+				t.Errorf("Test %d: Unexpected error: %v", i+1, err)
+			}
+			continue
+		}
+
+		if testCase.isErrExpected {
+			t.Errorf("Test %d: Expected error but got none", i+1)
+		}
+		if arn.String() != testCase.expectedARN {
+			t.Errorf("Test %d: Expected ARN %s but got %s", i+1, testCase.expectedARN, arn.String())
+		}
+
+	}
+}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Fixes an issue where a resource ID can start with a `-` because we hash the client ID in openid to get the resource ID.

## Motivation and Context

Fix a customer issue.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
