### PR TITLE
DiskInfo() must return errDiskNotFound not internal errors

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -31,7 +31,6 @@ import (
 	"github.com/minio/minio/internal/color"
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/config/storageclass"
-	"github.com/minio/minio/internal/grid"
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/v2/sync/errgroup"
@@ -391,7 +390,7 @@ func saveFormatErasure(disk StorageAPI, format *formatErasureV3, healID string) 
 func loadFormatErasure(disk StorageAPI) (format *formatErasureV3, err error) {
 	// Ensure that the grid is online.
 	if _, err := disk.DiskInfo(context.Background(), false); err != nil {
-		if errors.Is(err, grid.ErrDisconnected) {
+		if errors.Is(err, errDiskNotFound) {
 			return nil, err
 		}
 	}

--- a/cmd/lock-rest-client.go
+++ b/cmd/lock-rest-client.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/minio/minio/internal/dsync"
 	"github.com/minio/minio/internal/grid"
-	"github.com/minio/minio/internal/logger"
 )
 
 // lockRESTClient is authenticable lock REST client
@@ -54,7 +53,6 @@ func (c *lockRESTClient) String() string {
 func (c *lockRESTClient) call(ctx context.Context, h *grid.SingleHandler[*dsync.LockArgs, *dsync.LockResp], args *dsync.LockArgs) (ok bool, err error) {
 	r, err := h.Call(ctx, c.connection, args)
 	if err != nil {
-		logger.LogIfNot(ctx, err, grid.ErrDisconnected)
 		return false, err
 	}
 	defer h.PutResponse(r)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -270,7 +270,7 @@ func (client *storageRESTClient) DiskInfo(ctx context.Context, metrics bool) (in
 		// were attempted. This can lead to false success under certain conditions
 		// - this change attempts to avoid stale information if the underlying
 		// transport is already down.
-		return info, grid.ErrDisconnected
+		return info, errDiskNotFound
 	}
 	fetchDI := func(di *timedValue, metrics bool) {
 		di.TTL = time.Second


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
DiskInfo() must return errDiskNotFound, not internal errors

## Motivation and Context
callers of DiskInfo() are not expecting grid.ErrConnected,
convert it to errDiskNotFound instead.

## How to test this PR?
DiskInfo() returns incorrect errors when nodes are 
disconnected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
