### PR TITLE
fix: relax free inode check for single drive deployments

### DIFF
--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1198,7 +1198,7 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 		if disk == nil || disk.Total == 0 {
 			continue
 		}
-		if disk.FreeInodes < diskMinInodes && disk.UsedInodes > 0 {
+		if !globalIsErasureSD && disk.FreeInodes < diskMinInodes && disk.UsedInodes > 0 {
 			// We have an inode count, but not enough inodes.
 			return false, nil
 		}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: relax free inode check for single drive deployments

## Motivation and Context
users might use MinIO on NFS (some implementations), GPFS 
provide dynamic inodes and may not even have a concept of 
free inodes.

to allow users to use MinIO on top of GPFS to relax the 
free inode check.

fixes #18405

## How to test this PR?
GPFS does not have a concept of free inodes, relax the check.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
