### PR TITLE
Added newer noncurrent versions field

### DIFF
--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -39,7 +39,6 @@ const (
 // https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html
 func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "PutBucketLifecycle")
-
 	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
 
 	objAPI := api.ObjectAPI()
@@ -170,7 +169,6 @@ func (api objectAPIHandlers) DeleteBucketLifecycleHandler(w http.ResponseWriter,
 
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]
-
 	if s3Error := checkRequestAuthType(ctx, r, policy.PutBucketLifecycleAction, bucket, ""); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL)
 		return

--- a/internal/bucket/lifecycle/noncurrentversion.go
+++ b/internal/bucket/lifecycle/noncurrentversion.go
@@ -97,9 +97,11 @@ func (n NoncurrentVersionExpiration) Validate() error {
 
 // NoncurrentVersionTransition - an action for lifecycle configuration rule.
 type NoncurrentVersionTransition struct {
-	NoncurrentDays TransitionDays `xml:"NoncurrentDays"`
-	StorageClass   string         `xml:"StorageClass"`
-	set            bool
+	NoncurrentDays          TransitionDays `xml:"NoncurrentDays"`
+	StorageClass            string         `xml:"StorageClass"`
+	NewerNoncurrentVersions int            `xml:"NewerNoncurrentVersions,omitempty" json:"NewerNoncurrentVersions,omitempty"`
+
+	set bool
 }
 
 // MarshalXML is extended to leave out


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Field missing for newer noncurrent version transition

## Motivation and Context
Unable to add meaningful noncurrent version transition ILM rules - no field to hold number of versions after which to transition. See --json output here showing before/after.
<img width="790" alt="Screenshot 2023-10-26 at 2 29 31 PM" src="https://github.com/minio/minio/assets/65002498/8bfe8f44-e4d8-4d06-a2e6-6abca079b68b">


## How to test this PR?
Create a new ILM rule using the --noncurrent-transition-newer flag ex:
`mc ilm rule add --noncurrent-transition-newer 3 --noncurrent-transition-tier TESTA minio/jilltest`

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
