### PR TITLE
audit: Try to send audit even if the status is offline

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -379,10 +379,6 @@ func (h *Target) SendFromStore(key store.Key) (err error) {
 // Messages are queued in the disk if the store is enabled
 // If Cancel has been called the message is ignored.
 func (h *Target) Send(ctx context.Context, entry interface{}) error {
-	if atomic.LoadInt32(&h.status) == statusOffline {
-		h.config.LogOnce(ctx, fmt.Errorf("target %s is offline", h.Endpoint()), h.Endpoint())
-		return nil
-	}
 	if atomic.LoadInt32(&h.status) == statusClosed {
 		return nil
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Currently, once the audit becomes offline, there is no code that tries to reconnect to the audit, at the same time Send() quickly returns with an error without really trying to send a message the audit endpoint; so the audit endpoint will never be online again.

Fixing this behavir; the current downside is that we miss printing some logs when the audit becomes offline; however this information is available in prometheus

Later, we can refactor internal/logger so the http endpoint can send errors to console target.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
