### PR TITLE
Re-add duplicate upload id sanity check.

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -323,7 +323,7 @@ func (er erasureObjects) ListMultipartUploads(ctx context.Context, bucket, objec
 			UploadID:  base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%s.%s", globalDeploymentID(), uploadID))),
 			Initiated: startTime,
 		})
-
+		populatedUploadIds.Add(uploadID)
 	}
 
 	sort.Slice(uploads, func(i int, j int) bool {


### PR DESCRIPTION
## Description

https://github.com/minio/minio/pull/18307 partially removed the duplicate upload id check.

While I can't really see how ListDir can return duplicate entries, let's re-add it, since it is a cheap sanity check.


## How to test this PR?

Not sure if it is even triggerable. Just sanity.

## Types of changes
- [x] Add Sanity check