### PR TITLE
Pass SUBNET URL to console

### DIFF
--- a/cmd/callhome.go
+++ b/cmd/callhome.go
@@ -157,15 +157,11 @@ func performCallhome(ctx context.Context) {
 }
 
 const (
-	healthURL    = "https://subnet.min.io/api/health/upload"
-	healthURLDev = "http://localhost:9000/api/health/upload"
+	subnetHealthPath = "/api/health/upload"
 )
 
 func sendHealthInfo(ctx context.Context, healthInfo madmin.HealthInfo) error {
-	url := healthURL
-	if globalIsCICD {
-		url = healthURLDev
-	}
+	url := globalSubnetConfig.BaseURL + subnetHealthPath
 
 	filename := fmt.Sprintf("health_%s.json.gz", UTCNow().Format("20060102150405"))
 	url += "?filename=" + filename

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -631,7 +631,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		if err != nil {
 			logger.LogIf(ctx, fmt.Errorf("Unable to parse subnet configuration: %w", err))
 		} else {
-			globalSubnetConfig.Update(subnetConfig)
+			globalSubnetConfig.Update(subnetConfig, globalIsCICD)
 			globalSubnetConfig.ApplyEnv() // update environment settings for Console UI
 		}
 	case config.CallhomeSubSys:

--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -29,8 +29,7 @@ import (
 
 const (
 	licUpdateCycle = 24 * time.Hour * 30
-	licRenewURL    = "https://subnet.min.io/api/cluster/renew-license"
-	licRenewURLDev = "http://localhost:9000/api/cluster/renew-license"
+	licRenewPath   = "/api/cluster/renew-license"
 )
 
 // initlicenseUpdateJob start the periodic license update job in the background.
@@ -82,10 +81,7 @@ func licenceUpdaterLoop(ctx context.Context, objAPI ObjectLayer) {
 func performLicenseUpdate(ctx context.Context, objectAPI ObjectLayer) {
 	// the subnet license renewal api renews the license only
 	// if required e.g. when it is expiring soon
-	url := licRenewURL
-	if globalIsCICD {
-		url = licRenewURLDev
-	}
+	url := globalSubnetConfig.BaseURL + licRenewPath
 
 	resp, err := globalSubnetConfig.Post(url, nil)
 	if err != nil {


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

When minio is running with MINIO_CI_CD=on, it is expected to communicate with the locally running SUBNET. This is happening in case of minio code like callhome, however the subnet related functionality inside the console continues to talk to SUBNET production URL. Because of this, console cannot be tested with a locally running SUBNET.

Fix this by setting the env variable CONSOLE_SUBNET_URL correctly in such cases. (console already has code to use the value of this variable as the subnet URL)

## Motivation and Context

Ability to test console with locally running SUBNET during development.

## How to test this PR?

- Create a new cluster by running minio with `MINIO_CI_CD=on` (on a port other than 9000)
- Start SUBNET locally
- Try to register the cluster from the console UI, providing api-key / user-credentials of a customer in the locally running SUBNET
- Verify that the registration goes through
- Verify that the `License` page shows correct license for the customer

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
