### PR TITLE
Fix resource metrics "concurrent map iteration and map write"

### DIFF
--- a/cmd/metrics-resource.go
+++ b/cmd/metrics-resource.go
@@ -387,21 +387,11 @@ func newMinioResourceCollector(metricsGroups []*MetricsGroup) *minioResourceColl
 func prepareResourceMetrics(rm ResourceMetric, subSys MetricSubsystem, requireAvgMax bool) []Metric {
 	help := resourceMetricsHelpMap[rm.Name]
 	name := rm.Name
-	copyMSS := func(in map[string]string) map[string]string {
-		if in == nil {
-			return nil
-		}
-		r := make(map[string]string, len(in))
-		for k, v := range in {
-			r[k] = v
-		}
-		return r
-	}
-	metrics := []Metric{}
+	metrics := make([]Metric, 0, 3)
 	metrics = append(metrics, Metric{
 		Description:    getResourceMetricDescription(subSys, name, help),
 		Value:          rm.Current,
-		VariableLabels: copyMSS(rm.Labels),
+		VariableLabels: cloneMSS(rm.Labels),
 	})
 
 	if requireAvgMax {
@@ -410,7 +400,7 @@ func prepareResourceMetrics(rm ResourceMetric, subSys MetricSubsystem, requireAv
 		metrics = append(metrics, Metric{
 			Description:    getResourceMetricDescription(subSys, avgName, avgHelp),
 			Value:          math.Round(rm.Avg*100) / 100,
-			VariableLabels: copyMSS(rm.Labels),
+			VariableLabels: cloneMSS(rm.Labels),
 		})
 
 		maxName := MetricName(fmt.Sprintf("%s_max", name))
@@ -418,7 +408,7 @@ func prepareResourceMetrics(rm ResourceMetric, subSys MetricSubsystem, requireAv
 		metrics = append(metrics, Metric{
 			Description:    getResourceMetricDescription(subSys, maxName, maxHelp),
 			Value:          rm.Max,
-			VariableLabels: copyMSS(rm.Labels),
+			VariableLabels: cloneMSS(rm.Labels),
 		})
 	}
 


### PR DESCRIPTION
## Description

`resourceMetricsMap` has no protection against concurrent reads and writes (including maps inside)

Add a mutex and don't use maps from last iteration.

Bug introduced in #18057

Fixes #18271

@anjalshireesh You may need to do some deeper testing, even after this - I may or may not have caught all - and it is rather copy/lock heavy now, to be safe. Build with `-race` and run several tests - one test may not catch it.

## How to test this PR?

Build with `-race`. Poll metrics. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression  #18057
