### PR TITLE
Add detailed parameter tracing + custom prefix

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -732,7 +732,7 @@ func (s *storageRESTServer) DeleteVersionsHandler(w http.ResponseWriter, r *http
 	encoder.Encode(dErrsResp)
 }
 
-var storageRenameDataHandler = grid.NewSingleHandler[*RenameDataHandlerParams, *RenameDataResp](grid.HandlerRenamedata, func() *RenameDataHandlerParams {
+var storageRenameDataHandler = grid.NewSingleHandler[*RenameDataHandlerParams, *RenameDataResp](grid.HandlerRenameData, func() *RenameDataHandlerParams {
 	return &RenameDataHandlerParams{}
 }, func() *RenameDataResp {
 	return &RenameDataResp{}

--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -336,7 +336,7 @@ func (c *Connection) Request(ctx context.Context, h HandlerID, req []byte) ([]by
 		}
 		c.outgoing.Delete(client.MuxID)
 	}()
-	return client.traceRoundtrip(c.trace, h, req)
+	return client.traceRoundtrip(ctx, c.trace, h, req)
 }
 
 // Request allows to do a single remote request.
@@ -364,7 +364,7 @@ func (c *Subroute) Request(ctx context.Context, h HandlerID, req []byte) ([]byte
 		}
 		c.outgoing.Delete(client.MuxID)
 	}()
-	return client.traceRoundtrip(c.trace, h, req)
+	return client.traceRoundtrip(ctx, c.trace, h, req)
 }
 
 // NewStream creates a new stream.

--- a/internal/grid/handlers.go
+++ b/internal/grid/handlers.go
@@ -55,7 +55,7 @@ const (
 	HandlerUpdateMetadata
 	HandlerWriteMetadata
 	HandlerCheckParts
-	HandlerRenamedata
+	HandlerRenameData
 
 	// Add more above here ^^^
 	// If all handlers are used, the type of Handler can be changed.
@@ -63,6 +63,34 @@ const (
 	handlerTest
 	handlerTest2
 	handlerLast
+)
+
+// handlerPrefixes are prefixes for handler IDs used for tracing.
+// If a handler is not listed here, it will be traced with "grid" prefix.
+var handlerPrefixes = [handlerLast]string{
+	HandlerLockLock:        lockPrefix,
+	HandlerLockRLock:       lockPrefix,
+	HandlerLockUnlock:      lockPrefix,
+	HandlerLockRUnlock:     lockPrefix,
+	HandlerLockRefresh:     lockPrefix,
+	HandlerLockForceUnlock: lockPrefix,
+	HandlerWalkDir:         storagePrefix,
+	HandlerStatVol:         storagePrefix,
+	HandlerDiskInfo:        storagePrefix,
+	HandlerNSScanner:       storagePrefix,
+	HandlerReadXL:          storagePrefix,
+	HandlerReadVersion:     storagePrefix,
+	HandlerDeleteFile:      storagePrefix,
+	HandlerDeleteVersion:   storagePrefix,
+	HandlerUpdateMetadata:  storagePrefix,
+	HandlerWriteMetadata:   storagePrefix,
+	HandlerCheckParts:      storagePrefix,
+	HandlerRenameData:      storagePrefix,
+}
+
+const (
+	lockPrefix    = "lock"
+	storagePrefix = "storageR"
 )
 
 func init() {
@@ -364,6 +392,7 @@ func (h *SingleHandler[Req, Resp]) Call(ctx context.Context, c Requester, req Re
 	if err != nil {
 		return resp, err
 	}
+	ctx = context.WithValue(ctx, TraceParamsKey{}, req)
 	res, err := c.Request(ctx, h.id, payload)
 	PutByteBuffer(payload)
 	if err != nil {

--- a/internal/grid/handlers_string.go
+++ b/internal/grid/handlers_string.go
@@ -26,13 +26,13 @@ func _() {
 	_ = x[HandlerUpdateMetadata-15]
 	_ = x[HandlerWriteMetadata-16]
 	_ = x[HandlerCheckParts-17]
-	_ = x[HandlerRenamedata-18]
+	_ = x[HandlerRenameData-18]
 	_ = x[handlerTest-19]
 	_ = x[handlerTest2-20]
 	_ = x[handlerLast-21]
 }
 
-const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenamedatahandlerTesthandlerTest2handlerLast"
+const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenameDatahandlerTesthandlerTest2handlerLast"
 
 var _HandlerID_index = [...]uint8{0, 14, 22, 31, 41, 52, 63, 78, 85, 92, 100, 109, 115, 126, 136, 149, 163, 176, 186, 196, 207, 219, 230}
 

--- a/internal/grid/trace.go
+++ b/internal/grid/trace.go
@@ -18,19 +18,27 @@
 package grid
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio/internal/pubsub"
 )
 
+// TraceParamsKey allows to pass trace parameters to the request via context.
+// This is only needed when un-typed requests are used.
+// MSS, map[string]string types are preferred, but any struct with exported fields will work.
+type TraceParamsKey struct{}
+
 // traceRequests adds request tracing to the connection.
 func (c *Connection) traceRequests(p *pubsub.PubSub[madmin.TraceInfo, madmin.TraceType]) {
 	c.trace = &tracer{
 		Publisher: p,
 		TraceType: madmin.TraceInternal,
-		Prefix:    "grid.",
+		Prefix:    "grid",
 		Local:     c.Local,
 		Remote:    c.Remote,
 		Subroute:  "",
@@ -56,7 +64,7 @@ type tracer struct {
 	Subroute  string
 }
 
-func (c *muxClient) traceRoundtrip(t *tracer, h HandlerID, req []byte) ([]byte, error) {
+func (c *muxClient) traceRoundtrip(ctx context.Context, t *tracer, h HandlerID, req []byte) ([]byte, error) {
 	if t == nil || t.Publisher.NumSubscribers(t.TraceType) == 0 {
 		return c.roundtrip(h, req)
 	}
@@ -74,9 +82,14 @@ func (c *muxClient) traceRoundtrip(t *tracer, h HandlerID, req []byte) ([]byte, 
 			status = http.StatusBadRequest
 		}
 	}
+
+	prefix := t.Prefix
+	if p := handlerPrefixes[h]; p != "" {
+		prefix = p
+	}
 	trace := madmin.TraceInfo{
 		TraceType: t.TraceType,
-		FuncName:  t.Prefix + h.String(),
+		FuncName:  prefix + "." + h.String(),
 		NodeName:  t.Local,
 		Time:      start,
 		Duration:  end.Sub(start),
@@ -104,6 +117,21 @@ func (c *muxClient) traceRoundtrip(t *tracer, h HandlerID, req []byte) ([]byte, 
 				TimeToFirstByte: end.Sub(start),
 			},
 		},
+	}
+	// If the context contains a TraceParamsKey, add it to the trace path.
+	v := ctx.Value(TraceParamsKey{})
+	if p, ok := v.(*MSS); ok && p != nil {
+		trace.Path = trace.Path + p.ToQuery()
+		trace.HTTP.ReqInfo.Path = trace.Path
+	} else if p, ok := v.(map[string]string); ok {
+		m := MSS(p)
+		trace.Path = trace.Path + m.ToQuery()
+		trace.HTTP.ReqInfo.Path = trace.Path
+	} else if v != nil {
+		// Print exported fields as single request to path.
+		p := fmt.Sprintf("%+v", v)
+		trace.Path = fmt.Sprintf("%s?req=%s", trace.Path, url.QueryEscape(p))
+		trace.HTTP.ReqInfo.Path = trace.Path
 	}
 	t.Publisher.Publish(trace)
 	return resp, err

--- a/internal/grid/trace.go
+++ b/internal/grid/trace.go
@@ -121,16 +121,15 @@ func (c *muxClient) traceRoundtrip(ctx context.Context, t *tracer, h HandlerID, 
 	// If the context contains a TraceParamsKey, add it to the trace path.
 	v := ctx.Value(TraceParamsKey{})
 	if p, ok := v.(*MSS); ok && p != nil {
-		trace.Path = trace.Path + p.ToQuery()
+		trace.Path += p.ToQuery()
 		trace.HTTP.ReqInfo.Path = trace.Path
 	} else if p, ok := v.(map[string]string); ok {
 		m := MSS(p)
-		trace.Path = trace.Path + m.ToQuery()
+		trace.Path += m.ToQuery()
 		trace.HTTP.ReqInfo.Path = trace.Path
 	} else if v != nil {
 		// Print exported fields as single request to path.
-		p := fmt.Sprintf("%+v", v)
-		trace.Path = fmt.Sprintf("%s?req=%s", trace.Path, url.QueryEscape(p))
+		trace.Path = fmt.Sprintf("%s?req=%s", trace.Path, url.QueryEscape(fmt.Sprintf("%+v", v)))
 		trace.HTTP.ReqInfo.Path = trace.Path
 	}
 	t.Publisher.Publish(trace)

--- a/internal/grid/types.go
+++ b/internal/grid/types.go
@@ -19,6 +19,9 @@ package grid
 
 import (
 	"errors"
+	"net/url"
+	"sort"
+	"strings"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -115,6 +118,31 @@ func NewMSS() *MSS {
 func NewMSSWith(m map[string]string) *MSS {
 	m2 := MSS(m)
 	return &m2
+}
+
+// ToQuery constructs a URL query string from the MSS, including "?" if there are any keys.
+func (m MSS) ToQuery() string {
+	if len(m) == 0 {
+		return ""
+	}
+	var buf strings.Builder
+	buf.WriteByte('?')
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := m[k]
+		keyEscaped := url.QueryEscape(k)
+		if buf.Len() > 1 {
+			buf.WriteByte('&')
+		}
+		buf.WriteString(keyEscaped)
+		buf.WriteByte('=')
+		buf.WriteString(url.QueryEscape(v))
+	}
+	return buf.String()
 }
 
 // NewBytes returns a new Bytes.


### PR DESCRIPTION
## Description

* Allow per handler custom prefix.
* Add automatic parameter extraction

Example with `map[string]string` request:

```
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s2/d2?disk-id=2bd68ef2-d382-4207-beeb-5c70273c4a63&metrics=false http://127.0.0.1:9002        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s2/d4?disk-id=c4a57da3-2c03-4b0f-923f-4c1ac95c3522&metrics=false http://127.0.0.1:9002        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s1/d2?disk-id=f724f1a4-6626-415d-8071-6feb7fe0744d&metrics=false http://127.0.0.1:9001        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s2/d1?disk-id=9801aca8-a56e-4ce1-92fc-55afacad1d9c&metrics=false http://127.0.0.1:9002        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s3/d1?disk-id=8f8f6457-4b3f-44de-a3a4-c0b91143c527&metrics=false http://127.0.0.1:9003        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s3/d3?disk-id=2c55b3d7-5962-44e2-ac2a-7d33d076fe5b&metrics=false http://127.0.0.1:9003        0s           ⇣  0s         ↑ 61 B ↓ 225 B
2023-11-24T11:56:35.070 [200 OK] storageR.DiskInfo http://127.0.0.1:9005/data/distxl-big/s3/d2?disk-id=207e81f3-6dfa-4fb2-9767-fb68225ae792&metrics=false http://127.0.0.1:9003        0s           ⇣  0s         ↑ 61 B ↓ 225 B
```

Example with custom struct:

```
2023-11-24T11:56:34.501 [200 OK] lock.LockRLock http://127.0.0.1:9004?req=%26%7BUID%3A0747a4f6-b1c1-46a3-aca2-5f28958332e0+Resources%3A%5B.minio.sys%2Fconfig%2Fiam%2Fusers%2Ffoobar-admin%2Fidentity.json%5D+Source%3A%5Berasure-object.go%3A205%3AerasureObjects.GetObjectNInfo%28%29%5D+Owner%3A127.0.0.1%3A9004+Quorum%3A2%7D http://127.0.0.1:9006        0s           ⇣  0s         ↑ 203 B ↓ 12 B
2023-11-24T11:56:34.501 [200 OK] lock.LockRLock http://127.0.0.1:9004?req=%26%7BUID%3A0747a4f6-b1c1-46a3-aca2-5f28958332e0+Resources%3A%5B.minio.sys%2Fconfig%2Fiam%2Fusers%2Ffoobar-admin%2Fidentity.json%5D+Source%3A%5Berasure-object.go%3A205%3AerasureObjects.GetObjectNInfo%28%29%5D+Owner%3A127.0.0.1%3A9004+Quorum%3A2%7D http://127.0.0.1:9005        0s           ⇣  0s         ↑ 203 B ↓ 12 B
2023-11-24T11:56:34.501 [200 OK] lock.LockRUnlock http://127.0.0.1:9004?req=%26%7BUID%3A0747a4f6-b1c1-46a3-aca2-5f28958332e0+Resources%3A%5B.minio.sys%2Fconfig%2Fiam%2Fusers%2Ffoobar-admin%2Fidentity.json%5D+Source%3A+Owner%3A127.0.0.1%3A9004+Quorum%3A0%7D http://127.0.0.1:9005        0s           ⇣  0s         ↑ 147 B ↓ 12 B
2023-11-24T11:56:34.501 [200 OK] lock.LockRUnlock http://127.0.0.1:9004?req=%26%7BUID%3A0747a4f6-b1c1-46a3-aca2-5f28958332e0+Resources%3A%5B.minio.sys%2Fconfig%2Fiam%2Fusers%2Ffoobar-admin%2Fidentity.json%5D+Source%3A+Owner%3A127.0.0.1%3A9004+Quorum%3A0%7D http://127.0.0.1:9006        0s           ⇣  0s         ↑ 147 B ↓ 12 B
```

After decoding URL value:

```
lock.LockRLock http://127.0.0.1:9004?req=&{UID:0747a4f6-b1c1-46a3-aca2-5f28958332e0 Resources:[.minio.sys/config/iam/users/foobar-admin/identity.json] Source:[erasure-object.go:205:erasureObjects.GetObjectNInfo()] Owner:127.0.0.1:9004 Quorum:2}
```

## Motivation and Context

More detailed tracing

## How to test this PR?

Start minio. Use `mc admin trace --call=internal myminio`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
