### PR TITLE
fix: flaky and stupid tests in root lockdown

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -376,7 +376,8 @@ func configRetriableErrors(err error) bool {
 		return false
 	}
 
-	notInitialized := err.Error() == "Server not initialized, please try again"
+	notInitialized := strings.Contains(err.Error(), "Server not initialized, please try again") ||
+		errors.Is(err, errServerNotInitialized)
 
 	// Initializing sub-systems needs a retry mechanism for
 	// the following reasons:


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: flaky and stupid tests in root lockdown

## Motivation and Context
retry "server not initialized" in multiple ways

## How to test this PR?
CI/CD already test this scenario

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
