### PR TITLE
Skip versions expired by DeleteAllVersionsAction

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -477,7 +477,7 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 			item.heal.enabled = item.heal.enabled && f.healObjectSelect > 0
 
 			sz, err := f.getSize(item)
-			if err != nil {
+			if err != nil && err != errIgnoreFileContrib {
 				wait() // wait to proceed to next entry.
 				if err != errSkipFile && f.dataUsageScannerDebug {
 					console.Debugf(scannerLogPrefix+" getSize \"%v/%v\" returned err: %v\n", bucket, item.objectPath(), err)
@@ -495,8 +495,10 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 			// object.
 			delete(abandonedChildren, pathJoin(item.bucket, item.objectPath()))
 
-			into.addSizes(sz)
-			into.Objects++
+			if err != errIgnoreFileContrib {
+				into.addSizes(sz)
+				into.Objects++
+			}
 
 			wait() // wait to proceed to next entry.
 

--- a/cmd/storage-errors.go
+++ b/cmd/storage-errors.go
@@ -118,6 +118,8 @@ var errDoneForNow = errors.New("done for now")
 // to proceed to next entry.
 var errSkipFile = errors.New("skip this file")
 
+var errIgnoreFileContrib = errors.New("ignore this file's contribution toward data-usage")
+
 // errXLBackend XL drive mode requires fresh deployment.
 var errXLBackend = errors.New("XL backend requires fresh drive")
 

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -653,7 +653,7 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 			}
 		}
 		if objDeleted {
-			// we return errSkipFile to signal this function's
+			// we return errIgnoreFileContrib to signal this function's
 			// callers to skip this object's contribution towards
 			// usage.
 			return sizeSummary{}, errIgnoreFileContrib

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -656,7 +656,7 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 			// we return errSkipFile to signal this function's
 			// callers to skip this object's contribution towards
 			// usage.
-			return sizeSummary{}, errSkipFile
+			return sizeSummary{}, errIgnoreFileContrib
 		}
 		return sizeS, nil
 	}, scanMode)


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Object versions expired by `DeleteAllVersionsAction` must not be included toward data-usage accounting. Also, current object versions expired via `DeleteAction`, in a versioned bucket, must not be removed from data-usage accounting as this results in a delete marker on top of the 'expired' version.

## Motivation and Context
Objects expired by `DeleteAllVersionsAction` (MinIO extension) could be accounted incorrectly as non-versioned objects. This could happen when an object has exactly one version at the time of such expiry. 

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
