### PR TITLE
Fix BackendInfo() race

### DIFF
--- a/internal/config/storageclass/storage-class.go
+++ b/internal/config/storageclass/storage-class.go
@@ -228,7 +228,7 @@ func validateParity(ssParity, rrsParity, setDriveCount int) (err error) {
 //
 //	is returned, the caller is expected to choose the right parity
 //	at that point.
-func (sCfg Config) GetParityForSC(sc string) (parity int) {
+func (sCfg *Config) GetParityForSC(sc string) (parity int) {
 	ConfigLock.RLock()
 	defer ConfigLock.RUnlock()
 	switch strings.TrimSpace(sc) {


### PR DESCRIPTION
## Description

`GetParityForSC` has a value receiver, so `globalStorageClass` is copied before the lock is obtained.

Make it pointer receiver.

Fixes:

```
WARNING: DATA RACE
Read at 0x0000079cdd10 by goroutine 190:
  github.com/minio/minio/cmd.(*erasureServerPools).BackendInfo()
      github.com/minio/minio/cmd/erasure-server-pool.go:579 +0x6f
  github.com/minio/minio/cmd.(*erasureServerPools).LocalStorageInfo()
      github.com/minio/minio/cmd/erasure-server-pool.go:614 +0x3c6
  github.com/minio/minio/cmd.(*peerRESTServer).LocalStorageInfoHandler()
      github.com/minio/minio/cmd/peer-rest-server.go:347 +0x4ea
  github.com/minio/minio/cmd.(*peerRESTServer).LocalStorageInfoHandler-fm()
...

WARNING: DATA RACE
Read at 0x0000079cdd10 by goroutine 190:
  github.com/minio/minio/cmd.(*erasureServerPools).BackendInfo()
      github.com/minio/minio/cmd/erasure-server-pool.go:579 +0x6f
  github.com/minio/minio/cmd.(*erasureServerPools).LocalStorageInfo()
      github.com/minio/minio/cmd/erasure-server-pool.go:614 +0x3c6
  github.com/minio/minio/cmd.(*peerRESTServer).LocalStorageInfoHandler()
      github.com/minio/minio/cmd/peer-rest-server.go:347 +0x4ea
  github.com/minio/minio/cmd.(*peerRESTServer).LocalStorageInfoHandler-fm()
```

## How to test this PR?

Run with -race.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
