### PR TITLE
Fixing a file consistency issue on SFTP upload

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -201,11 +201,15 @@ func (f *sftpDriver) Fileread(r *sftp.Request) (ra io.ReaderAt, err error) {
 	return obj, nil
 }
 
-func (w *writerAt) Close() error {
+func (w *writerAt) Close() (err error) {
+	if w.remaining > 0 {
+		err = w.w.CloseWithError(errors.New("some file segments were not flushed from the queue"))
+	} else {
+		err = w.w.Close()
+	}
 	for i := range w.buffers {
 		w.buffers[i] = nil
 	}
-	err := w.w.Close()
 	w.wg.Wait()
 	return err
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Our community raised an [issue with SFTP](https://github.com/minio/minio/issues/18415) where files would randomly get corrupted on upload. The issue is that SFTP demands underlying implementations to offer multiplex support for file segments, while our SFTP to S3 interface was assuming writes would be in sync. 

## Resolution
In order to ensure file consistency, a file segment queue was created which ensures that our S3 store receives all file segments in order. 

## NOTES
The current queue size is set to 1000 segments, if filled the writer returns an error "sftp segment queue is full".
During testing using local interfaces I would regularly run into a queue size of 1-10, so it is probably safe to assume that under certain circumstances the queue size can grow quite a bit bigger than 10. 

## How to test this PR?
The SFTP module relies on manual testing. I recommend uploading 1GB+ files.

1. Create a 1GB file
2. Get the md5 sum of the file
3. Upload the file and download it again
4. compare the md5sums of the downloaded file and the original


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
