### PR TITLE
Adding error handling for network errors in the SFTP layer

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -206,19 +206,24 @@ func (f *sftpDriver) Fileread(r *sftp.Request) (ra io.ReaderAt, err error) {
 // be called, so we do not need to Wait() here.
 func (w *writerAt) TransferError(err error) {
 	_ = w.w.CloseWithError(err)
-	for i := range w.buffer {
-		delete(w.buffer, i)
-	}
+	_ = w.r.CloseWithError(err)
+	w.err = err
 }
 
 func (w *writerAt) Close() (err error) {
-	if len(w.buffer) > 0 {
-		err = w.w.CloseWithError(errors.New("some file segments were not flushed from the queue"))
-		for i := range w.buffer {
-			delete(w.buffer, i)
-		}
-	} else {
+	switch {
+	case len(w.buffer) > 0:
+		err = errors.New("some file segments were not flushed from the queue")
+		_ = w.w.CloseWithError(err)
+	case w.err != nil:
+		// No need to close here since both pipes were
+		// closing inside TransferError()
+		err = w.err
+	default:
 		err = w.w.Close()
+	}
+	for i := range w.buffer {
+		delete(w.buffer, i)
 	}
 	w.wg.Wait()
 	return err
@@ -226,8 +231,10 @@ func (w *writerAt) Close() (err error) {
 
 type writerAt struct {
 	w      *io.PipeWriter
+	r      *io.PipeReader
 	wg     *sync.WaitGroup
 	buffer map[int64][]byte
+	err    error
 
 	nextOffset int64
 	m          sync.Mutex
@@ -289,6 +296,7 @@ func (f *sftpDriver) Filewrite(r *sftp.Request) (w io.WriterAt, err error) {
 	wa := &writerAt{
 		buffer: make(map[int64][]byte),
 		w:      pw,
+		r:      pr,
 		wg:     &sync.WaitGroup{},
 	}
 	wa.wg.Add(1)

--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -201,6 +201,16 @@ func (f *sftpDriver) Fileread(r *sftp.Request) (ra io.ReaderAt, err error) {
 	return obj, nil
 }
 
+// TransferError will catch network errors during transfer.
+// When TransferError() is called Close() will also
+// be called, so we do not need to Wait() here.
+func (w *writerAt) TransferError(err error) {
+	_ = w.w.CloseWithError(err)
+	for i := range w.buffer {
+		delete(w.buffer, i)
+	}
+}
+
 func (w *writerAt) Close() (err error) {
 	if len(w.buffer) > 0 {
 		err = w.w.CloseWithError(errors.New("some file segments were not flushed from the queue"))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Implementing the elusive TransferError interface. This interface will report network errors during transfer. I also confirmed that if these errors occur the file data will not be written to minio.

![image](https://github.com/minio/minio/assets/20964930/b37aa8b5-2916-40a9-9fe6-c6b14fd1fd57)

## Note
Originally we wanted to find a way to catch a ctrl+C signal from the SFTP client in order to stop the SFTP server implementation from uploading incomplete files. However, SFTP clients do not differentiate between ctrl+C and a complete file transfer. Both results send the same signal to the server.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
