### PR TITLE
Adding a missing return to fix SFTP Rmdir message

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -340,6 +340,7 @@ func (f *sftpDriver) Filecmd(r *sftp.Request) (err error) {
 				return err.Err
 			}
 		}
+		return err
 
 	case "Remove":
 		bucket, object := path2BucketObject(r.Filepath)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This is a fix for https://github.com/minio/minio/issues/18434 
There was a simple return missing.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
