### PR TITLE
fix: add enpoint to peer client offline

### DIFF
--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -58,7 +58,7 @@ func (client *peerRESTClient) call(method string, values url.Values, body io.Rea
 // after verifying format.json
 func (client *peerRESTClient) callWithContext(ctx context.Context, method string, values url.Values, body io.Reader, length int64) (respBody io.ReadCloser, err error) {
 	if client == nil || !client.IsOnline() {
-		return nil, errPeerNotReachable
+		return nil, fmt.Errorf("%w - %s", errPeerNotReachable, client)
 	}
 
 	if values == nil {

--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -58,7 +58,7 @@ func (client *peerRESTClient) call(method string, values url.Values, body io.Rea
 // after verifying format.json
 func (client *peerRESTClient) callWithContext(ctx context.Context, method string, values url.Values, body io.Reader, length int64) (respBody io.ReadCloser, err error) {
 	if client == nil || !client.IsOnline() {
-		return nil, fmt.Errorf("%w - %s", errPeerNotReachable, client)
+		return nil, fmt.Errorf("%s - %w", client, errPeerNotReachable)
 	}
 
 	if values == nil {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context

Mesh netperf will get `peer is not reachable`. Add endpoint to it.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
