### PR TITLE
Fix leaking offline disks

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -217,6 +217,10 @@ func (s *erasureSets) connectDisks() {
 				continue
 			}
 		}
+		if cdisk != nil {
+			// Close previous offline disk.
+			cdisk.Close()
+		}
 
 		wg.Add(1)
 		go func(endpoint Endpoint) {


### PR DESCRIPTION
## Description

`monitorAndConnectEndpoints` will continue to attempt to reconnect offline disks.

Since disks were never closed, a `MarkOffline` would continue to try to check these disks forever.

Close previous disks.


## How to test this PR?

Have disk(s) offline. Observe growth in `github.com/minio/minio/internal/rest.(*Client).MarkOffline.func1` goroutines.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
