### PR TITLE
Relax batch size limit for kafka events

### DIFF
--- a/internal/event/target/kafka.go
+++ b/internal/event/target/kafka.go
@@ -75,8 +75,6 @@ const (
 	EnvKafkaClientTLSKey  = "MINIO_NOTIFY_KAFKA_CLIENT_TLS_KEY"
 	EnvKafkaVersion       = "MINIO_NOTIFY_KAFKA_VERSION"
 	EnvKafkaBatchSize     = "MINIO_NOTIFY_KAFKA_BATCH_SIZE"
-
-	maxBatchLimit = 100
 )
 
 // KafkaArgs - Kafka target arguments.
@@ -130,9 +128,6 @@ func (k KafkaArgs) Validate() error {
 	if k.BatchSize > 1 {
 		if k.QueueDir == "" {
 			return errors.New("batch should be enabled only if queue dir is enabled")
-		}
-		if k.BatchSize > maxBatchLimit {
-			return fmt.Errorf("batch limit should not exceed %d", maxBatchLimit)
 		}
 	}
 	return nil


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This patch relaxes the maximum batch limit check while setting batch_size in kafka notification target


## Motivation and Context

Fixes #18490

## How to test this PR?

by setting the batch_size greater than 100

for example,

```sh
mc admin config set myminio notify_kafka enable=on topic=quickstart-events brokers=localhost:9092 queue_dir=/tmp/events batch_size=1000
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
