### PR TITLE
FIX: Use STS env variable to increase the IDP token expiration

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -83,3 +83,11 @@ const (
 	EnvRegion     = "MINIO_REGION"      // legacy
 	EnvRegionName = "MINIO_REGION_NAME" // legacy
 )
+
+// Expiration Token durations
+// These values are used to validate the expiration time range from
+// either the exp claim or MINI_STS_DURATION value
+const (
+	MinExpiration = 900
+	MaxExpiration = 31536000
+)

--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -114,8 +114,7 @@ func updateClaimsExpiry(dsecs string, claims map[string]interface{}) error {
 		return nil
 	}
 
-	expAt, err := auth.ExpToInt64(expStr)
-	if err != nil {
+	if _, err := auth.ExpToInt64(expStr); err != nil {
 		return err
 	}
 
@@ -123,13 +122,6 @@ func updateClaimsExpiry(dsecs string, claims map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	// Verify if JWT expiry is lesser than default expiry duration,
-	// if that is the case then set the default expiration to be
-	// from the JWT expiry claim.
-	if time.Unix(expAt, 0).UTC().Sub(time.Now().UTC()) < defaultExpiryDuration {
-		defaultExpiryDuration = time.Unix(expAt, 0).UTC().Sub(time.Now().UTC())
-	} // else honor the specified expiry duration.
 
 	claims["exp"] = time.Now().UTC().Add(defaultExpiryDuration).Unix() // update with new expiry.
 	return nil


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This is a follow up of the related PR https://github.com/minio/minio/pull/18297#event-10810942753

## Motivation and Context
Currently when you create a share link, the expiration of that link is tied to the expiration of the token without any way to increase it, unless the expiration is extended on the IDP itself.

This adds the ability to declare an env variable ( MINIO_STS_DURATION ) to increase the lifespan of the IDP Token by overriding the expiration claim if the environment variable is set, otherwise it will use the expiration from the expiration claim.

## How to test this PR?
Setup the IDP configuration and declare the env variable:
MINIO_STS_DURATION=2h

Note: Tested with latest version of Keycloak 

Remove the environment variable to use the IDP expiration instead.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
