### PR TITLE
Change console address port from 9001 to 9090, to keep consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ for more complete documentation.
 Run the following command to run the latest stable image of MinIO as a container using an ephemeral data volume:
 
 ```sh
-podman run -p 9000:9000 -p 9001:9001 \
-  quay.io/minio/minio server /data --console-address ":9001"
+podman run -p 9000:9000 -p 9090:9090 \
+  quay.io/minio/minio server /data --console-address ":9090"
 ```
 
 The MinIO deployment starts using default root credentials `minioadmin:minioadmin`. You can test the deployment using the MinIO Console, an embedded
@@ -151,10 +151,10 @@ For hosts with ufw enabled (Debian based distros), you can use `ufw` command to 
 ufw allow 9000
 ```
 
-Below command enables all incoming traffic to ports ranging from 9000 to 9010.
+Below command enables all incoming traffic to ports ranging from 9000 to 9090.
 
 ```sh
-ufw allow 9000:9010/tcp
+ufw allow 9000:9090/tcp
 ```
 
 ### firewall-cmd
@@ -187,10 +187,10 @@ iptables -A INPUT -p tcp --dport 9000 -j ACCEPT
 service iptables restart
 ```
 
-Below command enables all incoming traffic to ports ranging from 9000 to 9010.
+Below command enables all incoming traffic to ports ranging from 9000 to 9090.
 
 ```sh
-iptables -A INPUT -p tcp --dport 9000:9010 -j ACCEPT
+iptables -A INPUT -p tcp --dport 9000:9090 -j ACCEPT
 service iptables restart
 ```
 
@@ -208,7 +208,7 @@ MinIO redirects browser access requests to the configured server port (i.e. `127
 
 For deployments behind a load balancer, proxy, or ingress rule where the MinIO host IP address or port is not public, use the `MINIO_BROWSER_REDIRECT_URL` environment variable to specify the external hostname for the redirect. The LB/Proxy must have rules for directing traffic to the Console port specifically.
 
-For example, consider a MinIO deployment behind a proxy `https://minio.example.net`, `https://console.minio.example.net` with rules for forwarding traffic on port :9000 and :9001 to MinIO and the MinIO Console respectively on the internal network. Set `MINIO_BROWSER_REDIRECT_URL` to `https://console.minio.example.net` to ensure the browser receives a valid reachable URL.
+For example, consider a MinIO deployment behind a proxy `https://minio.example.net`, `https://console.minio.example.net` with rules for forwarding traffic on port :9000 and :9090 to MinIO and the MinIO Console respectively on the internal network. Set `MINIO_BROWSER_REDIRECT_URL` to `https://console.minio.example.net` to ensure the browser receives a valid reachable URL.
 
 Similarly, if your TLS certificates do not have the IP SAN for the MinIO server host, the MinIO Console may fail to validate the connection to the server. Use the `MINIO_SERVER_URL` environment variable  and specify the proxy-accessible hostname of the MinIO server to allow the Console to use the MinIO server API using the TLS certificate.
 


### PR DESCRIPTION
…th https://min.io/docs

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The console address port in readme is 9001, in min.io/docs is 9090

## Motivation and Context
To keep consistency, use 9090

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
