### PR TITLE
Always remove subroute when queuing message on the connection.

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -544,7 +544,10 @@ func (c *Connection) send(msg []byte) error {
 // queueMsg queues a message, with an optional payload.
 // sender should not reference msg.Payload
 func (c *Connection) queueMsg(msg message, payload sender) error {
-	msg.Flags |= c.baseFlags
+	// Add baseflags.
+	msg.Flags.Set(c.baseFlags)
+	// This cannot encode subroute.
+	msg.Flags.Clear(FlagSubroute)
 	if payload != nil {
 		if cap(msg.Payload) < payload.Msgsize() {
 			old := msg.Payload

--- a/internal/grid/msg.go
+++ b/internal/grid/msg.go
@@ -186,6 +186,16 @@ func (f Flags) String() string {
 	return "[" + strings.Join(res, ",") + "]"
 }
 
+// Set one or more flags on f.
+func (f *Flags) Set(flags Flags) {
+	*f |= flags
+}
+
+// Clear one or more flags on f.
+func (f *Flags) Clear(flags Flags) {
+	*f &^= flags
+}
+
 // parse an incoming message.
 func (m *message) parse(b []byte) (*subHandlerID, []byte, error) {
 	var sub *subHandlerID


### PR DESCRIPTION
## Description

Fix occasional ` ws parse package: want subroute len 32, got 0`.

## How to test this PR?

Seems like this happens when requests time out.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
