### PR TITLE
site replication: avoid propagating bucket b/w settings

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3787,14 +3787,6 @@ func (c *SiteReplicationSys) PeerEditReq(ctx context.Context, arg madmin.PeerInf
 		p := c.state.Peers[i]
 		if p.DeploymentID == arg.DeploymentID {
 			p.Endpoint = arg.Endpoint
-			if arg.DefaultBandwidth.IsSet {
-				if arg.DefaultBandwidth.UpdatedAt.After(p.DefaultBandwidth.UpdatedAt) {
-					p.DefaultBandwidth = arg.DefaultBandwidth
-				}
-			}
-			if !arg.SyncState.Empty() {
-				p.SyncState = arg.SyncState
-			}
 			c.state.Peers[arg.DeploymentID] = p
 		}
 		if p.DeploymentID == globalDeploymentID() {


### PR DESCRIPTION
replication mode and bucket bandwidth are one-way and should not be propagated to peer cluster.

Regression from #18062

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
Flexibility - replication mode and bucket bandwidth are defaults applicable to a replication target of a site, they don't have to be symmetric on all peer clusters.

## How to test this PR?
`mc admin replicate add sitea siteb sitec`
`mc admin replicate update --deployment-id <B's depl id> --bucket-bandwidth 4G  siteA`
^^ should set bucket bandwidth of 4G for replication from A -> B and accordingly should be seen on `mc admin replicate info sitea` . However `mc admin replicate info siteb` should not show a b/w restriction for site A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
