### PR TITLE
cleanup handling of STS isAllowed and simplifies the PolicyDBGet()

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -252,7 +252,7 @@ func (driver *ftpDriver) CheckPasswd(c *ftp.Context, username, password string) 
 		if err != nil {
 			return false, err
 		}
-		ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, groupDistNames...)
 		return len(ldapPolicies) > 0, nil
 	}
 
@@ -273,7 +273,7 @@ func (driver *ftpDriver) getMinIOClient(ctx *ftp.Context) (*minio.Client, error)
 		if err != nil {
 			return nil, err
 		}
-		ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, false, targetGroups...)
+		ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, targetGroups...)
 		if len(ldapPolicies) == 0 {
 			return nil, errAuthentication
 		}

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -655,7 +655,7 @@ func (store *IAMStoreSys) GroupNotificationHandler(ctx context.Context, group st
 
 // PolicyDBGet - fetches policies associated with the given user or group, and
 // additional groups if provided.
-func (store *IAMStoreSys) PolicyDBGet(name string, isGroup bool, groups ...string) ([]string, error) {
+func (store *IAMStoreSys) PolicyDBGet(name string, groups ...string) ([]string, error) {
 	if name == "" {
 		return nil, errInvalidArgument
 	}
@@ -663,19 +663,17 @@ func (store *IAMStoreSys) PolicyDBGet(name string, isGroup bool, groups ...strin
 	cache := store.rlock()
 	defer store.runlock()
 
-	policies, _, err := cache.policyDBGet(store, name, isGroup)
+	policies, _, err := cache.policyDBGet(store, name, false)
 	if err != nil {
 		return nil, err
 	}
 
-	if !isGroup {
-		for _, group := range groups {
-			ps, _, err := cache.policyDBGet(store, group, true)
-			if err != nil {
-				return nil, err
-			}
-			policies = append(policies, ps...)
+	for _, group := range groups {
+		ps, _, err := cache.policyDBGet(store, group, true)
+		if err != nil {
+			return nil, err
 		}
+		policies = append(policies, ps...)
 	}
 
 	return policies, nil
@@ -1218,6 +1216,9 @@ func (store *IAMStoreSys) GetPolicy(name string) (policy.Policy, error) {
 			return v.Policy, errNoSuchPolicy
 		}
 		toMerge = append(toMerge, v.Policy)
+	}
+	if len(toMerge) == 0 {
+		return policy.Policy{}, errNoSuchPolicy
 	}
 	return policy.MergePolicies(toMerge...), nil
 }

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1720,12 +1720,12 @@ func (sys *IAMSys) PolicyDBUpdateLDAP(ctx context.Context, isAttach bool,
 
 // PolicyDBGet - gets policy set on a user or group. If a list of groups is
 // given, policies associated with them are included as well.
-func (sys *IAMSys) PolicyDBGet(name string, isGroup bool, groups ...string) ([]string, error) {
+func (sys *IAMSys) PolicyDBGet(name string, groups ...string) ([]string, error) {
 	if !sys.Initialized() {
 		return nil, errServerNotInitialized
 	}
 
-	return sys.store.PolicyDBGet(name, isGroup, groups...)
+	return sys.store.PolicyDBGet(name, groups...)
 }
 
 const sessionPolicyNameExtracted = policy.SessionPolicyName + "-extracted"
@@ -1774,7 +1774,7 @@ func (sys *IAMSys) IsAllowedServiceAccount(args policy.Args, parentUser string) 
 
 	default:
 		// Check policy for parent user of service account.
-		svcPolicies, err = sys.PolicyDBGet(parentUser, false, args.Groups...)
+		svcPolicies, err = sys.PolicyDBGet(parentUser, args.Groups...)
 		if err != nil {
 			logger.LogIf(GlobalContext, err)
 			return false
@@ -1882,7 +1882,7 @@ func (sys *IAMSys) IsAllowedSTS(args policy.Args, parentUser string) bool {
 	default:
 		// Otherwise, inherit parent user's policy
 		var err error
-		policies, err = sys.store.PolicyDBGet(parentUser, false, args.Groups...)
+		policies, err = sys.store.PolicyDBGet(parentUser, args.Groups...)
 		if err != nil {
 			logger.LogIf(GlobalContext, fmt.Errorf("error fetching policies on %s: %v", parentUser, err))
 			return false
@@ -2019,7 +2019,7 @@ func (sys *IAMSys) IsAllowed(args policy.Args) bool {
 	}
 
 	// Continue with the assumption of a regular user
-	policies, err := sys.PolicyDBGet(args.AccountName, false, args.Groups...)
+	policies, err := sys.PolicyDBGet(args.AccountName, args.Groups...)
 	if err != nil {
 		return false
 	}

--- a/cmd/sftp-server.go
+++ b/cmd/sftp-server.go
@@ -114,7 +114,7 @@ func startSFTPServer(c *cli.Context) {
 				if err != nil {
 					return nil, err
 				}
-				ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, false, targetGroups...)
+				ldapPolicies, _ := globalIAMSys.PolicyDBGet(targetUser, targetGroups...)
 				if len(ldapPolicies) == 0 {
 					return nil, errAuthentication
 				}

--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -267,7 +267,7 @@ func (sts *stsAPIHandlers) AssumeRole(w http.ResponseWriter, r *http.Request) {
 
 	// Validate that user.AccessKey's policies can be retrieved - it may not
 	// be in case the user is disabled.
-	if _, err = globalIAMSys.PolicyDBGet(user.AccessKey, false); err != nil {
+	if _, err = globalIAMSys.PolicyDBGet(user.AccessKey, user.Groups...); err != nil {
 		writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue, err)
 		return
 	}
@@ -630,7 +630,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithLDAPIdentity(w http.ResponseWriter, r *
 	}
 
 	// Check if this user or their groups have a policy applied.
-	ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, groupDistNames...)
+	ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, groupDistNames...)
 	if len(ldapPolicies) == 0 && newGlobalAuthZPluginFn() == nil {
 		writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue,
 			fmt.Errorf("expecting a policy to be set for user `%s` or one of their groups: `%s` - rejecting this request",


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
cleanup handling of STS isAllowed and simplifies the PolicyDBGet()

## Motivation and Context
regular cleanup to avoid mistakes and also fix 

- TemporaryAccountInfo() did not honor groups for STS
- TemporaryAccountInfo() did not honor policies from claims when parent mapping is missing

## How to test this PR?
CI/CD should cover the tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
