### PR TITLE
fix:hang sftp when put

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -207,6 +207,9 @@ func (w *writerAt) Close() (err error) {
 		for i := range w.buffer {
 			delete(w.buffer, i)
 		}
+	}
+	if err != nil {
+		w.w.Close()
 	} else {
 		err = w.w.Close()
 	}

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -209,7 +209,7 @@ func (w *writerAt) Close() (err error) {
 		}
 	}
 	if err != nil {
-		w.w.Close()
+		w.w.CloseWithError(err)
 	} else {
 		err = w.w.Close()
 	}


### PR DESCRIPTION
fix:hang upload call when  sftp put

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

`w.w.Close()` is a sign to end the PutObject call. 
```go
	go func() {
		_, err := clnt.PutObject(r.Context(), bucket, object, pr, -1, minio.PutObjectOptions{SendContentMd5: true})
		pr.CloseWithError(err)
		wa.wg.Done()
	}()
```
 Canceling the upload triggers Close.
## Motivation and Context

 It's just a matter of canceling the upload at the same time as the disorganization occurs.
 Canceling the upload triggers Close.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
