### PR TITLE
do not check for query params to be signed headers

### DIFF
--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -273,15 +273,5 @@ func checkMetaHeaders(signedHeadersMap http.Header, r *http.Request) APIErrorCod
 		}
 	}
 
-	// check values from url, if no http header
-	for k, val := range r.Form {
-		if stringsHasPrefixFold(k, "x-amz-meta-") {
-			if signedHeadersMap.Get(http.CanonicalHeaderKey(k)) == val[0] {
-				continue
-			}
-			return ErrUnsignedHeaders
-		}
-	}
-
 	return ErrNone
 }

--- a/cmd/signature-v4-utils_test.go
+++ b/cmd/signature-v4-utils_test.go
@@ -394,17 +394,4 @@ func TestCheckMetaHeaders(t *testing.T) {
 	if errCode != ErrNone {
 		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrNone, errCode)
 	}
-
-	// Add extra metadata in url values
-	r, err = http.NewRequest(http.MethodPut, "http://play.min.io:9000?x-amz-meta-test=test&x-amz-meta-extension=png&x-amz-meta-name=imagepng&x-amz-meta-clone=fail", nil)
-	if err != nil {
-		t.Fatal("Unable to create http.Request :", err)
-	}
-
-	r.ParseForm()
-	// calling the function being tested.
-	errCode = checkMetaHeaders(signedHeadersMap, r)
-	if errCode != ErrUnsignedHeaders {
-		t.Fatalf("Expected the APIErrorCode to be %d, but got %d", ErrUnsignedHeaders, errCode)
-	}
 }


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
do not check for query params to be signed headers

## Motivation and Context
x-amz-signed-headers is meant for HTTP headers only 
not for query params, using that to verify things
further can lead to failure.

The generated presigned URL with custom metadata
is already kosher (tamper proof).

fixes #18281

## How to test this PR?
As per reproducer in #18281 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
