### PR TITLE
[Helm Chart] add full security context in Helm chart

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Multi-Cloud Object Storage
 name: minio
-version: 5.0.14
+version: 5.0.15
 appVersion: RELEASE.2023-09-30T07-02-29Z
 keywords:
   - minio

--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 description: Multi-Cloud Object Storage
 name: minio
 version: 5.0.15
@@ -13,6 +13,7 @@ home: https://min.io
 icon: https://min.io/resources/img/logo/MINIO_wordmark.png
 sources:
 - https://github.com/minio/minio
+type: application
 maintainers:
 - name: MinIO, Inc
   email: dev@minio.io

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
             {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
-            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.extraContainers }}

--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -47,24 +47,10 @@ spec:
           {{- toYaml .Values.podAnnotations | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.runtimeClassName }}
-      runtimeClassName: "{{ .Values.runtimeClassName }}"
-      {{- end }}
-      {{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "20") }}
-        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
-        {{- end }}
-      {{- end }}
-      {{ if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- end }}
+      {{- include "minio.imagePullSecrets" . | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -163,6 +149,10 @@ spec:
             - name: {{ $key }}
               value: {{ tpl $val $ | quote }}
             {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.extraContainers }}
           {{- if eq (typeOf .) "string" }}
@@ -174,9 +164,18 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "minio.imagePullSecrets" . | indent 6 }}
-      {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: "{{ .Values.runtimeClassName }}"
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+      {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -40,9 +40,7 @@ spec:
       {{- end }}
       {{- if .Values.postJob.securityContext.enabled }}
       securityContext:
-        runAsUser: {{ .Values.postJob.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.postJob.securityContext.runAsGroup }}
-        fsGroup: {{ .Values.postJob.securityContext.fsGroup }}
+      {{- omit .Values.postJob.securityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       volumes:
         - name: etc-path
@@ -89,11 +87,6 @@ spec:
       initContainers:
         - name: minio-make-policy
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          {{- if .Values.makePolicyJob.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.makePolicyJob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.makePolicyJob.securityContext.runAsGroup }}
-          {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makePolicyJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
@@ -118,16 +111,15 @@ spec:
               mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
           resources: {{- toYaml .Values.makePolicyJob.resources | nindent 12 }}
+          {{- if .Values.makePolicyJob.securityContext.enabled }}
+          securityContext:
+          {{- omit .Values.makePolicyJob.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         {{- if .Values.buckets }}
         - name: minio-make-bucket
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          {{- if .Values.makeBucketJob.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.makeBucketJob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.makeBucketJob.securityContext.runAsGroup }}
-          {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeBucketJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
@@ -152,15 +144,14 @@ spec:
               mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
           resources: {{- toYaml .Values.makeBucketJob.resources | nindent 12 }}
+          {{- if .Values.makeBucketJob.securityContext.enabled }}
+          securityContext:
+          {{- omit .Values.makeBucketJob.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.users }}
         - name: minio-make-user
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          {{- if .Values.makeUserJob.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.makeUserJob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.makeUserJob.securityContext.runAsGroup }}
-          {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeUserJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
@@ -185,15 +176,14 @@ spec:
               mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
           resources: {{- toYaml .Values.makeUserJob.resources | nindent 12 }}
+          {{- if .Values.makeUserJob.securityContext.enabled }}
+          securityContext:
+          {{- omit .Values.makeUserJob.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.customCommands }}
         - name: minio-custom-command
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          {{- if .Values.customCommandJob.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.customCommandJob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.customCommandJob.securityContext.runAsGroup }}
-          {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.customCommandJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
@@ -218,15 +208,14 @@ spec:
               mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
           resources: {{- toYaml .Values.customCommandJob.resources | nindent 12 }}
+          {{- if .Values.customCommandJob.securityContext.enabled }}
+          securityContext:
+          {{- omit .Values.customCommandJob.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.svcaccts }}
         - name: minio-make-svcacct
           image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
-          {{- if .Values.makeServiceAccountJob.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.makeServiceAccountJob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.makeServiceAccountJob.securityContext.runAsGroup }}
-          {{- end }}
           imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
           {{- if .Values.makeServiceAccountJob.exitCommand }}
           command: [ "/bin/sh", "-c" ]
@@ -251,5 +240,9 @@ spec:
               mountPath: {{ .Values.configPathmc }}certs
             {{- end }}
           resources: {{- toYaml .Values.makeServiceAccountJob.resources | nindent 12 }}
+          {{- if .Values.makeServiceAccountJob.securityContext.enabled }}
+          securityContext:
+          {{- omit .Values.makeServiceAccountJob.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- end }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -75,24 +75,10 @@ spec:
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.priorityClassName }}
-      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.runtimeClassName }}
-      runtimeClassName: "{{ .Values.runtimeClassName }}"
-      {{- end }}
-      {{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        {{- if and (ge .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "20") }}
-        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
-        {{- end }}
-      {{- end }}
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{- end }}
+      {{- include "minio.imagePullSecrets" . | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -180,6 +166,10 @@ spec:
               value: {{ tpl $val $ | quote }}
             {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
         {{- with .Values.extraContainers }}
           {{- if eq (typeOf .) "string" }}
             {{- tpl . $ | nindent 8 }}
@@ -190,9 +180,18 @@ spec:
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- include "minio.imagePullSecrets" . | indent 6 }}
-      {{- with .Values.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: "{{ .Values.runtimeClassName }}"
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+      {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -243,12 +243,25 @@ topologySpreadConstraints: []
 
 ## Add stateful containers to have security context, if enabled MinIO will run as this
 ## user and group NOTE: securityContext is only enabled if persistence.enabled=true
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 securityContext:
   enabled: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
   runAsUser: 1000
   runAsGroup: 1000
+
+## Add security context for Pod
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+podSecurityContext:
+  enabled: true
   fsGroup: 1000
-  fsGroupChangePolicy: "OnRootMismatch"
+  supplementalGroups:
+  - 1000
 
 # Additational pod annotations
 podAnnotations: {}


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

The Helm chart lags on the possibility to configure security context for Pod and Container. Skip the static settings and let the user full control this configuration items.

## Motivation and Context

In the context of Zero Trust and the missing of Pod Security Policy since Kubernetes 1.25 this settings should be applied on a minimum security level as default or should be configurable by the user.

## How to test this PR?

With `helm lint . `as in the CI pipeline.

Or install the Chart in a cluster and verify `securityContext` in the Pod

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
