### PR TITLE
fix: relax enforcing filename on PostPolicy

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -983,7 +983,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		}
 
 		var b bytes.Buffer
-		if fileName == "" {
+		if name != "file" {
 			if http.CanonicalHeaderKey(name) == http.CanonicalHeaderKey("x-minio-fanout-list") {
 				dec := json.NewDecoder(part)
 

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -314,6 +314,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 		secretKey          string
 		dates              []interface{}
 		policy             string
+		noFilename         bool
 		corruptedBase64    bool
 		corruptedMultipart bool
 	}{
@@ -326,6 +327,17 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 			secretKey:          credentials.SecretKey,
 			dates:              []interface{}{curTimePlus5Min.Format(iso8601TimeFormat), curTime.Format(iso8601DateFormat), curTime.Format(yyyymmdd)},
 			policy:             `{"expiration": "%s","conditions":[["eq", "$bucket", "` + bucketName + `"], ["starts-with", "$key", "test/"], ["eq", "$x-amz-algorithm", "AWS4-HMAC-SHA256"], ["eq", "$x-amz-date", "%s"], ["eq", "$x-amz-credential", "` + credentials.AccessKey + `/%s/us-east-1/s3/aws4_request"],["eq", "$x-amz-meta-uuid", "1234"]]}`,
+		},
+		// Success case, no multipart filename.
+		{
+			objectName:         "test",
+			data:               []byte("Hello, World"),
+			expectedRespStatus: http.StatusNoContent,
+			accessKey:          credentials.AccessKey,
+			secretKey:          credentials.SecretKey,
+			dates:              []interface{}{curTimePlus5Min.Format(iso8601TimeFormat), curTime.Format(iso8601DateFormat), curTime.Format(yyyymmdd)},
+			policy:             `{"expiration": "%s","conditions":[["eq", "$bucket", "` + bucketName + `"], ["starts-with", "$key", "test/"], ["eq", "$x-amz-algorithm", "AWS4-HMAC-SHA256"], ["eq", "$x-amz-date", "%s"], ["eq", "$x-amz-credential", "` + credentials.AccessKey + `/%s/us-east-1/s3/aws4_request"],["eq", "$x-amz-meta-uuid", "1234"]]}`,
+			noFilename:         true,
 		},
 		// Success case, big body.
 		{
@@ -399,7 +411,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 		testCase.policy = fmt.Sprintf(testCase.policy, testCase.dates...)
 
 		req, perr := newPostRequestV4Generic("", bucketName, testCase.objectName, testCase.data, testCase.accessKey,
-			testCase.secretKey, region, curTime, []byte(testCase.policy), nil, testCase.corruptedBase64, testCase.corruptedMultipart)
+			testCase.secretKey, region, curTime, []byte(testCase.policy), nil, testCase.noFilename, testCase.corruptedBase64, testCase.corruptedMultipart)
 		if perr != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", i+1, instanceType, perr)
 		}
@@ -539,7 +551,7 @@ func testPostPolicyBucketHandlerRedirect(obj ObjectLayer, instanceType string, t
 	// Create a new POST request with success_action_redirect field specified
 	req, perr := newPostRequestV4Generic("", bucketName, keyName, []byte("objData"),
 		credentials.AccessKey, credentials.SecretKey, region, curTime,
-		[]byte(policy), map[string]string{"success_action_redirect": redirectURL.String()}, false, false)
+		[]byte(policy), map[string]string{"success_action_redirect": redirectURL.String()}, false, false, false)
 
 	if perr != nil {
 		t.Fatalf("%s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", instanceType, perr)
@@ -647,7 +659,7 @@ func buildGenericPolicy(t time.Time, accessKey, region, bucketName, objectName s
 }
 
 func newPostRequestV4Generic(endPoint, bucketName, objectName string, objData []byte, accessKey, secretKey string, region string,
-	t time.Time, policy []byte, addFormData map[string]string, corruptedB64 bool, corruptedMultipart bool,
+	t time.Time, policy []byte, addFormData map[string]string, noFilename bool, corruptedB64 bool, corruptedMultipart bool,
 ) (*http.Request, error) {
 	// Get the user credential.
 	credStr := getCredentialString(accessKey, region, t)
@@ -662,9 +674,17 @@ func newPostRequestV4Generic(endPoint, bucketName, objectName string, objData []
 	// Presign with V4 signature based on the policy.
 	signature := postPresignSignatureV4(encodedPolicy, t, secretKey, region)
 
+	// If there is no filename on multipart, get the filename from the key.
+	key := objectName
+	if noFilename {
+		key += "/upload.txt"
+	} else {
+		key += "/${filename}"
+	}
+
 	formData := map[string]string{
 		"bucket":           bucketName,
-		"key":              objectName + "/${filename}",
+		"key":              key,
 		"x-amz-credential": credStr,
 		"policy":           encodedPolicy,
 		"x-amz-signature":  signature,
@@ -689,7 +709,13 @@ func newPostRequestV4Generic(endPoint, bucketName, objectName string, objData []
 	}
 	// Set the File formData but don't if we want send an incomplete multipart request
 	if !corruptedMultipart {
-		writer, err := w.CreateFormFile("file", "upload.txt")
+		var writer io.Writer
+		var err error
+		if noFilename {
+			writer, err = w.CreateFormField("file")
+		} else {
+			writer, err = w.CreateFormFile("file", "upload.txt")
+		}
 		if err != nil {
 			// return nil, err
 			return nil, err
@@ -716,12 +742,12 @@ func newPostRequestV4WithContentLength(endPoint, bucketName, objectName string, 
 	t := UTCNow()
 	region := "us-east-1"
 	policy := buildGenericPolicy(t, accessKey, region, bucketName, objectName, true)
-	return newPostRequestV4Generic(endPoint, bucketName, objectName, objData, accessKey, secretKey, region, t, policy, nil, false, false)
+	return newPostRequestV4Generic(endPoint, bucketName, objectName, objData, accessKey, secretKey, region, t, policy, nil, false, false, false)
 }
 
 func newPostRequestV4(endPoint, bucketName, objectName string, objData []byte, accessKey, secretKey string) (*http.Request, error) {
 	t := UTCNow()
 	region := "us-east-1"
 	policy := buildGenericPolicy(t, accessKey, region, bucketName, objectName, false)
-	return newPostRequestV4Generic(endPoint, bucketName, objectName, objData, accessKey, secretKey, region, t, policy, nil, false, false)
+	return newPostRequestV4Generic(endPoint, bucketName, objectName, objData, accessKey, secretKey, region, t, policy, nil, false, false, false)
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The filename on the `file` field isn't required, but it's being used as reference for checking if we have reached the `file` field on the multipart fields loop. Check the current field using it's name instead.

## Motivation and Context
If the filename isn't set, the `fileName == ""` check is always true and the file reader never gets assigned, which causes a nullptr dereference when calling `PutObject` on `PostPolicyBucketHandler`. This fully fixes issue #18235

## How to test this PR?
```go
package main

import (
	"bytes"
	"context"
	"fmt"
	"log"
	"mime/multipart"
	"net/http"
	"time"

	"github.com/minio/minio-go/v7"
	"github.com/minio/minio-go/v7/pkg/credentials"
)

func main() {
	endpoint := "example.com"
	accessKeyID := "ACCESS_KEY"
	secretAccessKey := "ACCESS_SECRET"
	useSSL := true

	// Initialize minio client object.
	minioClient, err := minio.New(endpoint, &minio.Options{
		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
		Secure: useSSL,
	})
	if err != nil {
		log.Fatalln(err)
	}

	// Initialize policy condition config.
	policy := minio.NewPostPolicy()

	// Apply upload policy restrictions:
	policy.SetBucket("bucket")
	policy.SetKey("data/somedata")
	policy.SetExpires(time.Now().UTC().AddDate(0, 0, 10))

	// Get the POST form key/value object:
	url, formData, err := minioClient.PresignedPostPolicy(context.Background(), policy)
	if err != nil {
		fmt.Println(err)
		return
	}

	body := &bytes.Buffer{}
	writer := multipart.NewWriter(body)

	for fieldName, fieldValue := range formData {
		part, _ := writer.CreateFormField(fieldName)
		part.Write([]byte(fieldValue))
	}

	// Set the file field using CreateFormField to skip filename assignment
	part, _ := writer.CreateFormField("file")
	part.Write([]byte{30}) // "0"

	writer.Close()

	r, _ := http.NewRequest("POST", url.String(), body)
	r.Header.Add("Content-Type", writer.FormDataContentType())
	client := &http.Client{}
	client.Do(r)
}
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
