### PR TITLE
fix: close the http.Body when WebhookTarget isActive

### DIFF
--- a/internal/config/lambda/target/webhook.go
+++ b/internal/config/lambda/target/webhook.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	xhttp "github.com/minio/minio/internal/http"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -30,7 +31,6 @@ import (
 	"time"
 
 	"github.com/minio/minio/internal/config/lambda/event"
-	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/v2/certs"
 	xnet "github.com/minio/pkg/v2/net"
@@ -133,7 +133,7 @@ func (target *WebhookTarget) isActive() (bool, error) {
 		}
 		return false, err
 	}
-	xioutil.DiscardReader(resp.Body)
+	xhttp.DrainBody(resp.Body)
 	// No network failure i.e response from the target means its up
 	return true, nil
 }

--- a/internal/config/lambda/target/webhook.go
+++ b/internal/config/lambda/target/webhook.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
-	xhttp "github.com/minio/minio/internal/http"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -31,6 +30,7 @@ import (
 	"time"
 
 	"github.com/minio/minio/internal/config/lambda/event"
+	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/v2/certs"
 	xnet "github.com/minio/pkg/v2/net"


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: close the http.Body when WebhookTarget isActive

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
