### PR TITLE
add MC_CONFIG_DIR to use mc from writable path

### DIFF
--- a/Dockerfile.hotfix
+++ b/Dockerfile.hotfix
@@ -17,6 +17,7 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav" \
     MINIO_CONFIG_ENV_FILE=config.env \
+    MC_CONFIG_DIR=/tmp/.mc \
     PATH=/opt/bin:$PATH
 
 COPY dockerscripts/verify-minio.sh /usr/bin/verify-minio.sh

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -19,6 +19,7 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav" \
     MINIO_CONFIG_ENV_FILE=config.env \
+    MC_CONFIG_DIR=/tmp/.mc \
     PATH=/opt/bin:$PATH
 
 COPY dockerscripts/verify-minio.sh /usr/bin/verify-minio.sh

--- a/Dockerfile.release.fips
+++ b/Dockerfile.release.fips
@@ -19,6 +19,7 @@ ENV MINIO_ACCESS_KEY_FILE=access_key \
     MINIO_KMS_SECRET_KEY_FILE=kms_master_key \
     MINIO_UPDATE_MINISIGN_PUBKEY="RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav" \
     MINIO_CONFIG_ENV_FILE=config.env \
+    MC_CONFIG_DIR=/tmp/.mc \
     PATH=/opt/bin:$PATH
 
 COPY dockerscripts/verify-minio.sh /usr/bin/verify-minio.sh


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add MC_CONFIG_DIR to use mc from the writable path

## Motivation and Context
`mc` will currently fail inside MinIO pod without
`--config-dir` option, instead use the ENV to
avoid passing flags.

## How to test this PR?
Run MinIO container and type `mc` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
