### PR TITLE
fix: Set the metric first and then wait for dynamicSleeper Timer/Sleep

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1368,10 +1368,10 @@ func (d *dynamicSleeper) Timer(ctx context.Context) func() {
 			select {
 			case <-ctx.Done():
 				if !timer.Stop() {
+					if d.isScanner {
+						globalScannerMetrics.incTime(scannerMetricYield, wantSleep)
+					}
 					<-timer.C
-				}
-				if d.isScanner {
-					globalScannerMetrics.incTime(scannerMetricYield, wantSleep)
 				}
 				return
 			case <-timer.C:
@@ -1382,10 +1382,10 @@ func (d *dynamicSleeper) Timer(ctx context.Context) func() {
 			case <-cycle:
 				if !timer.Stop() {
 					// We expired.
-					<-timer.C
 					if d.isScanner {
 						globalScannerMetrics.incTime(scannerMetricYield, wantSleep)
 					}
+					<-timer.C
 					return
 				}
 			}
@@ -1415,10 +1415,10 @@ func (d *dynamicSleeper) Sleep(ctx context.Context, base time.Duration) {
 		select {
 		case <-ctx.Done():
 			if !timer.Stop() {
-				<-timer.C
 				if d.isScanner {
 					globalScannerMetrics.incTime(scannerMetricYield, wantSleep)
 				}
+				<-timer.C
 			}
 			return
 		case <-timer.C:
@@ -1429,10 +1429,10 @@ func (d *dynamicSleeper) Sleep(ctx context.Context, base time.Duration) {
 		case <-cycle:
 			if !timer.Stop() {
 				// We expired.
-				<-timer.C
 				if d.isScanner {
 					globalScannerMetrics.incTime(scannerMetricYield, wantSleep)
 				}
+				<-timer.C
 				return
 			}
 		}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Set the metric first and then wait.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
