### PR TITLE
Fixed transition rules getting overwritten while healing

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -6095,8 +6095,11 @@ func mergeWithCurrentLCConfig(ctx context.Context, bucket string, expLCCfg *stri
 		// else simply add to the map. This may happen if ILM expiry replication
 		// was disabled for sometime and rules were updated independently in different
 		// sites. Latest changes would get applied but merge only the non transition details
-		if _, ok := rMap[id]; ok {
-			rMap[id] = rl.CloneNonTransition()
+		if existingRl, ok := rMap[id]; ok {
+			clonedRl := rl.CloneNonTransition()
+			clonedRl.Transition = existingRl.Transition
+			clonedRl.NoncurrentVersionTransition = existingRl.NoncurrentVersionTransition
+			rMap[id] = clonedRl
 		} else {
 			rMap[id] = rl
 		}

--- a/docs/bucket/replication/setup_ilm_expiry_replication.sh
+++ b/docs/bucket/replication/setup_ilm_expiry_replication.sh
@@ -204,7 +204,7 @@ fi
 
 ## Check to make sure sitea transition rule is not overwritten
 transDays=$(./mc ilm rule list sitea/bucket --json | jq '.config.Rules[0].Transition.Days')
-if [ $transDays -ne 0 ] || [ "${transDays}" == "null" ] ; then
+if [ $transDays -ne 0 ] || [ "${transDays}" == "null" ]; then
 	echo "BUG: Transition rule on sitea seems to be overwritten"
 	exit 1
 fi

--- a/docs/bucket/replication/setup_ilm_expiry_replication.sh
+++ b/docs/bucket/replication/setup_ilm_expiry_replication.sh
@@ -109,6 +109,25 @@ if [ $count -ne 1 ]; then
 	exit 1
 fi
 
+## Check replication of rules content
+expDays=$(./mc ilm rule list siteb/bucket --json | jq '.config.Rules[0].Expiration.Days')
+noncurrentDays=$(./mc ilm rule list siteb/bucket --json | jq '.config.Rules[0].NoncurrentVersionExpiration.NoncurrentDays')
+if [ $expDays -ne 3 ]; then
+	echo "BUG: Incorrect expiry days '${expDays}' set for 'siteb'"
+	exit 1
+fi
+if [ $noncurrentDays -ne 2 ]; then
+	echo "BUG: Incorrect non current expiry days '${noncurrentDays}' set for siteb"
+	exit 1
+fi
+
+## Make sure transition rule not replicated to siteb
+tranDays=$(./mc ilm rule list siteb/bucket --json | jq '.config.Rules[0].Transition.Days')
+if [ "${tranDays}" != "null" ]; then
+	echo "BUG: Transition rules as well copied to siteb"
+	exit 1
+fi
+
 ## Check replication of rules prefix and tags
 prefix=$(./mc ilm rule list siteb/bucket --json | jq '.config.Rules[0].Filter.And.Prefix' | sed 's/"//g')
 tagName1=$(./mc ilm rule list siteb/bucket --json | jq '.config.Rules[0].Filter.And.Tags[0].Key' | sed 's/"//g')
@@ -180,6 +199,13 @@ if [ $count1 -ne 888 ]; then
 fi
 if [ $count2 -ne 888 ]; then
 	echo "BUG: Latest expiration days not updated on 'siteb'"
+	exit 1
+fi
+
+## Check to make sure sitea transition rule is not overwritten
+transDays=$(./mc ilm rule list sitea/bucket --json | jq '.config.Rules[0].Transition.Days')
+if [ $transDays -ne 0 ] || [ "${transDays}" == "null" ] ; then
+	echo "BUG: Transition rule on sitea seems to be overwritten"
 	exit 1
 fi
 


### PR DESCRIPTION
While healing the latest changes of expiry rules across sites if target had pre existing transition rules, they were getting overwritten as cloned latest expiry rules from remote site were getting written as is. Fixed the same and added test cases as well.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?
Follow below detailed steps for verifying the different scenarios 

**Step-1**: Create three MinIO sites sat `m1`, `m2` and `m3`

**Step-2**: Setup site replication between the first two sites now
`mc admin replicate add m1 m2 --replicate-ilm-expiry`

**Step-3**: Create a bucket for first site (`test-bucket`)
`mc mb m1/test-bucket`

**Step-4**: Setup warm tier to `m3` for site `m1`
```
$ ./mc mb m3/test-bucket
$ ./mc ilm tier add minio m1 WARM-TIER --endpoint http://localhost:9020 --access-key minioadmin --secret-key minioadmin --bucket test-bucket
```

**Step-5**: Check details of the replication
```
$ mc admin replicate info m1
SiteReplication enabled for:

Deployment ID                        | Site Name       | Endpoint                                       | Sync | Bandwidth  | ILM Expiry Replication
                                     |                 |                                                |      | Per Bucket |                     
9d3ba3d6-e1b0-4fe7-bd15-0119ead88cae | m1              | http://localhost:9000                          |      | N/A        | true                
56712687-d45e-4fbf-bc98-25e8d5b84c9b | m2              | http://localhost:9010                          |      | N/A        | true     

$ mc admin replicate info m2 
SiteReplication enabled for:

Deployment ID                        | Site Name       | Endpoint                                       | Sync | Bandwidth  | ILM Expiry Replication
                                     |                 |                                                |      | Per Bucket |                     
9d3ba3d6-e1b0-4fe7-bd15-0119ead88cae | m1              | http://localhost:9000                          |      | N/A        | true                
56712687-d45e-4fbf-bc98-25e8d5b84c9b | m2              | http://localhost:9010                          |      | N/A        | true                
```

**Step-6**: Add ILM rules to the first site's bucket `test-bucket`
```
$ ./mc ilm add m1/test-bucket --transition-days 0 --transition-tier WARM-TIER --transition-days 0 --noncurrent-expire-days 2 --expire-days 3 --prefix "shu" --tags "tag1=val1&tag2=val2&tag3=val3"
```

**Step-7**: Check ILM rules list for sites 
```
$ ./mc ilm rule list m1/test-bucket 
┌────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Transition for latest version (Transition)                                                         │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬──────────────┬───────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO TIER │ TIER      │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼──────────────┼───────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            0 │ WARM-TIER │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴──────────────┴───────────┘
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              3 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘

$ ./mc ilm rule list m2/test-bucket 
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              3 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘
```

**Step-8**: Check replication status details as below
```
$ ./mc admin replicate status m1
Bucket replication status:
●  1/1 Buckets in sync

Policy replication status:
●  5/5 Policies in sync

User replication status:
No Users present

Group replication status:
No Groups present

ILM Expiry Rules replication status:
●  1/1 ILM Expiry Rules in sync

Object replication status:
Replication status since 7 minutes 
Summary:
Replicated:    0 objects (0 B)
Queued:        ● 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
Received:      0 objects (0 B)

$ ./mc admin replicate status m2
Bucket replication status:
●  1/1 Buckets in sync

Policy replication status:
●  5/5 Policies in sync

User replication status:
No Users present

Group replication status:
No Groups present

ILM Expiry Rules replication status:
●  1/1 ILM Expiry Rules in sync

Object replication status:
Replication status since 8 minutes 
Summary:
Replicated:    0 objects (0 B)
Queued:        ● 0 objects, (0 B) (avg: 0 objects, 0 B; max: 0 objects, 0 B)
Received:      0 objects (0 B)

$ ./mc admin replicate status m1 --ilm-expiry-rules
ILM Expiry Rules replication status:
●  1/1 ILM Expiry Rules in sync

$ ./mc admin replicate status m1 --ilm-expiry-rule cksbdd5b4dtt2fpuur80 
●  ILM Expiry Rule replication summary for: cksbdd5b4dtt2fpuur80

ILMExpiryRule   | M1              | M2             
ILM Expiry Rule | ✔               | ✔  
```

**Step-9:** Disable replication of ILM expiry

```
$ ./mc admin replicate update m1 --disable-ilm-expiry-replication
Cluster replication configuration updated successfully with:
- replicate-ilm-expiry: false

$ ./mc admin replicate info m1
SiteReplication enabled for:

Deployment ID                        | Site Name       | Endpoint                                       | Sync | Bandwidth  | ILM Expiry Replication
                                     |                 |                                                |      | Per Bucket |                     
9d3ba3d6-e1b0-4fe7-bd15-0119ead88cae | m1              | http://localhost:9000                          |      | N/A        | false               
56712687-d45e-4fbf-bc98-25e8d5b84c9b | m2              | http://localhost:9010                          |      | N/A        | false                

$ ./mc admin replicate info m2
SiteReplication enabled for:

Deployment ID                        | Site Name       | Endpoint                                       | Sync | Bandwidth  | ILM Expiry Replication
                                     |                 |                                                |      | Per Bucket |                     
9d3ba3d6-e1b0-4fe7-bd15-0119ead88cae | m1              | http://localhost:9000                          |      | N/A        | false               
56712687-d45e-4fbf-bc98-25e8d5b84c9b | m2              | http://localhost:9010                          |      | N/A        | false                
```

**Step-10:** Separately edit rules in two sites

```
$ ./mc ilm edit --id "cl69k9db4dtnd3f3odm0" --expire-days "333" m1/test-bucket 
Lifecycle configuration rule with ID `cl69k9db4dtnd3f3odm0` modified  to m1/test-bucket.
$ ./mc ilm edit --id "cl69k9db4dtnd3f3odm0" --expire-days "444" m2/test-bucket
Lifecycle configuration rule with ID `cl69k9db4dtnd3f3odm0` modified  to m2/test-bucket.

$ ./mc ilm rule list m1/test-bucket 
┌────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Transition for latest version (Transition)                                                         │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬──────────────┬───────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO TIER │ TIER      │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼──────────────┼───────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            0 │ WARM-TIER │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴──────────────┴───────────┘
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            333 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘

$ ./mc ilm rule list m2/test-bucket 
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            444 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘
```

**Step-11:** Re-enable expiry of ILM rules and wait for few secs for healing of rules
```
$ ./mc admin replicate update m1 --enable-ilm-expiry-replicatione-ilm-expiry 
Cluster replication configuration updated successfully with:
- replicate-ilm-expiry: true

$ ./mc ilm rule list m1/test-bucket
┌────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Transition for latest version (Transition)                                                         │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬──────────────┬───────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO TIER │ TIER      │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼──────────────┼───────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            0 │ WARM-TIER │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴──────────────┴───────────┘
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            444 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘

$ ./mc ilm rule list m2/test-bucket 
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for latest version (Expiration)                                                                     │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬─────────────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ EXPIRE DELETEMARKER │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼─────────────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │            444 │ false               │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴─────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expiration for older versions (NoncurrentVersionExpiration)                                              │
├──────────────────────┬─────────┬────────┬───────────────────────────────┬────────────────┬───────────────┤
│ ID                   │ STATUS  │ PREFIX │ TAGS                          │ DAYS TO EXPIRE │ KEEP VERSIONS │
├──────────────────────┼─────────┼────────┼───────────────────────────────┼────────────────┼───────────────┤
│ cl69k9db4dtnd3f3odm0 │ Enabled │ shu    │ tag1=val1&tag2=val2&tag3=val3 │              2 │             0 │
└──────────────────────┴─────────┴────────┴───────────────────────────────┴────────────────┴───────────────┘
```

Verify that first site's transition rule is intact.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
