### PR TITLE
Don't skip rules with ExpiredObjectDeleteMarker

### DIFF
--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -156,7 +156,8 @@ func (lc Lifecycle) HasActiveRules(prefix string) bool {
 		}
 
 		if len(prefix) > 0 && len(rule.GetPrefix()) > 0 {
-			// If recursive, we can skip this rule if it doesn't match the tested prefix.
+			// we can skip this rule if it doesn't match the tested
+			// prefix.
 			if !strings.HasPrefix(prefix, rule.GetPrefix()) && !strings.HasPrefix(rule.GetPrefix(), prefix) {
 				continue
 			}
@@ -171,13 +172,13 @@ func (lc Lifecycle) HasActiveRules(prefix string) bool {
 		if !rule.NoncurrentVersionTransition.IsNull() {
 			return true
 		}
-		if rule.Expiration.IsNull() && rule.Transition.IsNull() {
-			continue
-		}
 		if !rule.Expiration.IsDateNull() && rule.Expiration.Date.Before(time.Now().UTC()) {
 			return true
 		}
 		if !rule.Expiration.IsDaysNull() {
+			return true
+		}
+		if rule.Expiration.DeleteMarker.val {
 			return true
 		}
 		if !rule.Transition.IsDateNull() && rule.Transition.Date.Before(time.Now().UTC()) {

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -575,7 +575,7 @@ func TestHasActiveRules(t *testing.T) {
 			want:        true,
 		},
 		{ // empty prefix
-			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Filter></Filter><Expiration><Days>5</Days></Expiration></Rule></LifecycleConfiguration>`,
 			prefix:      "foodir/foobject/foo.txt",
 			want:        true,
 		},
@@ -600,13 +600,23 @@ func TestHasActiveRules(t *testing.T) {
 			want:        false,
 		},
 		{
-			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Transition><StorageClass>S3TIER-1</StorageClass></Transition></Rule></LifecycleConfiguration>`,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Filter></Filter><Transition><StorageClass>S3TIER-1</StorageClass></Transition></Rule></LifecycleConfiguration>`,
 			prefix:      "foodir/foobject/foo.txt",
 			want:        true,
 		},
 		{
-			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><NoncurrentVersionTransition><StorageClass>S3TIER-1</StorageClass></NoncurrentVersionTransition></Rule></LifecycleConfiguration>`,
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Filter></Filter><NoncurrentVersionTransition><StorageClass>S3TIER-1</StorageClass></NoncurrentVersionTransition></Rule></LifecycleConfiguration>`,
 			prefix:      "foodir/foobject/foo.txt",
+			want:        true,
+		},
+		{
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Filter></Filter><Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "",
+			want:        true,
+		},
+		{
+			inputConfig: `<LifecycleConfiguration><Rule><Status>Enabled</Status><Filter></Filter><Expiration><Days>42</Days><ExpiredObjectAllVersions>true</ExpiredObjectAllVersions></Expiration></Rule></LifecycleConfiguration>`,
+			prefix:      "",
 			want:        true,
 		},
 	}
@@ -618,8 +628,12 @@ func TestHasActiveRules(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Got unexpected error: %v", err)
 			}
+			// To ensure input lifecycle configurations are valid
+			if err := lc.Validate(); err != nil {
+				t.Fatalf("Invalid test case: %d %v", i+1, err)
+			}
 			if got := lc.HasActiveRules(tc.prefix); got != tc.want {
-				t.Fatalf("Expected result with recursive set to false: `%v`, got: `%v`", tc.want, got)
+				t.Fatalf("Expected result: `%v`, got: `%v`", tc.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
lifecycle.HasActiveRules returned false when an ILM policy had only rules with ExpiredObjectDeleteMarker tags. This will make scanner assume that a bucket has no ILM policy configured thereby not applying the ILM rule to remove orphaned delete markers.

## Motivation and Context
Expiration of orphaned delete markers

## How to test this PR?
Unit test added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
