### PR TITLE
Add codespell config and github action + use codespell to fix typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,*.pdf,*.svg,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,6 +3,6 @@
 # bother coming up with a regex for such lines
 skip = .git,*.pdf,*.svg,.codespellrc,CREDITS,certs_test.go
 check-hidden = true
-ignore-regex = \bnewfolder/afile\b
+ignore-regex = \b(newfolder/afile|filterIn)\b
 # some custom short variables used often etc
 ignore-words-list = inout,bui,to,bu,te,ot,toi,ist,helpes,parms,flate

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,6 @@
 [codespell]
 skip = .git,*.pdf,*.svg,.codespellrc
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+ignore-regex = \bnewfolder/afile\b
+# some custom short variables used often etc
+ignore-words-list = inout,bui,to,bu,te,ot

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,8 @@
 [codespell]
-skip = .git,*.pdf,*.svg,.codespellrc
+# certs_test.go - has lots of ceritificates and I did not
+# bother coming up with a regex for such lines
+skip = .git,*.pdf,*.svg,.codespellrc,CREDITS,certs_test.go
 check-hidden = true
 ignore-regex = \bnewfolder/afile\b
 # some custom short variables used often etc
-ignore-words-list = inout,bui,to,bu,te,ot
+ignore-words-list = inout,bui,to,bu,te,ot,toi,ist,helpes,parms,flate

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -3028,7 +3028,7 @@ func createHostAnonymizerForFSMode() map[string]string {
 // anonymizeHost - Add entries related to given endpoint in the host anonymizer map
 // The health report data can contain the hostname in various forms e.g. host, host:port,
 // host:port/drivepath, full url (http://host:port/drivepath)
-// The anonymizer map will have mappings for all these varients for efficiently replacing
+// The anonymizer map will have mappings for all these variants for efficiently replacing
 // any of these strings to the anonymized versions at the time of health report generation.
 func anonymizeHost(hostAnonymizer map[string]string, endpoint Endpoint, poolNum int, srvrNum int) {
 	if len(endpoint.Host) == 0 {
@@ -3076,7 +3076,7 @@ func anonymizeHost(hostAnonymizer map[string]string, endpoint Endpoint, poolNum 
 	}
 }
 
-// createHostAnonymizer - Creats a map of various strings to corresponding anonymized names
+// createHostAnonymizer - Creates a map of various strings to corresponding anonymized names
 func createHostAnonymizer() map[string]string {
 	if !globalIsDistErasure {
 		return createHostAnonymizerForFSMode()

--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -956,7 +956,7 @@ var errorCodes = errorCodeMap{
 	},
 	ErrReplicationBandwidthLimitError: {
 		Code:           "XMinioAdminReplicationBandwidthLimitError",
-		Description:    "Bandwidth limit for remote target must be atleast 100MBps",
+		Description:    "Bandwidth limit for remote target must be at least 100MBps",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrReplicationNoExistingObjects: {

--- a/cmd/auth-handler_test.go
+++ b/cmd/auth-handler_test.go
@@ -287,7 +287,7 @@ func mustNewSignedRequest(method string, urlStr string, contentLength int64, bod
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
 	cred := globalActiveCred
 	if err := signRequestV4(req, cred.AccessKey, cred.SecretKey); err != nil {
-		t.Fatalf("Unable to inititalized new signed http request %s", err)
+		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}
 	return req
 }
@@ -298,7 +298,7 @@ func mustNewSignedV2Request(method string, urlStr string, contentLength int64, b
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
 	cred := globalActiveCred
 	if err := signRequestV2(req, cred.AccessKey, cred.SecretKey); err != nil {
-		t.Fatalf("Unable to inititalized new signed http request %s", err)
+		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}
 	return req
 }
@@ -309,7 +309,7 @@ func mustNewPresignedV2Request(method string, urlStr string, contentLength int64
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
 	cred := globalActiveCred
 	if err := preSignV2(req, cred.AccessKey, cred.SecretKey, time.Now().Add(10*time.Minute).Unix()); err != nil {
-		t.Fatalf("Unable to inititalized new signed http request %s", err)
+		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}
 	return req
 }
@@ -320,7 +320,7 @@ func mustNewPresignedRequest(method string, urlStr string, contentLength int64, 
 	req := mustNewRequest(method, urlStr, contentLength, body, t)
 	cred := globalActiveCred
 	if err := preSignV4(req, cred.AccessKey, cred.SecretKey, time.Now().Add(10*time.Minute).Unix()); err != nil {
-		t.Fatalf("Unable to inititalized new signed http request %s", err)
+		t.Fatalf("Unable to initialized new signed http request %s", err)
 	}
 	return req
 }
@@ -491,7 +491,7 @@ func TestValidateAdminSignature(t *testing.T) {
 	for i, testCase := range testCases {
 		req := mustNewRequest(http.MethodGet, "http://localhost:9000/", 0, nil, t)
 		if err := signRequestV4(req, testCase.AccessKey, testCase.SecretKey); err != nil {
-			t.Fatalf("Unable to inititalized new signed http request %s", err)
+			t.Fatalf("Unable to initialized new signed http request %s", err)
 		}
 		_, _, s3Error := validateAdminSignature(ctx, req, globalMinioDefaultRegion)
 		if s3Error != testCase.ErrCode {

--- a/cmd/bitrot-streaming.go
+++ b/cmd/bitrot-streaming.go
@@ -134,7 +134,7 @@ func (b *streamingBitrotReader) Close() error {
 		return nil
 	}
 	if closer, ok := b.rc.(io.Closer); ok {
-		// drain the body for connection re-use at network layer.
+		// drain the body for connection reuse at network layer.
 		xhttp.DrainBody(struct {
 			io.Reader
 			io.Closer

--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -242,7 +242,7 @@ func verifyServerSystemConfig(ctx context.Context, endpointServerPools EndpointS
 			retries++
 			// after 20 retries start logging that servers are not reachable yet
 			if retries >= 20 {
-				logger.Info(fmt.Sprintf("Waiting for atleast %d remote servers with valid configuration to be online", len(clnts)/2))
+				logger.Info(fmt.Sprintf("Waiting for at least %d remote servers with valid configuration to be online", len(clnts)/2))
 				if len(offlineEndpoints) > 0 {
 					logger.Info(fmt.Sprintf("Following servers are currently offline or unreachable %s", offlineEndpoints))
 				}

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -423,7 +423,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		return
 	}
 
-	// Content-Md5 is requied should be set
+	// Content-Md5 is required should be set
 	// http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html
 	if _, ok := r.Header[xhttp.ContentMD5]; !ok {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMissingContentMD5), r.URL)

--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -252,7 +252,7 @@ func testHeadBucketHandler(obj ObjectLayer, instanceType, bucketName string, api
 		},
 		// Test case - 3.
 		// Testing for signature mismatch error.
-		// setting invalid acess and secret key.
+		// setting invalid access and secret key.
 		{
 			bucketName:         bucketName,
 			accessKey:          "abcd",
@@ -415,7 +415,7 @@ func testListMultipartUploadsHandler(obj ObjectLayer, instanceType, bucketName s
 			shouldPass:         false,
 		},
 		// Test case - 6.
-		// Setting a negative value to max-uploads paramater, should result in http.StatusBadRequest.
+		// Setting a negative value to max-uploads parameter, should result in http.StatusBadRequest.
 		{
 			bucket:             bucketName,
 			prefix:             "",

--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -111,7 +111,7 @@ func (api objectAPIHandlers) listObjectVersionsHandler(w http.ResponseWriter, r 
 
 	listObjectVersions := objectAPI.ListObjectVersions
 
-	// Inititate a list object versions operation based on the input params.
+	// Initiate a list object versions operation based on the input params.
 	// On success would return back ListObjectsInfo object to be
 	// marshaled into S3 compatible XML header.
 	listObjectVersionsInfo, err := listObjectVersions(ctx, bucket, prefix, marker, versionIDMarker, delimiter, maxkeys)
@@ -201,10 +201,10 @@ func (api objectAPIHandlers) listObjectsV2Handler(ctx context.Context, w http.Re
 	)
 
 	if r.Header.Get(xMinIOExtract) == "true" && strings.Contains(prefix, archivePattern) {
-		// Inititate a list objects operation inside a zip file based in the input params
+		// Initiate a list objects operation inside a zip file based in the input params
 		listObjectsV2Info, err = listObjectsV2InArchive(ctx, objectAPI, bucket, prefix, token, delimiter, maxKeys, fetchOwner, startAfter)
 	} else {
-		// Inititate a list objects operation based on the input params.
+		// Initiate a list objects operation based on the input params.
 		// On success would return back ListObjectsInfo object to be
 		// marshaled into S3 compatible XML header.
 		listObjectsV2Info, err = objectAPI.ListObjectsV2(ctx, bucket, prefix, token, delimiter, maxKeys, fetchOwner, startAfter)
@@ -304,7 +304,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 
 	listObjects := objectAPI.ListObjects
 
-	// Inititate a list objects operation based on the input params.
+	// Initiate a list objects operation based on the input params.
 	// On success would return back ListObjectsInfo object to be
 	// marshaled into S3 compatible XML header.
 	listObjectsInfo, err := listObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)

--- a/cmd/bucket-policy-handlers_test.go
+++ b/cmd/bucket-policy-handlers_test.go
@@ -317,7 +317,7 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		if err != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PutBucketPolicyHandler: <ERROR> %v", i+1, instanceType, err)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(recV4, reqV4)
 		if recV4.Code != testCase.expectedRespStatus {
@@ -331,7 +331,7 @@ func testPutBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		if err != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PutBucketPolicyHandler: <ERROR> %v", i+1, instanceType, err)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(recV2, reqV2)
 		if recV2.Code != testCase.expectedRespStatus {
@@ -407,7 +407,7 @@ func testGetBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create HTTP request for PutBucketPolicyHandler: <ERROR> %v", i+1, err)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(recV4, reqV4)
 		if recV4.Code != testPolicy.expectedRespStatus {
@@ -421,7 +421,7 @@ func testGetBucketPolicyHandler(obj ObjectLayer, instanceType, bucketName string
 		if err != nil {
 			t.Fatalf("Test %d: Failed to create HTTP request for PutBucketPolicyHandler: <ERROR> %v", i+1, err)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(recV2, reqV2)
 		if recV2.Code != testPolicy.expectedRespStatus {

--- a/cmd/bucket-replication-utils.go
+++ b/cmd/bucket-replication-utils.go
@@ -219,7 +219,7 @@ type ReplicateDecision struct {
 	targetsMap map[string]replicateTargetDecision
 }
 
-// ReplicateAny returns true if atleast one target qualifies for replication
+// ReplicateAny returns true if at least one target qualifies for replication
 func (d ReplicateDecision) ReplicateAny() bool {
 	for _, t := range d.targetsMap {
 		if t.Replicate {
@@ -229,7 +229,7 @@ func (d ReplicateDecision) ReplicateAny() bool {
 	return false
 }
 
-// Synchronous returns true if atleast one target qualifies for synchronous replication
+// Synchronous returns true if at least one target qualifies for synchronous replication
 func (d ReplicateDecision) Synchronous() bool {
 	for _, t := range d.targetsMap {
 		if t.Synchronous {
@@ -336,7 +336,7 @@ type ReplicationState struct {
 	DeleteMarker              bool                   // represents DeleteMarker replication state
 	ReplicationTimeStamp      time.Time              // timestamp when last replication activity happened
 	ReplicationStatusInternal string                 // stringified representation of all replication activity
-	// VersionPurgeStatusInternal is internally in the format "arn1=PENDING;arn2=COMMPLETED;"
+	// VersionPurgeStatusInternal is internally in the format "arn1=PENDING;arn2=COMPLETED;"
 	VersionPurgeStatusInternal string                            // stringified representation of all version purge statuses
 	ReplicateDecisionStr       string                            // stringified representation of replication decision for each target
 	Targets                    map[string]replication.StatusType // map of ARN->replication status for ongoing replication activity

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -497,7 +497,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 		}
 		tgtClnt := globalBucketTargetSys.GetRemoteTargetClient(bucket, tgtEntry.Arn)
 		if tgtClnt == nil {
-			// Skip stale targets if any and log them to be missing atleast once.
+			// Skip stale targets if any and log them to be missing at least once.
 			logger.LogOnceIf(ctx, fmt.Errorf("failed to get target for bucket:%s arn:%s", bucket, tgtEntry.Arn), tgtEntry.Arn)
 			sendEvent(eventArgs{
 				EventName:  event.ObjectReplicationNotTracked,
@@ -2829,7 +2829,7 @@ func (p *ReplicationPool) startResyncRoutine(ctx context.Context, buckets []Buck
 		}
 		duration := time.Duration(r.Float64() * float64(time.Minute))
 		if duration < time.Second {
-			// Make sure to sleep atleast a second to avoid high CPU ticks.
+			// Make sure to sleep at least a second to avoid high CPU ticks.
 			duration = time.Second
 		}
 		time.Sleep(duration)

--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -60,7 +60,7 @@ func initCallhome(ctx context.Context, objAPI ObjectLayer) {
 			// sleep for some time and try again.
 			duration := time.Duration(r.Float64() * float64(globalCallhomeConfig.FrequencyDur()))
 			if duration < time.Second {
-				// Make sure to sleep atleast a second to avoid high CPU ticks.
+				// Make sure to sleep at least a second to avoid high CPU ticks.
 				duration = time.Second
 			}
 			time.Sleep(duration)

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -790,7 +790,7 @@ func handleCommonEnvVars() {
 // It depends on KMS env variables and global cli flags.
 func handleKMSConfig() {
 	if env.IsSet(kms.EnvKMSSecretKey) && env.IsSet(kms.EnvKESEndpoint) {
-		logger.Fatal(errors.New("ambigious KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKMSSecretKey, kms.EnvKESEndpoint))
+		logger.Fatal(errors.New("ambiguous KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKMSSecretKey, kms.EnvKESEndpoint))
 	}
 
 	if env.IsSet(kms.EnvKMSSecretKey) {
@@ -803,10 +803,10 @@ func handleKMSConfig() {
 	if env.IsSet(kms.EnvKESEndpoint) {
 		if env.IsSet(kms.EnvKESAPIKey) {
 			if env.IsSet(kms.EnvKESClientKey) {
-				logger.Fatal(errors.New("ambigious KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKESAPIKey, kms.EnvKESClientKey))
+				logger.Fatal(errors.New("ambiguous KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKESAPIKey, kms.EnvKESClientKey))
 			}
 			if env.IsSet(kms.EnvKESClientCert) {
-				logger.Fatal(errors.New("ambigious KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKESAPIKey, kms.EnvKESClientCert))
+				logger.Fatal(errors.New("ambiguous KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKESAPIKey, kms.EnvKESClientCert))
 			}
 		}
 		if !env.IsSet(kms.EnvKESKeyName) {

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -451,7 +451,7 @@ func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 
 		if len(globalDomainNames) != 0 && !globalDomainIPs.IsEmpty() && globalEtcdClient != nil {
 			if globalDNSConfig != nil {
-				// if global DNS is already configured, indicate with a warning, incase
+				// if global DNS is already configured, indicate with a warning, in case
 				// users are confused.
 				logger.LogIf(ctx, fmt.Errorf("DNS store is already configured with %s, etcd is not used for DNS store", globalDNSConfig))
 			} else {

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -78,7 +78,7 @@ func initDataScanner(ctx context.Context, objAPI ObjectLayer) {
 			runDataScanner(ctx, objAPI)
 			duration := time.Duration(r.Float64() * float64(scannerCycle.Load()))
 			if duration < time.Second {
-				// Make sure to sleep atleast a second to avoid high CPU ticks.
+				// Make sure to sleep at least a second to avoid high CPU ticks.
 				duration = time.Second
 			}
 			time.Sleep(duration)
@@ -697,7 +697,7 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 				partial: func(entries metaCacheEntries, errs []error) {
 					entry, ok := entries.resolve(&resolver)
 					if !ok {
-						// check if we can get one entry atleast
+						// check if we can get one entry at least
 						// proceed to heal nonetheless, since
 						// this object might be dangling.
 						entry, _ = entries.firstFound()
@@ -1440,7 +1440,7 @@ func (d *dynamicSleeper) Sleep(ctx context.Context, base time.Duration) {
 }
 
 // Update the current settings and cycle all waiting.
-// Parameters are the same as in the contructor.
+// Parameters are the same as in the constructor.
 func (d *dynamicSleeper) Update(factor float64, maxWait time.Duration) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -924,7 +924,7 @@ type objectIO interface {
 // The loader is optimistic and has no locking, but tries 5 times before giving up.
 // If the object is not found, a nil error with empty data usage cache is returned.
 func (d *dataUsageCache) load(ctx context.Context, store objectIO, name string) error {
-	// By defaut, empty data usage cache
+	// By default, empty data usage cache
 	*d = dataUsageCache{}
 
 	load := func(name string, timeout time.Duration) (bool, error) {

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -754,7 +754,7 @@ func (o ObjectInfo) DecryptedSize() (int64, error) {
 // However, DecryptETag does not try to decrypt the ETag if
 // it consists of a 128 bit hex value (32 hex chars) and exactly
 // one '-' followed by a 32-bit number.
-// This special case adresses randomly-generated ETags generated
+// This special case addresses randomly-generated ETags generated
 // by the MinIO server when running in non-compat mode. These
 // random ETags are not encrypt.
 //

--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -667,7 +667,7 @@ func (d *DecryptBlocksReader) buildDecrypter(partID int) error {
 	mac.Write(partIDbin[:])
 	partEncryptionKey := mac.Sum(nil)
 
-	// Limit the reader, so the decryptor doesnt receive bytes
+	// Limit the reader, so the decryptor doesn't receive bytes
 	// from the next part (different DARE stream)
 	encLenToRead := d.parts[d.partIndex].Size - d.partEncRelOffset
 	decrypter, err := newDecryptReaderWithObjectKey(io.LimitReader(d.reader, encLenToRead), partEncryptionKey, d.startSeqNum)

--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -158,7 +158,7 @@ func (p *parallelReader) Read(dst [][]byte) ([][]byte, error) {
 			bufIdx := p.readerToBuf[i]
 			if p.buf[bufIdx] == nil {
 				// Reading first time on this disk, hence the buffer needs to be allocated.
-				// Subsequent reads will re-use this buffer.
+				// Subsequent reads will reuse this buffer.
 				p.buf[bufIdx] = make([]byte, p.shardSize)
 			}
 			// For the last shard, the shardsize might be less than previous shard sizes.

--- a/cmd/erasure-decode_test.go
+++ b/cmd/erasure-decode_test.go
@@ -144,7 +144,7 @@ func TestErasureDecode(t *testing.T) {
 		}
 		if err == nil {
 			if content := writer.Bytes(); !bytes.Equal(content, data[test.offset:test.offset+test.length]) {
-				t.Errorf("Test %d: read retruns wrong file content.", i)
+				t.Errorf("Test %d: read returns wrong file content.", i)
 			}
 		}
 

--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -57,7 +57,7 @@ func getLatestFileInfo(ctx context.Context, partsMetadata []FileInfo, defaultPar
 		return FileInfo{}, errErasureReadQuorum
 	}
 
-	// Interate through all the modTimes and count the FileInfo(s) with latest time.
+	// Iterate through all the modTimes and count the FileInfo(s) with latest time.
 	for index, t := range modTimes {
 		if partsMetadata[index].IsValid() && t.Equal(modTime) {
 			latestFileInfo = partsMetadata[index]

--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -31,7 +31,7 @@ import (
 
 // Returns the latest updated FileInfo files and error in case of failure.
 func getLatestFileInfo(ctx context.Context, partsMetadata []FileInfo, defaultParityCount int, errs []error) (FileInfo, error) {
-	// There should be atleast half correct entries, if not return failure
+	// There should be at least half correct entries, if not return failure
 	expectedRQuorum := len(partsMetadata) / 2
 	if defaultParityCount == 0 {
 		// if parity count is '0', we expected all entries to be present.

--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -107,7 +107,7 @@ func (er erasureObjects) listAndHeal(bucket, prefix string, healEntry func(strin
 		partial: func(entries metaCacheEntries, _ []error) {
 			entry, ok := entries.resolve(&resolver)
 			if !ok {
-				// check if we can get one entry atleast
+				// check if we can get one entry at least
 				// proceed to heal nonetheless.
 				entry, _ = entries.firstFound()
 			}

--- a/cmd/erasure-healing_test.go
+++ b/cmd/erasure-healing_test.go
@@ -1067,7 +1067,7 @@ func TestHealObjectCorruptedPools(t *testing.T) {
 	for i := 0; i < (nfi.Erasure.DataBlocks + nfi.Erasure.ParityBlocks); i++ {
 		stats, _ := erasureDisks[i].StatInfoFile(context.Background(), bucket, pathJoin(object, xlStorageFormatFile), false)
 		if len(stats) != 0 {
-			t.Errorf("Expected xl.meta file to be not present, but succeeeded")
+			t.Errorf("Expected xl.meta file to be not present, but succeeded")
 		}
 	}
 }

--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -64,7 +64,7 @@ func reduceErrs(errs []error, ignoredErrs []error) (maxCount int, maxErr error) 
 		if IsErrIgnored(err, ignoredErrs...) {
 			continue
 		}
-		// Errors due to context cancelation may be wrapped - group them by context.Canceled.
+		// Errors due to context cancellation may be wrapped - group them by context.Canceled.
 		if errors.Is(err, context.Canceled) {
 			errorCounts[context.Canceled]++
 			continue

--- a/cmd/erasure-metadata-utils_test.go
+++ b/cmd/erasure-metadata-utils_test.go
@@ -94,7 +94,7 @@ func TestReduceErrs(t *testing.T) {
 			},
 			nil, nil,
 		},
-		// Checks if wrapped context cancelation errors are grouped as one.
+		// Checks if wrapped context cancellation errors are grouped as one.
 		{canceledErrs, nil, context.Canceled},
 	}
 	// Validates list of all the testcases for returning valid errors.

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -532,7 +532,7 @@ func listObjectParities(partsMetadata []FileInfo, errs []error) (parities []int)
 // readQuorum is the min required disks to read data.
 // writeQuorum is the min required disks to write data.
 func objectQuorumFromMeta(ctx context.Context, partsMetaData []FileInfo, errs []error, defaultParityCount int) (objectReadQuorum, objectWriteQuorum int, err error) {
-	// There should be atleast half correct entries, if not return failure
+	// There should be at least half correct entries, if not return failure
 	expectedRQuorum := len(partsMetaData) / 2
 	if defaultParityCount == 0 {
 		// if parity count is '0', we expected all entries to be present.

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -103,7 +103,7 @@ func (er erasureObjects) checkUploadIDExists(ctx context.Context, bucket, object
 	return fi, partsMetadata, err
 }
 
-// Removes part.meta given by partName belonging to a mulitpart upload from minioMetaBucket
+// Removes part.meta given by partName belonging to a multipart upload from minioMetaBucket
 func (er erasureObjects) removePartMeta(bucket, object, uploadID, dataDir string, partNumber int) {
 	uploadIDPath := er.getUploadIDDir(bucket, object, uploadID)
 	curpartPath := pathJoin(uploadIDPath, dataDir, fmt.Sprintf("part.%d", partNumber))
@@ -127,7 +127,7 @@ func (er erasureObjects) removePartMeta(bucket, object, uploadID, dataDir string
 	g.Wait()
 }
 
-// Removes part given by partName belonging to a mulitpart upload from minioMetaBucket
+// Removes part given by partName belonging to a multipart upload from minioMetaBucket
 func (er erasureObjects) removeObjectPart(bucket, object, uploadID, dataDir string, partNumber int) {
 	uploadIDPath := er.getUploadIDDir(bucket, object, uploadID)
 	curpartPath := pathJoin(uploadIDPath, dataDir, fmt.Sprintf("part.%d", partNumber))
@@ -656,7 +656,7 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	var buffer []byte
 	switch size := data.Size(); {
 	case size == 0:
-		buffer = make([]byte, 1) // Allocate atleast a byte to reach EOF
+		buffer = make([]byte, 1) // Allocate at least a byte to reach EOF
 	case size == -1:
 		if size := data.ActualSize(); size > 0 && size < fi.Erasure.BlockSize {
 			// Account for padding and forced compression overhead and encryption.

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -758,7 +758,7 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 
 		// verify metadata is valid, it has similar erasure info
 		// as well as common modtime, if modtime is not possible
-		// verify if it has common "etag" atleast.
+		// verify if it has common "etag" at least.
 		if metaArr[i].IsValid() && metaArr[i].Erasure.Equal(fi.Erasure) {
 			ok := metaArr[i].ModTime.Equal(modTime)
 			if modTime.IsZero() || modTime.Equal(timeSentinel) {
@@ -949,7 +949,7 @@ func (er erasureObjects) putMetacacheObject(ctx context.Context, key string, r *
 	var buffer []byte
 	switch size := data.Size(); {
 	case size == 0:
-		buffer = make([]byte, 1) // Allocate atleast a byte to reach EOF
+		buffer = make([]byte, 1) // Allocate at least a byte to reach EOF
 	case size >= fi.Erasure.BlockSize:
 		buffer = er.bp.Get()
 		defer er.bp.Put(buffer)
@@ -1200,7 +1200,7 @@ func (er erasureObjects) putObject(ctx context.Context, bucket string, object st
 	var buffer []byte
 	switch size := data.Size(); {
 	case size == 0:
-		buffer = make([]byte, 1) // Allocate atleast a byte to reach EOF
+		buffer = make([]byte, 1) // Allocate at least a byte to reach EOF
 	case size >= fi.Erasure.BlockSize || size == -1:
 		buffer = er.bp.Get()
 		defer er.bp.Put(buffer)

--- a/cmd/erasure-object_test.go
+++ b/cmd/erasure-object_test.go
@@ -799,7 +799,7 @@ func TestPutObjectNoQuorumSmall(t *testing.T) {
 }
 
 // Test PutObject twice, one small and another bigger
-// than small data thresold and checks reading them again
+// than small data threshold and checks reading them again
 func TestPutObjectSmallInlineData(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -2075,7 +2075,7 @@ func (z *erasureServerPools) Walk(ctx context.Context, bucket, prefix string, re
 						partial: func(entries metaCacheEntries, _ []error) {
 							entry, ok := entries.resolve(&resolver)
 							if !ok {
-								// check if we can get one entry atleast
+								// check if we can get one entry at least
 								// proceed to heal nonetheless.
 								entry, _ = entries.firstFound()
 							}
@@ -2243,7 +2243,7 @@ const (
 	vmware = "VMWare"
 )
 
-// HealthOptions takes input options to return sepcific information
+// HealthOptions takes input options to return specific information
 type HealthOptions struct {
 	Maintenance    bool
 	DeploymentType string
@@ -2417,7 +2417,7 @@ func (z *erasureServerPools) PutObjectMetadata(ctx context.Context, bucket, obje
 	}
 
 	opts.MetadataChg = true
-	// We don't know the size here set 1GiB atleast.
+	// We don't know the size here set 1GiB at least.
 	idx, err := z.getPoolIdxExistingWithOpts(ctx, bucket, object, opts)
 	if err != nil {
 		return ObjectInfo{}, err
@@ -2435,7 +2435,7 @@ func (z *erasureServerPools) PutObjectTags(ctx context.Context, bucket, object s
 
 	opts.MetadataChg = true
 
-	// We don't know the size here set 1GiB atleast.
+	// We don't know the size here set 1GiB at least.
 	idx, err := z.getPoolIdxExistingWithOpts(ctx, bucket, object, opts)
 	if err != nil {
 		return ObjectInfo{}, err

--- a/cmd/erasure-utils.go
+++ b/cmd/erasure-utils.go
@@ -85,7 +85,7 @@ func writeDataBlocks(ctx context.Context, dst io.Writer, enBlocks [][]byte, data
 		if write < int64(len(block)) {
 			n, err := dst.Write(block[:write])
 			if err != nil {
-				// The writer will be closed incase of range queries, which will emit ErrClosedPipe.
+				// The writer will be closed in case of range queries, which will emit ErrClosedPipe.
 				// The reader pipe might be closed at ListObjects io.EOF ignore it.
 				if err != io.ErrClosedPipe && err != io.EOF {
 					logger.LogIf(ctx, err)
@@ -99,7 +99,7 @@ func writeDataBlocks(ctx context.Context, dst io.Writer, enBlocks [][]byte, data
 		// Copy the block.
 		n, err := dst.Write(block)
 		if err != nil {
-			// The writer will be closed incase of range queries, which will emit ErrClosedPipe.
+			// The writer will be closed in case of range queries, which will emit ErrClosedPipe.
 			// The reader pipe might be closed at ListObjects io.EOF ignore it.
 			if err != io.ErrClosedPipe && err != io.EOF {
 				logger.LogIf(ctx, err)

--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -483,7 +483,7 @@ func TestGetErasureID(t *testing.T) {
 
 	formats[2].ID = "bad-id"
 	if _, err = formatErasureGetDeploymentID(quorumFormat, formats); !errors.Is(err, errCorruptedFormat) {
-		t.Fatalf("Unexpect error %s", err)
+		t.Fatalf("Unexpected error %s", err)
 	}
 }
 

--- a/cmd/ftp-server.go
+++ b/cmd/ftp-server.go
@@ -51,7 +51,7 @@ func (log *minioLogger) Printf(sessionID string, format string, v ...interface{}
 	}
 }
 
-// PrintCommand impelment Logger
+// PrintCommand implement Logger
 func (log *minioLogger) PrintCommand(sessionID string, command string, params string) {
 	if serverDebugLog {
 		if command == "PASS" {
@@ -62,7 +62,7 @@ func (log *minioLogger) PrintCommand(sessionID string, command string, params st
 	}
 }
 
-// PrintResponse impelment Logger
+// PrintResponse implement Logger
 func (log *minioLogger) PrintResponse(sessionID string, code int, message string) {
 	if serverDebugLog {
 		logger.Info("%s < %d %s", sessionID, code, message)

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -258,7 +258,7 @@ func isKMSReq(r *http.Request) bool {
 
 // Supported Amz date headers.
 var amzDateHeaders = []string{
-	// Do not chane this order, x-amz-date value should be
+	// Do not change this order, x-amz-date value should be
 	// validated first.
 	"x-amz-date",
 	"date",

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -394,7 +394,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 			partial: func(entries metaCacheEntries, _ []error) {
 				entry, ok := entries.resolve(&resolver)
 				if !ok {
-					// check if we can get one entry atleast
+					// check if we can get one entry at least
 					// proceed to heal nonetheless.
 					entry, _ = entries.firstFound()
 				}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -245,7 +245,7 @@ var (
 	// Global server's network statistics
 	globalConnStats = newConnStats()
 
-	// Global HTTP request statisitics
+	// Global HTTP request statistics
 	globalHTTPStats = newHTTPStats()
 
 	// Global bucket network and API statistics

--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -207,7 +207,7 @@ func getReqAccessCred(r *http.Request, region string) (cred auth.Credentials) {
 	return cred
 }
 
-// Extract request params to be sent with event notifiation.
+// Extract request params to be sent with event notification.
 func extractReqParams(r *http.Request) map[string]string {
 	if r == nil {
 		return nil
@@ -238,7 +238,7 @@ func extractReqParams(r *http.Request) map[string]string {
 	return m
 }
 
-// Extract response elements to be sent with event notifiation.
+// Extract response elements to be sent with event notification.
 func extractRespElements(w http.ResponseWriter) map[string]string {
 	if w == nil {
 		return map[string]string{}

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -152,7 +152,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // LivenessCheckHandler checks whether MinIO is up. It differs from the
 // readiness handler since a failing liveness check causes pod restarts
-// in K8S enviromnents. Therefore, it does not contact external systems.
+// in K8S environments. Therefore, it does not contact external systems.
 func LivenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	if objLayer := newObjectLayerFn(); objLayer == nil {
 		w.Header().Set(xhttp.MinIOServerStatus, unavailable) // Service not initialized yet

--- a/cmd/leak-detect_test.go
+++ b/cmd/leak-detect_test.go
@@ -140,7 +140,7 @@ func pickRelevantGoroutines() (gs []string) {
 	buf := debug.Stack()
 	// runtime stack of go routines will be listed with 2 blank spaces between each of them, so split on "\n\n" .
 	for _, g := range strings.Split(string(buf), "\n\n") {
-		// Again split on a new line, the first line of the second half contaisn the info about the go routine.
+		// Again split on a new line, the first line of the second half contains the info about the go routine.
 		sl := strings.SplitN(g, "\n", 2)
 		if len(sl) != 2 {
 			continue

--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -48,7 +48,7 @@ func initLicenseUpdateJob(ctx context.Context, objAPI ObjectLayer) {
 			// sleep for some time and try again.
 			duration := time.Duration(r.Float64() * float64(time.Hour))
 			if duration < time.Second {
-				// Make sure to sleep atleast a second to avoid high CPU ticks.
+				// Make sure to sleep at least a second to avoid high CPU ticks.
 				duration = time.Second
 			}
 			time.Sleep(duration)

--- a/cmd/local-locker.go
+++ b/cmd/local-locker.go
@@ -34,7 +34,7 @@ type lockRequesterInfo struct {
 	UID             string    // UID to uniquely identify request of client.
 	Timestamp       time.Time // Timestamp set at the time of initialization.
 	TimeLastRefresh time.Time // Timestamp for last lock refresh.
-	Source          string    // Contains line, function and filename reqesting the lock.
+	Source          string    // Contains line, function and filename requesting the lock.
 	Group           bool      // indicates if it was a group lock.
 	// Owner represents the UUID of the owner who originally requested the lock
 	// useful in expiry.

--- a/cmd/lock-rest-server_test.go
+++ b/cmd/lock-rest-server_test.go
@@ -81,7 +81,7 @@ func getLockArgsOld(r *http.Request) (args dsync.LockArgs, err error) {
 	}
 
 	args = dsync.LockArgs{
-		Owner:  values.Get("onwer"),
+		Owner:  values.Get("owner"),
 		UID:    values.Get("uid"),
 		Source: values.Get("source"),
 		Quorum: quorum,

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -111,9 +111,9 @@ func getHostIP(host string) (ipList set.StringSet, err error) {
 	return ipList, err
 }
 
-// sortIPs - sort ips based on higher octects.
+// sortIPs - sort ips based on higher octets.
 // The logic to sort by last octet is implemented to
-// prefer CIDRs with higher octects, this in-turn skips the
+// prefer CIDRs with higher octets, this in-turn skips the
 // localhost/loopback address to be not preferred as the
 // first ip on the list. Subsequently this list helps us print
 // a user friendly message with appropriate values.

--- a/cmd/object-api-datatypes.go
+++ b/cmd/object-api-datatypes.go
@@ -399,7 +399,7 @@ func (lm ListMultipartsInfo) Lookup(uploadID string) bool {
 	return false
 }
 
-// ListMultipartsInfo - represnets bucket resources for incomplete multipart uploads.
+// ListMultipartsInfo - represents bucket resources for incomplete multipart uploads.
 type ListMultipartsInfo struct {
 	// Together with upload-id-marker, this parameter specifies the multipart upload
 	// after which listing should begin.

--- a/cmd/object-api-errors.go
+++ b/cmd/object-api-errors.go
@@ -539,7 +539,7 @@ func (e ObjectNameTooLong) Error() string {
 
 // Error returns string an error formatted as the given text.
 func (e ObjectNamePrefixAsSlash) Error() string {
-	return "Object name contains forward slash as pefix: " + e.Bucket + "/" + e.Object
+	return "Object name contains forward slash as prefix: " + e.Bucket + "/" + e.Object
 }
 
 // AllAccessDisabled All access to this object has been disabled

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -825,7 +825,7 @@ func _testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler, v
 		{"ad", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "ad"}, false},
 		// Using an existing file for bucket name, but its not a directory (5).
 		{"simple-file.txt", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "simple-file.txt"}, false},
-		// Valid bucket names, but they donot exist (6-8).
+		// Valid bucket names, but they do not exist (6-8).
 		{"volatile-bucket-1", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
@@ -1570,7 +1570,7 @@ func testListObjectVersions(obj ObjectLayer, instanceType string, t1 TestErrHand
 		{"ad", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "ad"}, false},
 		// Using an existing file for bucket name, but its not a directory (5).
 		{"simple-file.txt", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "simple-file.txt"}, false},
-		// Valid bucket names, but they donot exist (6-8).
+		// Valid bucket names, but they do not exist (6-8).
 		{"volatile-bucket-1", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", "", 0, ListObjectsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -52,16 +52,16 @@ func testObjectNewMultipartUpload(obj ObjectLayer, instanceType string, t TestEr
 	}
 
 	errMsg := "Bucket not found: minio-bucket"
-	// opearation expected to fail since the bucket on which NewMultipartUpload is being initiated doesn't exist.
+	// operation expected to fail since the bucket on which NewMultipartUpload is being initiated doesn't exist.
 	_, err = obj.NewMultipartUpload(context.Background(), bucket, object, opts)
 	if err == nil {
-		t.Fatalf("%s: Expected to fail since the NewMultipartUpload is intialized on a non-existent bucket.", instanceType)
+		t.Fatalf("%s: Expected to fail since the NewMultipartUpload is initialized on a non-existent bucket.", instanceType)
 	}
 	if errMsg != err.Error() {
 		t.Errorf("%s, Expected to fail with Error \"%s\", but instead found \"%s\".", instanceType, errMsg, err.Error())
 	}
 
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err = obj.MakeBucket(context.Background(), bucket, MakeBucketOptions{})
 	if err != nil {
 		// failed to create newbucket, abort.
@@ -94,7 +94,7 @@ func testObjectAbortMultipartUpload(obj ObjectLayer, instanceType string, t Test
 	bucket := "minio-bucket"
 	object := "minio-object"
 	opts := ObjectOptions{}
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err := obj.MakeBucket(context.Background(), bucket, MakeBucketOptions{})
 	if err != nil {
 		// failed to create newbucket, abort.
@@ -150,7 +150,7 @@ func testObjectAPIIsUploadIDExists(obj ObjectLayer, instanceType string, t TestE
 	bucket := "minio-bucket"
 	object := "minio-object"
 
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err := obj.MakeBucket(context.Background(), bucket, MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.
@@ -182,7 +182,7 @@ func testObjectAPIPutObjectPart(obj ObjectLayer, instanceType string, t TestErrH
 	bucket := "minio-bucket"
 	object := "minio-object"
 	opts := ObjectOptions{}
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err := obj.MakeBucket(context.Background(), bucket, MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.
@@ -348,7 +348,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 	// bucketnames[1].
 	// objectNames[0].
 	// uploadIds [1-3].
-	// Bucket to test for mutiple upload Id's for a given object.
+	// Bucket to test for multiple upload Id's for a given object.
 	err = obj.MakeBucket(context.Background(), bucketNames[1], MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.
@@ -366,7 +366,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 		uploadIDs = append(uploadIDs, res.UploadID)
 	}
 
-	// Bucket to test for mutiple objects, each with unique UUID.
+	// Bucket to test for multiple objects, each with unique UUID.
 	// bucketnames[2].
 	// objectNames[0-2].
 	// uploadIds [4-9].
@@ -1210,7 +1210,7 @@ func testListObjectPartsDiskNotFound(obj ObjectLayer, instanceType string, disks
 	// bucketnames[0].
 	// objectNames[0].
 	// uploadIds [0].
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err := obj.MakeBucket(context.Background(), bucketNames[0], MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.
@@ -1461,7 +1461,7 @@ func testListObjectParts(obj ObjectLayer, instanceType string, t TestErrHandler)
 	// bucketnames[0].
 	// objectNames[0].
 	// uploadIds [0].
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err := obj.MakeBucket(context.Background(), bucketNames[0], MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.
@@ -1702,7 +1702,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 	// bucketnames[0].
 	// objectNames[0].
 	// uploadIds [0].
-	// Create bucket before intiating NewMultipartUpload.
+	// Create bucket before initiating NewMultipartUpload.
 	err = obj.MakeBucket(context.Background(), bucketNames[0], MakeBucketOptions{})
 	if err != nil {
 		// Failed to create newbucket, abort.

--- a/cmd/object-api-multipart_test.go
+++ b/cmd/object-api-multipart_test.go
@@ -1045,7 +1045,7 @@ func testListMultipartUploads(obj ObjectLayer, instanceType string, t TestErrHan
 		{"Test", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "Test"}, false},
 		{"---", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "---"}, false},
 		{"ad", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "ad"}, false},
-		// Valid bucket names, but they donot exist (Test number 5-7).
+		// Valid bucket names, but they do not exist (Test number 5-7).
 		{"volatile-bucket-1", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", "", "", 0, ListMultipartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
@@ -1362,7 +1362,7 @@ func testListObjectPartsDiskNotFound(obj ObjectLayer, instanceType string, disks
 		{"---", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "---"}, false},
 		{"ad", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "ad"}, false},
 		// Test cases for listing uploadID with single part.
-		// Valid bucket names, but they donot exist (Test number 5-7).
+		// Valid bucket names, but they do not exist (Test number 5-7).
 		{"volatile-bucket-1", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
@@ -1599,7 +1599,7 @@ func testListObjectParts(obj ObjectLayer, instanceType string, t TestErrHandler)
 		{"---", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "---"}, false},
 		{"ad", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "ad"}, false},
 		// Test cases for listing uploadID with single part.
-		// Valid bucket names, but they donot exist (Test number 5-7).
+		// Valid bucket names, but they do not exist (Test number 5-7).
 		{"volatile-bucket-1", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", 0, 0, ListPartsInfo{}, BucketNotFound{Bucket: "volatile-bucket-3"}, false},
@@ -1814,7 +1814,7 @@ func testObjectCompleteMultipartUpload(obj ObjectLayer, instanceType string, t T
 		{"---", "", "", []CompletePart{}, "", BucketNotFound{Bucket: "---"}, false},
 		{"ad", "", "", []CompletePart{}, "", BucketNotFound{Bucket: "ad"}, false},
 		// Test cases for listing uploadID with single part.
-		// Valid bucket names, but they donot exist (Test number 5-7).
+		// Valid bucket names, but they do not exist (Test number 5-7).
 		{"volatile-bucket-1", "", "", []CompletePart{}, "", BucketNotFound{Bucket: "volatile-bucket-1"}, false},
 		{"volatile-bucket-2", "", "", []CompletePart{}, "", BucketNotFound{Bucket: "volatile-bucket-2"}, false},
 		{"volatile-bucket-3", "", "", []CompletePart{}, "", BucketNotFound{Bucket: "volatile-bucket-3"}, false},

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -99,7 +99,7 @@ func testPathTraversalExploit(obj ObjectLayer, instanceType, bucketName string, 
 		t.Fatalf("failed to create HTTP request for Put Object: <ERROR> %v", err)
 	}
 
-	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 	// Call the ServeHTTP to execute the handler.
 	apiRouter.ServeHTTP(rec, req)
 

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -1914,7 +1914,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 		},
 
 		// Test case - 6.
-		// Test case with ivalid byte range for exceeding source size boundaries.
+		// Test case with invalid byte range for exceeding source size boundaries.
 		{
 			bucketName:       bucketName,
 			uploadID:         uploadID,
@@ -2030,7 +2030,7 @@ func testAPICopyObjectPartHandler(obj ObjectLayer, instanceType, bucketName stri
 			secretKey:          credentials.SecretKey,
 			expectedRespStatus: http.StatusNotFound,
 		},
-		// Test case - 16,  Test case with ivalid byte range empty value.
+		// Test case - 16,  Test case with invalid byte range empty value.
 		{
 			bucketName:       bucketName,
 			uploadID:         uploadID,
@@ -3088,7 +3088,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 		if rec.Code == http.StatusOK {
 			// Verify whether the bucket obtained object is same as the one created.
 			if !bytes.Equal(testCase.expectedContent, actualContent) {
-				t.Errorf("Test %d : MinIO %s: CompleteMultipart response content differs from expected value. got %s, expecte %s", i+1, instanceType,
+				t.Errorf("Test %d : MinIO %s: CompleteMultipart response content differs from expected value. got %s, expected %s", i+1, instanceType,
 					string(actualContent), string(testCase.expectedContent))
 			}
 			continue
@@ -3366,7 +3366,7 @@ func testAPIDeleteObjectHandler(obj ObjectLayer, instanceType, bucketName string
 	}{
 		// Test case - 1.
 		// Deleting an existing object.
-		// Expected to return HTTP resposne status code 204.
+		// Expected to return HTTP response status code 204.
 		{
 			bucketName: bucketName,
 			objectName: objectName,
@@ -3490,7 +3490,7 @@ func testAPIPutObjectPartHandlerStreaming(obj ObjectLayer, instanceType, bucketN
 	}
 	apiRouter.ServeHTTP(rec, req)
 
-	// Get uploadID of the mulitpart upload initiated.
+	// Get uploadID of the multipart upload initiated.
 	var mpartResp InitiateMultipartUploadResponse
 	mpartRespBytes, err := io.ReadAll(rec.Result().Body)
 	if err != nil {
@@ -3897,7 +3897,7 @@ func testAPIListObjectPartsHandlerPreSign(obj ObjectLayer, instanceType, bucketN
 	}
 	apiRouter.ServeHTTP(rec, req)
 
-	// Get uploadID of the mulitpart upload initiated.
+	// Get uploadID of the multipart upload initiated.
 	var mpartResp InitiateMultipartUploadResponse
 	mpartRespBytes, err := io.ReadAll(rec.Result().Body)
 	if err != nil {

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -3021,7 +3021,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 		},
 		// Test case - 7.
 		// Test case with proper parts.
-		// Should successed and the content in the response body is asserted.
+		// Should succeeded and the content in the response body is asserted.
 		{
 			bucket:    bucketName,
 			object:    objectName,
@@ -3037,7 +3037,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 		},
 		// Test case - 8.
 		// Test case with proper parts.
-		// Should successed and the content in the response body is asserted.
+		// Should succeeded and the content in the response body is asserted.
 		{
 			bucket:    bucketName,
 			object:    objectName,

--- a/cmd/os_unix.go
+++ b/cmd/os_unix.go
@@ -88,7 +88,7 @@ func osMkdirAll(dirPath string, perm os.FileMode, baseDir string) error {
 // refer https://github.com/golang/go/issues/24015
 const blockSize = 8 << 10 // 8192
 
-// By default atleast 128 entries in single getdents call (1MiB buffer)
+// By default at least 128 entries in single getdents call (1MiB buffer)
 var (
 	direntPool = sync.Pool{
 		New: func() interface{} {

--- a/cmd/post-policy-fan-out.go
+++ b/cmd/post-policy-fan-out.go
@@ -40,7 +40,7 @@ type fanOutOptions struct {
 }
 
 // fanOutPutObject takes an input source reader and fans out multiple PUT operations
-// based on the incoming fan-out request, a context cancelation by the caller
+// based on the incoming fan-out request, a context cancellation by the caller
 // would ensure all fan-out operations are canceled.
 func fanOutPutObject(ctx context.Context, bucket string, objectAPI ObjectLayer, fanOutEntries []minio.PutObjectFanOutEntry, fanOutBuf []byte, opts fanOutOptions) ([]ObjectInfo, []error) {
 	errs := make([]error, len(fanOutEntries))

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -152,7 +152,7 @@ func testPostPolicyReservedBucketExploit(obj ObjectLayer, instanceType string, d
 	req.Header.Set("Content-Type", contentTypeHdr)
 	req.Header.Set("User-Agent", "Mozilla")
 
-	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 	// Call the ServeHTTP to execute the handler.
 	apiRouter.ServeHTTP(rec, req)
 
@@ -225,7 +225,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 		if perr != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", i+1, instanceType, perr)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(rec, req)
 		if rec.Code != test.expectedStatus {
@@ -284,7 +284,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 			// Change the request body.
 			req.Body = io.NopCloser(bytes.NewReader([]byte("Hello,")))
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(rec, req)
 		if rec.Code != testCase.expectedRespStatus {
@@ -415,7 +415,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 		if perr != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", i+1, instanceType, perr)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(rec, req)
 		if rec.Code != testCase.expectedRespStatus {
@@ -487,7 +487,7 @@ func testPostPolicyBucketHandler(obj ObjectLayer, instanceType string, t TestErr
 		if perr != nil {
 			t.Fatalf("Test %d: %s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", i+1, instanceType, perr)
 		}
-		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+		// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 		// Call the ServeHTTP to execute the handler.
 		apiRouter.ServeHTTP(rec, req)
 		if rec.Code != testCase.expectedRespStatus {
@@ -556,7 +556,7 @@ func testPostPolicyBucketHandlerRedirect(obj ObjectLayer, instanceType string, t
 	if perr != nil {
 		t.Fatalf("%s: Failed to create HTTP request for PostPolicyHandler: <ERROR> %v", instanceType, perr)
 	}
-	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic ofthe handler.
+	// Since `apiRouter` satisfies `http.Handler` it has a ServeHTTP to execute the logic of the handler.
 	// Call the ServeHTTP to execute the handler.
 	apiRouter.ServeHTTP(rec, req)
 

--- a/cmd/postpolicyform.go
+++ b/cmd/postpolicyform.go
@@ -260,7 +260,7 @@ func parsePostPolicyForm(r io.Reader) (PostPolicyForm, error) {
 	return parsedPolicy, nil
 }
 
-// checkPolicyCond returns a boolean to indicate if a condition is satisified according
+// checkPolicyCond returns a boolean to indicate if a condition is satisfied according
 // to the passed operator
 func checkPolicyCond(op string, input1, input2 string) bool {
 	switch op {

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -83,7 +83,7 @@ var ServerFlags = []cli.Flag{
 	cli.DurationFlag{
 		Name:   "idle-timeout",
 		Value:  xhttp.DefaultIdleTimeout,
-		Usage:  "idle timeout is the maximum amount of time to wait for the next request when keep-alives are enabled",
+		Usage:  "idle timeout is the maximum amount of time to wait for the next request when keep-alive are enabled",
 		EnvVar: "MINIO_IDLE_TIMEOUT",
 		Hidden: true,
 	},
@@ -360,7 +360,7 @@ func initAllSubsystems(ctx context.Context) {
 		globalBucketVersioningSys = NewBucketVersioningSys()
 	}
 
-	// Create new bucket replication subsytem
+	// Create new bucket replication subsystem
 	globalBucketTargetSys = NewBucketTargetSys(GlobalContext)
 
 	// Create new ILM tier configuration subsystem

--- a/cmd/signature-v2.go
+++ b/cmd/signature-v2.go
@@ -199,7 +199,7 @@ func getReqAccessKeyV2(r *http.Request) (auth.Credentials, bool, APIErrorCode) {
 		return auth.Credentials{}, false, ErrMissingFields
 	}
 
-	// Then will be splitting on ":", this will seprate `AWSAccessKeyId` and `Signature` string.
+	// Then will be splitting on ":", this will separate `AWSAccessKeyId` and `Signature` string.
 	keySignFields := strings.Split(strings.TrimSpace(authFields[1]), ":")
 	if len(keySignFields) != 2 {
 		return auth.Credentials{}, false, ErrMissingFields

--- a/cmd/signature-v4-parser.go
+++ b/cmd/signature-v4-parser.go
@@ -161,7 +161,7 @@ type signValues struct {
 	Signature     string
 }
 
-// preSignValues data type represents structued form of AWS Signature V4 query string.
+// preSignValues data type represents structured form of AWS Signature V4 query string.
 type preSignValues struct {
 	signValues
 	Date    time.Time
@@ -244,7 +244,7 @@ func parsePreSignV4(query url.Values, region string, stype serviceType) (psv pre
 		return psv, aec
 	}
 
-	// Return structed form of signature query string.
+	// Return structured form of signature query string.
 	return preSignV4Values, ErrNone
 }
 

--- a/cmd/signature-v4-parser_test.go
+++ b/cmd/signature-v4-parser_test.go
@@ -79,7 +79,7 @@ func validateCredentialfields(t *testing.T, testNum int, expectedCredentials cre
 }
 
 // TestParseCredentialHeader - validates the format validator and extractor for the Credential header in an aws v4 request.
-// A valid format of creadential should be of the following format.
+// A valid format of credential should be of the following format.
 // Credential = accessKey + SlashSeparator+ scope
 // where scope = string.Join([]string{  currTime.Format(yyyymmdd),
 //
@@ -387,7 +387,7 @@ func TestParseSignV4(t *testing.T) {
 		},
 		// Test case - 5.
 		// Auth field with missing "SigHeaderTag",ErrMissingSignHeadersTag expected.
-		// A vaild credential is generated.
+		// A valid credential is generated.
 		// Test case with invalid credential field.
 		{
 			inputV4AuthStr: signV4Algorithm +
@@ -409,7 +409,7 @@ func TestParseSignV4(t *testing.T) {
 		},
 		// Test case - 6.
 		// Auth string with missing "SignatureTag",ErrMissingSignTag expected.
-		// A vaild credential is generated.
+		// A valid credential is generated.
 		// Test case with invalid credential field.
 		{
 			inputV4AuthStr: signV4Algorithm +

--- a/cmd/signature-v4-utils.go
+++ b/cmd/signature-v4-utils.go
@@ -206,7 +206,7 @@ func extractSignedHeaders(signedHeaders []string, r *http.Request) (http.Header,
 	extractedSignedHeaders := make(http.Header)
 	for _, header := range signedHeaders {
 		// `host` will not be found in the headers, can be found in r.Host.
-		// but its alway necessary that the list of signed headers containing host in it.
+		// but its always necessary that the list of signed headers containing host in it.
 		val, ok := reqHeaders[http.CanonicalHeaderKey(header)]
 		if !ok {
 			// try to set headers from Query String

--- a/cmd/signature-v4_test.go
+++ b/cmd/signature-v4_test.go
@@ -220,7 +220,7 @@ func TestDoesPresignedSignatureMatch(t *testing.T) {
 			expected: ErrRequestNotReadyYet,
 		},
 		// (7) Should not error with invalid region instead, call should proceed
-		// with sigature does not match.
+		// with signature does not match.
 		{
 			queryParams: map[string]string{
 				"X-Amz-Algorithm":      signV4Algorithm,

--- a/cmd/site-replication-utils.go
+++ b/cmd/site-replication-utils.go
@@ -90,7 +90,7 @@ func (sm *siteResyncMetrics) init(ctx context.Context) {
 		}
 		duration := time.Duration(r.Float64() * float64(time.Second*10))
 		if duration < time.Second {
-			// Make sure to sleep atleast a second to avoid high CPU ticks.
+			// Make sure to sleep at least a second to avoid high CPU ticks.
 			duration = time.Second
 		}
 		time.Sleep(duration)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1225,7 +1225,7 @@ func checkDiskFatalErrs(errs []error) error {
 // at each implementation of error for added hints.
 //
 // FIXME: This is an unusual function but serves its purpose for
-// now, need to revist the overall erroring structure here.
+// now, need to revisit the overall erroring structure here.
 // Do not like it :-(
 func logFatalErrs(err error, endpoint Endpoint, exit bool) {
 	switch {

--- a/cmd/streaming-signature-v4.go
+++ b/cmd/streaming-signature-v4.go
@@ -171,7 +171,7 @@ func calculateSeedSignature(r *http.Request, trailers bool) (cred auth.Credentia
 		return cred, "", "", time.Time{}, ErrSignatureDoesNotMatch
 	}
 
-	// Return caculated signature.
+	// Return calculated signature.
 	return cred, newSignature, region, date, ErrNone
 }
 

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -723,7 +723,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 	// We have to establish a TLS connection and the
 	// client must provide exactly one client certificate.
 	// Otherwise, we don't have a certificate to verify or
-	// the policy lookup would ambigious.
+	// the policy lookup would ambiguous.
 	if r.TLS == nil {
 		writeSTSErrorResponse(ctx, w, ErrSTSInsecureConnection, errors.New("No TLS connection attempt"))
 		return
@@ -732,7 +732,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithCertificate(w http.ResponseWriter, r *h
 	// A client may send a certificate chain such that we end up
 	// with multiple peer certificates. However, we can only accept
 	// a single client certificate. Otherwise, the certificate to
-	// policy mapping would be ambigious.
+	// policy mapping would be ambiguous.
 	// However, we can filter all CA certificates and only check
 	// whether they client has sent exactly one (non-CA) leaf certificate.
 	peerCertificates := make([]*x509.Certificate, 0, len(r.TLS.PeerCertificates))

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1660,7 +1660,7 @@ func ExecObjectLayerAPIAnonTest(t *testing.T, obj ObjectLayer, testName, bucketN
 	// expected error response when the unsigned HTTP request is not permitted.
 	unsupportedSignature := getAPIError(ErrSignatureVersionNotSupported).HTTPStatusCode
 	if rec.Code != unsupportedSignature {
-		t.Fatal(failTestStr(unknownSignTestStr, fmt.Sprintf("Object API Unknow auth test for \"%s\", expected to fail with %d, but failed with %d", testName, unsupportedSignature, rec.Code)))
+		t.Fatal(failTestStr(unknownSignTestStr, fmt.Sprintf("Object API Unknown auth test for \"%s\", expected to fail with %d, but failed with %d", testName, unsupportedSignature, rec.Code)))
 	}
 }
 
@@ -1674,7 +1674,7 @@ func ExecObjectLayerAPINilTest(t TestErrHandler, bucketName, objectName, instanc
 	// httptest Recorder to capture all the response by the http handler.
 	rec := httptest.NewRecorder()
 
-	// The  API handler gets the referece to the object layer via the global object Layer,
+	// The  API handler gets the reference to the object layer via the global object Layer,
 	// setting it to `nil` in order test for handlers response for uninitialized object layer.
 	globalObjLayerMutex.Lock()
 	globalObjectAPI = nil
@@ -1757,7 +1757,7 @@ func ExecObjectLayerAPITest(t *testing.T, objAPITest objAPITestType, endpoints [
 
 	bucketErasure, erAPIRouter, err := initAPIHandlerTest(ctx, objLayer, endpoints)
 	if err != nil {
-		t.Fatalf("Initialzation of API handler tests failed: <ERROR> %s", err)
+		t.Fatalf("Initialization of API handler tests failed: <ERROR> %s", err)
 	}
 
 	// initialize the server and obtain the credentials and root.

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -1511,7 +1511,7 @@ func removeRoots(roots []string) {
 
 // creates a bucket for the tests and returns the bucket name.
 // initializes the specified API endpoints for the tests.
-// initialies the root and returns its path.
+// initializes the root and returns its path.
 // return credentials.
 func initAPIHandlerTest(ctx context.Context, obj ObjectLayer, endpoints []string) (string, http.Handler, error) {
 	initAllSubsystems(ctx)

--- a/cmd/tier-journal.go
+++ b/cmd/tier-journal.go
@@ -72,7 +72,7 @@ func NewTierJournal() *TierJournal {
 	return j
 }
 
-// Init intializes an in-memory journal built using a
+// Init initializes an in-memory journal built using a
 // buffered channel for new journal entries. It also initializes the on-disk
 // journal only to process existing journal entries made from previous versions.
 func (t *TierJournal) Init(ctx context.Context) error {

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -99,7 +99,7 @@ var errNoSuchPolicy = errors.New("Specified canned policy does not exist")
 var errPolicyInUse = errors.New("Specified policy is in use and cannot be deleted.")
 
 // error returned when more than a single policy is specified when only one is
-// expectd.
+// expected.
 var errTooManyPolicies = errors.New("Only a single policy may be specified here.")
 
 // error returned in IAM subsystem when an external users systems is configured.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -288,7 +288,7 @@ func isMaxPartID(partID int) bool {
 	return partID > globalMaxPartID
 }
 
-// profilerWrapper is created becauses pkg/profiler doesn't
+// profilerWrapper is created because pkg/profiler doesn't
 // provide any API to calculate the profiler file path in the
 // disk since the name of this latter is randomly generated.
 type profilerWrapper struct {

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -770,7 +770,7 @@ func readXLMetaNoData(r io.Reader, size int64) ([]byte, error) {
 		case 1, 2, 3:
 			sz, tmp, err := msgp.ReadBytesHeader(tmp)
 			if err != nil {
-				return nil, fmt.Errorf("readXLMetaNoData(read_meta): uknown metadata version %w", err)
+				return nil, fmt.Errorf("readXLMetaNoData(read_meta): unknown metadata version %w", err)
 			}
 			want := int64(sz) + int64(len(buf)-len(tmp))
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2355,7 +2355,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		formatLegacy := s.formatLegacy
 		s.RUnlock()
 		// It is possible that some drives may not have `xl.meta` file
-		// in such scenarios verify if atleast `part.1` files exist
+		// in such scenarios verify if at least `part.1` files exist
 		// to verify for legacy version.
 		if formatLegacy {
 			// We only need this code if we are moving

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2145,7 +2145,7 @@ func (s *xlStorage) deleteFile(basePath, deletePath string, recursive, force boo
 			if runtime.GOOS == globalMacOSName {
 				storeFilePath := pathJoin(deletePath, ".DS_Store")
 				_, err := Stat(storeFilePath)
-				// .DS_Store exsits
+				// .DS_Store exists
 				if err == nil {
 					// delete first
 					Remove(storeFilePath)

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -1204,7 +1204,7 @@ func TestXLStorageReadFile(t *testing.T) {
 			if err == nil && err != testCase.expectedErr {
 				t.Errorf("Case: %d %#v, expected: %s, got :%s", i+1, testCase, testCase.expectedErr, err)
 			}
-			// Expected error retured, proceed further to validate the returned results.
+			// Expected error returned, proceed further to validate the returned results.
 			if err != nil && testCase.expectedErr == nil {
 				t.Errorf("Case: %d %#v, expected: %s, got :%s", i+1, testCase, testCase.expectedErr, err)
 			}
@@ -1408,7 +1408,7 @@ func TestXLStorageAppendFile(t *testing.T) {
 	}
 
 	// TestXLStorage case with invalid volume name.
-	// A valid volume name should be atleast of size 3.
+	// A valid volume name should be at least of size 3.
 	err = xlStorage.AppendFile(context.Background(), "bn", "yes", []byte("hello, world"))
 	if err != errVolumeNotFound {
 		t.Fatalf("expected: \"Invalid argument error\", got: \"%s\"", err)
@@ -1564,7 +1564,7 @@ func TestXLStorageRenameFile(t *testing.T) {
 			expectedErr: errVolumeNotFound,
 		},
 		// TestXLStorage case - 12.
-		// TestXLStorage case with invalid src volume name. Length should be atleast 3.
+		// TestXLStorage case with invalid src volume name. Length should be at least 3.
 		// Expecting to fail with `errInvalidArgument`.
 		{
 			srcVol:      "ab",
@@ -1574,7 +1574,7 @@ func TestXLStorageRenameFile(t *testing.T) {
 			expectedErr: errVolumeNotFound,
 		},
 		// TestXLStorage case - 13.
-		// TestXLStorage case with invalid destination volume name. Length should be atleast 3.
+		// TestXLStorage case with invalid destination volume name. Length should be at least 3.
 		// Expecting to fail with `errInvalidArgument`.
 		{
 			srcVol:      "abcd",
@@ -1584,7 +1584,7 @@ func TestXLStorageRenameFile(t *testing.T) {
 			expectedErr: errVolumeNotFound,
 		},
 		// TestXLStorage case - 14.
-		// TestXLStorage case with invalid destination volume name. Length should be atleast 3.
+		// TestXLStorage case with invalid destination volume name. Length should be at least 3.
 		// Expecting to fail with `errInvalidArgument`.
 		{
 			srcVol:      "abcd",

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -857,7 +857,7 @@ When the _access_ format is used, MinIO appends events to a table. It creates ro
 
 The steps below show how to use this notification target in `namespace` format. The other format is very similar and is omitted for brevity.
 
-### Step 1: Ensure PostgresSQL minimum requirements are met
+### Step 1: Ensure postgresql minimum requirements are met
 
 MinIO requires PostgreSQL version 9.5 or above. MinIO uses the [`INSERT ON CONFLICT`](https://www.postgresql.org/docs/9.5/static/sql-insert.html#SQL-ON-CONFLICT) (aka UPSERT) feature, introduced in version 9.5 and the [JSONB](https://www.postgresql.org/docs/9.4/static/datatype-json.html) data-type introduced in version 9.4.
 

--- a/docs/debugging/reorder-disks/main.go
+++ b/docs/debugging/reorder-disks/main.go
@@ -56,7 +56,7 @@ func getMountMap() (map[string]string, error) {
 	for scanner.Scan() {
 		s := strings.Split(scanner.Text(), " ")
 		if len(s) != 11 {
-			return nil, errors.New("unsupport /proc/self/mountinfo format")
+			return nil, errors.New("unsupported /proc/self/mountinfo format")
 		}
 		result[s[2]] = s[9]
 	}

--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -26,7 +26,7 @@ MinIO follows strict **read-after-write** and **list-after-write** consistency m
 
 **In our tests we also found ext4 does not honor POSIX O_DIRECT/Fdatasync semantics, ext4 trades performance for consistency guarantees. Please avoid ext4 in your setup.**
 
-**If MinIO distributed setup is using NFS volumes underneath it is not guaranteed MinIO will provide these consistency guarantees since NFS is not strictly consistent (If you must use NFS we recommend that you atleast use NFSv4 instead of NFSv3 for relatively better outcomes).**
+**If MinIO distributed setup is using NFS volumes underneath it is not guaranteed MinIO will provide these consistency guarantees since NFS is not strictly consistent (If you must use NFS we recommend that you at least use NFSv4 instead of NFSv3 for relatively better outcomes).**
 
 ## Get started
 

--- a/docs/hotfixes.md
+++ b/docs/hotfixes.md
@@ -110,7 +110,7 @@ Verify if healing and replacing a drive works
 λ make verify-healing
 ```
 
-At this point in time the backport is ready to be submitted as a pull request to the relevant branch. A pull request is recommended to ensure [mint](http://github.com/minio/mint) tests are validated. Pull request also ensures code-reviews for the backports incase of any unforeseen regressions.
+At this point in time the backport is ready to be submitted as a pull request to the relevant branch. A pull request is recommended to ensure [mint](http://github.com/minio/mint) tests are validated. Pull request also ensures code-reviews for the backports in case of any unforeseen regressions.
 
 ### Building a hotfix binary and container
 

--- a/docs/kms/IAM.md
+++ b/docs/kms/IAM.md
@@ -31,7 +31,7 @@ export MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl
 ```
 
 > You can choose an arbitrary name for the key - instead of `my-minio-key`.
-> Please note that loosing the `MINIO_KMS_SECRET_KEY` will cause data loss
+> Please note that losing the `MINIO_KMS_SECRET_KEY` will cause data loss
 > since you will not be able to decrypt the IAM/configuration data anymore.
 For distributed MinIO deployments, specify the *same* `MINIO_KMS_SECRET_KEY` for each MinIO server process.
 

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -4,7 +4,7 @@ MinIO uses a key-management-system (KMS) to support SSE-S3. If a client requests
 
 ## Quick Start
 
-MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you havn't installed MinIO, yet, then follow the MinIO [install instructions](https://min.io/docs/minio/linux/index.html#quickstart-for-linux) first.
+MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you haven't installed MinIO, yet, then follow the MinIO [install instructions](https://min.io/docs/minio/linux/index.html#quickstart-for-linux) first.
 
 ### 1. Fetch the root identity
 

--- a/docs/metrics/prometheus/grafana/minio-replication.json
+++ b/docs/metrics/prometheus/grafana/minio-replication.json
@@ -1150,7 +1150,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum by (server,enpoint) (minio_cluster_replication_link_offline_duration_seconds{job=\"$scrape_jobs\"})",
+          "expr": "sum by (server,endpoint) (minio_cluster_replication_link_offline_duration_seconds{job=\"$scrape_jobs\"})",
           "interval": "1m",
           "legendFormat": "{{server,endpoint}}",
           "refId": "A"

--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -51,7 +51,7 @@ We found the following APIs to be redundant or less useful outside of AWS S3. If
 
 ## Object name restrictions on MinIO
 
-- Object name restrictions on MinIO are governed by OS and filesystem limitations. For example object names that contain characters `^*|\/&";` are unsupported on Windows platform or any other file systems that do not support filenames with special charaters.
+- Object name restrictions on MinIO are governed by OS and filesystem limitations. For example object names that contain characters `^*|\/&";` are unsupported on Windows platform or any other file systems that do not support filenames with special characters.
 
 > **This list is non exhaustive, it depends on the operating system and filesystem under use - please consult your operating system vendor for a more comprehensive list of special characters**.
 

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -107,7 +107,7 @@ The returned user's DN and their password are then verified with the LDAP server
 
 ### Group membership search
 
-MinIO can be optionally configured to find the groups of a user from AD/LDAP by specifying the folllowing variables:
+MinIO can be optionally configured to find the groups of a user from AD/LDAP by specifying the following variables:
 
 ```
 MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER     (string)    search filter for groups e.g. "(&(objectclass=groupOfNames)(memberUid=%s))"

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -265,7 +265,7 @@ Sample URLs for Keycloak are
 
 `config_url` - `http://localhost:8080/auth/realms/demo/.well-known/openid-configuration`
 
-JWT token returned by the Identity Provider should include a custom claim for the policy, this is required to create a STS user in MinIO. The name of the custom claim could be either `policy` or `<NAMESPACE_PREFIX>policy`.  If there is no namespace then `claim_prefix` can be ingored. For example if the custom claim name is `https://min.io/policy` then, `claim_prefix` should be set as `https://min.io/`.
+JWT token returned by the Identity Provider should include a custom claim for the policy, this is required to create a STS user in MinIO. The name of the custom claim could be either `policy` or `<NAMESPACE_PREFIX>policy`.  If there is no namespace then `claim_prefix` can be ignored. For example if the custom claim name is `https://min.io/policy` then, `claim_prefix` should be set as `https://min.io/`.
 
 - Open MinIO Console and click `Login with SSO`
 - The user will be redirected to the Identity Provider login page

--- a/internal/amztime/parse.go
+++ b/internal/amztime/parse.go
@@ -50,7 +50,7 @@ func Parse(amzDateStr string) (time.Time, error) {
 }
 
 var httpTimeFormats = []string{
-	// Do not chagne this order, http time format dates
+	// Do not change this order, http time format dates
 	// are usually in http.TimeFormat however there are
 	// situations where for example aws-sdk-java doesn't
 	// send the correct format.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -594,7 +594,7 @@ func LookupSite(siteKV KVS, regionKV KVS) (s Site, err error) {
 }
 
 // CheckValidKeys - checks if inputs KVS has the necessary keys,
-// returns error if it find extra or superflous keys.
+// returns error if it find extra or superfluous keys.
 func CheckValidKeys(subSys string, kv KVS, validKVS KVS, deprecatedKeys ...string) error {
 	nkv := KVS{}
 	for _, kv := range kv {

--- a/internal/config/identity/openid/jwt_test.go
+++ b/internal/config/identity/openid/jwt_test.go
@@ -258,7 +258,7 @@ func TestExpCorrect(t *testing.T) {
 	if err := updateClaimsExpiry("3600", claimsMap.MapClaims); err != nil {
 		t.Error(err)
 	}
-	// Build simple toke with updated expiration claim
+	// Build simple token with updated expiration claim
 	token := jwtgo.NewWithClaims(jwtgo.SigningMethodHS256, claimsMap)
 	tokenString, err := token.SignedString(signKey)
 	if err != nil {

--- a/internal/config/identity/openid/provider/provider.go
+++ b/internal/config/identity/openid/provider/provider.go
@@ -53,7 +53,7 @@ var (
 	ErrAccessTokenExpired = errors.New("access_token expired or unauthorized")
 )
 
-// Provider implements indentity provider specific admin operations, such as
+// Provider implements identity provider specific admin operations, such as
 // looking up users, fetching additional attributes etc.
 type Provider interface {
 	LoginWithUser(username, password string) error

--- a/internal/config/identity/openid/providercfg.go
+++ b/internal/config/identity/openid/providercfg.go
@@ -91,7 +91,7 @@ func (p *providerCfg) initializeProvider(cfgGet func(string) string, transport h
 		)
 		return err
 	default:
-		return fmt.Errorf("Unsupport vendor %s", keyCloakVendor)
+		return fmt.Errorf("Unsupported vendor %s", keyCloakVendor)
 	}
 }
 

--- a/internal/config/identity/plugin/config.go
+++ b/internal/config/identity/plugin/config.go
@@ -197,7 +197,7 @@ func (h *metrics) accumRequestRTT(reqStartTime time.Time, rttMs float64, isSucce
 		}
 	}
 
-	// Round the reqest time *down* to whole minute.
+	// Round the request time *down* to whole minute.
 	reqTimeMinute := reqStartTime.Truncate(time.Minute)
 	if reqTimeMinute.After(h.currentMinute.statsTime) {
 		// Drop the last full minute now, since we got a request for a time we

--- a/internal/config/lambda/event/targetidset.go
+++ b/internal/config/lambda/event/targetidset.go
@@ -50,7 +50,7 @@ func (set TargetIDSet) Union(sset TargetIDSet) TargetIDSet {
 	return nset
 }
 
-// Difference - returns diffrence with given set as new set.
+// Difference - returns difference with given set as new set.
 func (set TargetIDSet) Difference(sset TargetIDSet) TargetIDSet {
 	nset := NewTargetIDSet()
 	for k := range set {

--- a/internal/config/notify/help.go
+++ b/internal/config/notify/help.go
@@ -143,7 +143,7 @@ var (
 		},
 		config.HelpKV{
 			Key:         target.AmqpPublisherConfirms,
-			Description: "enable consumer acknowlegement and publisher confirms, use this along with queue_dir for guaranteed delivery of all events",
+			Description: "enable consumer acknowledgement and publisher confirms, use this along with queue_dir for guaranteed delivery of all events",
 			Optional:    true,
 			Type:        "on|off",
 		},

--- a/internal/crypto/key.go
+++ b/internal/crypto/key.go
@@ -74,7 +74,7 @@ func GenerateIV(random io.Reader) (iv [32]byte) {
 // SealedKey represents a sealed object key. It can be stored
 // at an untrusted location.
 type SealedKey struct {
-	Key       [64]byte // The encrypted and authenticted object-key.
+	Key       [64]byte // The encrypted and authenticated object-key.
 	IV        [32]byte // The random IV used to encrypt the object-key.
 	Algorithm string   // The sealing algorithm used to encrypt the object key.
 }

--- a/internal/crypto/metadata.go
+++ b/internal/crypto/metadata.go
@@ -156,7 +156,7 @@ func IsEncrypted(metadata map[string]string) (Type, bool) {
 }
 
 // CreateMultipartMetadata adds the multipart flag entry to metadata
-// and returns modifed metadata. It allocates a new metadata map if
+// and returns modified metadata. It allocates a new metadata map if
 // metadata is nil.
 func CreateMultipartMetadata(metadata map[string]string) map[string]string {
 	if metadata == nil {

--- a/internal/crypto/sse-c.go
+++ b/internal/crypto/sse-c.go
@@ -58,7 +58,7 @@ func (ssec) IsRequested(h http.Header) bool {
 }
 
 // IsEncrypted returns true if the metadata contains an SSE-C
-// entry inidicating that the object has been encrypted using
+// entry indicating that the object has been encrypted using
 // SSE-C.
 func (ssec) IsEncrypted(metadata map[string]string) bool {
 	if _, ok := metadata[MetaSealedKeySSEC]; ok {

--- a/internal/crypto/sse-kms.go
+++ b/internal/crypto/sse-kms.go
@@ -137,7 +137,7 @@ func (ssekms) CreateMetadata(metadata map[string]string, keyID string, kmsKey []
 		logger.CriticalIf(context.Background(), Errorf("The seal algorithm '%s' is invalid for SSE-S3", sealedKey.Algorithm))
 	}
 
-	// There are two possibilites:
+	// There are two possibilities:
 	// - We use a KMS -> There must be non-empty key ID and a KMS data key.
 	// - We use a K/V -> There must be no key ID and no KMS data key.
 	// Otherwise, the caller has passed an invalid argument combination.
@@ -187,7 +187,7 @@ func (ssekms) ParseMetadata(metadata map[string]string) (keyID string, kmsKey []
 		return keyID, kmsKey, sealedKey, ctx, Errorf("The object metadata is missing the internal sealed key for SSE-S3")
 	}
 
-	// There are two possibilites:
+	// There are two possibilities:
 	// - We use a KMS -> There must be a key ID and a KMS data key.
 	// - We use a K/V -> There must be no key ID and no KMS data key.
 	// Otherwise, the metadata is corrupted.

--- a/internal/crypto/sse-s3.go
+++ b/internal/crypto/sse-s3.go
@@ -157,7 +157,7 @@ func (sses3) CreateMetadata(metadata map[string]string, keyID string, kmsKey []b
 		logger.CriticalIf(context.Background(), Errorf("The seal algorithm '%s' is invalid for SSE-S3", sealedKey.Algorithm))
 	}
 
-	// There are two possibilites:
+	// There are two possibilities:
 	// - We use a KMS -> There must be non-empty key ID and a KMS data key.
 	// - We use a K/V -> There must be no key ID and no KMS data key.
 	// Otherwise, the caller has passed an invalid argument combination.
@@ -203,7 +203,7 @@ func (sses3) ParseMetadata(metadata map[string]string) (keyID string, kmsKey []b
 		return keyID, kmsKey, sealedKey, Errorf("The object metadata is missing the internal sealed key for SSE-S3")
 	}
 
-	// There are two possibilites:
+	// There are two possibilities:
 	// - We use a KMS -> There must be a key ID and a KMS data key.
 	// - We use a K/V -> There must be no key ID and no KMS data key.
 	// Otherwise, the metadata is corrupted.

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -557,7 +557,7 @@ func checkFailedUnlocks(locks []string, tolerance int) bool {
 	// caller know that lock is not successfully released
 	// yet.
 	if len(locks)-tolerance == tolerance {
-		// Incase of split brain scenarios where
+		// In case of split brain scenarios where
 		// tolerance is exactly half of the len(*locks)
 		// then we need to make sure we have unlocked
 		// upto tolerance+1 - especially for RUnlock

--- a/internal/etag/etag.go
+++ b/internal/etag/etag.go
@@ -102,7 +102,7 @@
 // (case-sensitive) and will fail otherwise.
 // Further, some clients require that the ETag value is a double-quoted
 // string. Therefore, this package provides dedicated functions for
-// adding and extracing the ETag to/from HTTP headers.
+// adding and extracting the ETag to/from HTTP headers.
 package etag
 
 import (

--- a/internal/etag/reader.go
+++ b/internal/etag/reader.go
@@ -52,7 +52,7 @@ func (r wrapReader) ETag() ETag {
 // returns ETag of the content. Otherwise, it returns
 // nil as ETag.
 //
-// Wrap provides an adapter for io.Reader implemetations
+// Wrap provides an adapter for io.Reader implementations
 // that don't implement the Tagger interface.
 // It is mainly used to provide a high-level io.Reader
 // access to the ETag computed by a low-level io.Reader:

--- a/internal/event/rules.go
+++ b/internal/event/rules.go
@@ -99,7 +99,7 @@ func (rules Rules) Union(rules2 Rules) Rules {
 	return nrules
 }
 
-// Difference - returns diffrence with given rules as new rules.
+// Difference - returns difference with given rules as new rules.
 func (rules Rules) Difference(rules2 Rules) Rules {
 	nrules := make(Rules)
 

--- a/internal/event/target/elasticsearch.go
+++ b/internal/event/target/elasticsearch.go
@@ -71,7 +71,7 @@ const (
 	ESSUnknown ESSupportStatus = "ESSUnknown"
 	// ESSDeprecated -> support will be removed in future
 	ESSDeprecated ESSupportStatus = "ESSDeprecated"
-	// ESSUnsupported -> we wont work with this ES server
+	// ESSUnsupported -> we won't work with this ES server
 	ESSUnsupported ESSupportStatus = "ESSUnsupported"
 	// ESSSupported -> all good!
 	ESSSupported ESSupportStatus = "ESSSupported"

--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -324,7 +324,7 @@ func (target *KafkaTarget) Close() error {
 	return nil
 }
 
-// Check if atleast one broker in cluster is active
+// Check if at least one broker in cluster is active
 func (k KafkaArgs) pingBrokers() (err error) {
 	d := net.Dialer{Timeout: 1 * time.Second}
 
@@ -460,6 +460,6 @@ func NewKafkaTarget(id string, args KafkaArgs, loggerOnce logger.LogOnce) (*Kafk
 }
 
 func isKafkaConnErr(err error) bool {
-	// Sarama opens the ciruit breaker after 3 consecutive connection failures.
+	// Sarama opens the circuit breaker after 3 consecutive connection failures.
 	return err == sarama.ErrLeaderNotAvailable || err.Error() == "circuit breaker is open"
 }

--- a/internal/event/targetidset.go
+++ b/internal/event/targetidset.go
@@ -50,7 +50,7 @@ func (set TargetIDSet) Union(sset TargetIDSet) TargetIDSet {
 	return nset
 }
 
-// Difference - returns diffrence with given set as new set.
+// Difference - returns difference with given set as new set.
 func (set TargetIDSet) Difference(sset TargetIDSet) TargetIDSet {
 	nset := NewTargetIDSet()
 	for k := range set {

--- a/internal/hash/checksum.go
+++ b/internal/hash/checksum.go
@@ -166,7 +166,7 @@ func (c ChecksumType) Hasher() hash.Hash {
 	return nil
 }
 
-// Trailing return whether the checksum is traling.
+// Trailing return whether the checksum is trailing.
 func (c ChecksumType) Trailing() bool {
 	return c.Is(ChecksumTrailing)
 }

--- a/internal/http/close.go
+++ b/internal/http/close.go
@@ -27,11 +27,11 @@ import (
 // convenient wrapper to drain any remaining data on response body.
 //
 // Subsequently this allows golang http RoundTripper
-// to re-use the same connection for future requests.
+// to reuse the same connection for future requests.
 func DrainBody(respBody io.ReadCloser) {
 	// Callers should close resp.Body when done reading from it.
 	// If resp.Body is not closed, the Client's underlying RoundTripper
-	// (typically Transport) may not be able to re-use a persistent TCP
+	// (typically Transport) may not be able to reuse a persistent TCP
 	// connection to the server for a subsequent "keep-alive" request.
 	if respBody != nil {
 		// Drain any remaining Body and then close the connection.

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -112,7 +112,7 @@ const (
 	// Dummy putBucketACL
 	AmzACL = "x-amz-acl"
 
-	// Signature V4 related contants.
+	// Signature V4 related constants.
 	AmzContentSha256        = "X-Amz-Content-Sha256"
 	AmzDate                 = "X-Amz-Date"
 	AmzAlgorithm            = "X-Amz-Algorithm"

--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -32,7 +32,7 @@ type acceptResult struct {
 
 // httpListener - HTTP listener capable of handling multiple server addresses.
 type httpListener struct {
-	tcpListeners []*net.TCPListener // underlaying TCP listeners.
+	tcpListeners []*net.TCPListener // underlying TCP listeners.
 	acceptCh     chan acceptResult  // channel where all TCP listeners write accepted connection.
 	ctx          context.Context
 	ctxCanceler  context.CancelFunc

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -109,7 +109,7 @@ func (srv *Server) Init(listenCtx context.Context, listenErrCallback func(listen
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// If server is in shutdown.
 		if atomic.LoadUint32(&srv.inShutdown) != 0 {
-			// To indicate disable keep-alives
+			// To indicate disable keep-alive
 			w.Header().Set("Connection", "close")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			w.Write([]byte(http.ErrServerClosed.Error()))

--- a/internal/ioutil/ioutil.go
+++ b/internal/ioutil/ioutil.go
@@ -312,7 +312,7 @@ var copyBufPool = sync.Pool{
 	},
 }
 
-// Copy is exactly like io.Copy but with re-usable buffers.
+// Copy is exactly like io.Copy but with reusable buffers.
 func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
 	bufp := copyBufPool.Get().(*[]byte)
 	buf := *bufp

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -77,7 +77,7 @@ type Config struct {
 	LogOnce func(ctx context.Context, err error, id string, errKind ...interface{}) `json:"-"`
 }
 
-// Check if atleast one broker in cluster is active
+// Check if at least one broker in cluster is active
 func (k Config) pingBrokers() (err error) {
 	d := net.Dialer{Timeout: 1 * time.Second}
 

--- a/internal/mountinfo/mountinfo_linux_test.go
+++ b/internal/mountinfo/mountinfo_linux_test.go
@@ -34,7 +34,7 @@ func TestCrossDeviceMountPaths(t *testing.T) {
 	successCase := `/dev/0 /path/to/0/1 type0 flags 0 0
 		/dev/1    /path/to/1   type1	flags 1 1
 		/dev/2 /path/to/1/2 type2 flags,1,2=3 2 2
-                /dev/3 /path/to/1.1 type3 falgs,1,2=3 3 3
+                /dev/3 /path/to/1.1 type3 flags,1,2=3 3 3
 		`
 	var err error
 	dir := t.TempDir()
@@ -83,7 +83,7 @@ func TestCrossDeviceMount(t *testing.T) {
 	successCase := `/dev/0 /path/to/0/1 type0 flags 0 0
 		/dev/1    /path/to/1   type1	flags 1 1
 		/dev/2 /path/to/1/2 type2 flags,1,2=3 2 2
-                /dev/3 /path/to/1.1 type3 falgs,1,2=3 3 3
+                /dev/3 /path/to/1.1 type3 flags,1,2=3 3 3
 		`
 	var err error
 	dir := t.TempDir()

--- a/internal/pubsub/pubsub_test.go
+++ b/internal/pubsub/pubsub_test.go
@@ -194,7 +194,7 @@ func TestMultiPubSubMask(t *testing.T) {
 
 	select {
 	case msg := <-ch3:
-		t.Fatalf(fmt.Sprintf("unexpect msg, f got %s", msg))
+		t.Fatalf(fmt.Sprintf("unexpected msg, f got %s", msg))
 	default:
 	}
 }

--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -125,7 +125,7 @@ func removeEmptyPort(host string) string {
 	return host
 }
 
-// Copied from http.NewRequest but implemented to ensure we re-use `url.URL` instance.
+// Copied from http.NewRequest but implemented to ensure we reuse `url.URL` instance.
 func (c *Client) newRequest(ctx context.Context, u url.URL, body io.Reader) (*http.Request, error) {
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {

--- a/internal/s3select/sql/parser_test.go
+++ b/internal/s3select/sql/parser_test.go
@@ -41,7 +41,7 @@ func TestJSONPathElement(t *testing.T) {
 		// Index
 		"[2]", "[0]", "[100]",
 
-		// Object wilcard
+		// Object wildcard
 		".*",
 
 		// array wildcard


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add codespell config, workflow (just to detect, not to fix) and use [codespell](https://github.com/codespell-project/codespell) to auto-fix typos

## Motivation and Context

- "typos free" world domination: introduced [codespell](https://github.com/codespell-project/codespell) to dozens if not hundreds of projects so far. Amazed with how robust it is.
- saw that `codespell` already used in minio-py

## How to test this PR?

- review
- ensure no side effects detected by CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
