### PR TITLE
grid: Remove allocs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-openapi/loads v0.21.2
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/gobwas/ws v1.2.1
+	github.com/gobwas/ws v1.3.1-0.20231030152437-516805a9f3b3
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gomodule/redigo v1.8.9
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
-github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
-github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/gobwas/ws v1.3.1-0.20231030152437-516805a9f3b3 h1:u5on5kZjHKikhx6d2IAGOxFf4BAcJhUb2v8VJFHBgFA=
+github.com/gobwas/ws v1.3.1-0.20231030152437-516805a9f3b3/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/internal/grid/grid_test.go
+++ b/internal/grid/grid_test.go
@@ -160,11 +160,7 @@ func TestSingleRoundtripGenerics(t *testing.T) {
 		return resp, nil
 	}
 	// Return error
-	h2 := NewSingleHandler[*testRequest, *testResponse](handlerTest2, func() *testRequest {
-		return &testRequest{}
-	}, func() *testResponse {
-		return &testResponse{}
-	})
+	h2 := NewSingleHandler[*testRequest, *testResponse](handlerTest2, newTestRequest, newTestResponse)
 	handler2 := func(req *testRequest) (resp *testResponse, err *RemoteErr) {
 		r := RemoteErr(req.String)
 		return nil, &r
@@ -682,13 +678,7 @@ func testGenericsStreamRoundtrip(t *testing.T, local, remote *Manager) {
 
 	// We fake a local and remote server.
 	remoteHost := remote.HostName()
-	handler := NewStream[*testRequest, *testRequest, *testResponse](handlerTest, func() *testRequest {
-		return &testRequest{}
-	}, func() *testRequest {
-		return &testRequest{}
-	}, func() *testResponse {
-		return &testResponse{}
-	})
+	handler := NewStream[*testRequest, *testRequest, *testResponse](handlerTest, newTestRequest, newTestRequest, newTestResponse)
 	handler.InCapacity = 1
 	handler.OutCapacity = 1
 	const payloads = 10
@@ -759,13 +749,7 @@ func testGenericsStreamRoundtripSubroute(t *testing.T, local, remote *Manager) {
 
 	// We fake a local and remote server.
 	remoteHost := remote.HostName()
-	handler := NewStream[*testRequest, *testRequest, *testResponse](handlerTest, func() *testRequest {
-		return &testRequest{}
-	}, func() *testRequest {
-		return &testRequest{}
-	}, func() *testResponse {
-		return &testResponse{}
-	})
+	handler := NewStream[*testRequest, *testRequest, *testResponse](handlerTest, newTestRequest, newTestRequest, newTestResponse)
 	handler.InCapacity = 1
 	handler.OutCapacity = 1
 	const payloads = 10

--- a/internal/grid/grid_types_test.go
+++ b/internal/grid/grid_types_test.go
@@ -29,3 +29,11 @@ type testResponse struct {
 	OrgString string
 	Embedded  testRequest
 }
+
+func newTestRequest() *testRequest {
+	return &testRequest{}
+}
+
+func newTestResponse() *testResponse {
+	return &testResponse{}
+}

--- a/internal/grid/handlers.go
+++ b/internal/grid/handlers.go
@@ -147,6 +147,7 @@ type (
 	// A non-nil error value will be returned as RemoteErr(msg) to client.
 	// No client information or cancellation (deadline) is available.
 	// Include this in payload if needed.
+	// Payload should be recycled with PutByteBuffer if not needed after the call.
 	SingleHandlerFn func(payload []byte) ([]byte, *RemoteErr)
 
 	// StatelessHandlerFn must handle incoming stateless request.

--- a/internal/grid/muxclient.go
+++ b/internal/grid/muxclient.go
@@ -35,7 +35,6 @@ type muxClient struct {
 	MuxID            uint64
 	SendSeq, RecvSeq uint32
 	LastPong         int64
-	Resp             chan []byte
 	BaseFlags        Flags
 	ctx              context.Context
 	cancelFn         context.CancelCauseFunc
@@ -62,7 +61,6 @@ func newMuxClient(ctx context.Context, muxID uint64, parent *Connection) *muxCli
 	ctx, cancelFn := context.WithCancelCause(ctx)
 	return &muxClient{
 		MuxID:     muxID,
-		Resp:      make(chan []byte, 1),
 		ctx:       ctx,
 		cancelFn:  cancelFn,
 		parent:    parent,


### PR DESCRIPTION
## Description
(against next)

Removes some minor allocations and cleans up benchmarks as well as adds typed roundtrip benchmarks.

Websocket library updated to include https://github.com/gobwas/ws/pull/189

## How to test this PR?

Run included benchmark

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
