### PR TITLE
site replication must heal policy mappings with correct userType

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -2032,7 +2032,7 @@ func (c *SiteReplicationSys) syncToAllPeers(ctx context.Context, addOpts madmin.
 				Type: madmin.SRIAMItemPolicyMapping,
 				PolicyMapping: &madmin.SRPolicyMapping{
 					UserOrGroup: group,
-					UserType:    -1,
+					UserType:    int(unknownIAMUserType),
 					IsGroup:     true,
 					Policy:      mp.Policies,
 				},
@@ -3757,12 +3757,14 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 	if opts.Users || opts.Entity == madmin.SRUserEntity {
 		// Replicate policy mappings on local to all peers.
 		userPolicyMap := make(map[string]MappedPolicy)
+		stsPolicyMap := make(map[string]MappedPolicy)
+		svcPolicyMap := make(map[string]MappedPolicy)
 		if opts.Entity == madmin.SRUserEntity {
 			if mp, ok := globalIAMSys.store.GetMappedPolicy(opts.EntityValue, false); ok {
 				userPolicyMap[opts.EntityValue] = mp
 			}
 		} else {
-			stsErr := globalIAMSys.store.loadMappedPolicies(ctx, stsUser, false, userPolicyMap)
+			stsErr := globalIAMSys.store.loadMappedPolicies(ctx, stsUser, false, stsPolicyMap)
 			if stsErr != nil {
 				return info, errSRBackendIssue(stsErr)
 			}
@@ -3770,7 +3772,7 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 			if usrErr != nil {
 				return info, errSRBackendIssue(usrErr)
 			}
-			svcErr := globalIAMSys.store.loadMappedPolicies(ctx, svcUser, false, userPolicyMap)
+			svcErr := globalIAMSys.store.loadMappedPolicies(ctx, svcUser, false, svcPolicyMap)
 			if svcErr != nil {
 				return info, errSRBackendIssue(svcErr)
 			}
@@ -3780,6 +3782,25 @@ func (c *SiteReplicationSys) SiteReplicationMetaInfo(ctx context.Context, objAPI
 			info.UserPolicies[user] = madmin.SRPolicyMapping{
 				IsGroup:     false,
 				UserOrGroup: user,
+				UserType:    int(regUser),
+				Policy:      mp.Policies,
+				UpdatedAt:   mp.UpdatedAt,
+			}
+		}
+		for stsU, mp := range stsPolicyMap {
+			info.UserPolicies[stsU] = madmin.SRPolicyMapping{
+				IsGroup:     false,
+				UserOrGroup: stsU,
+				UserType:    int(stsUser),
+				Policy:      mp.Policies,
+				UpdatedAt:   mp.UpdatedAt,
+			}
+		}
+		for svcU, mp := range svcPolicyMap {
+			info.UserPolicies[svcU] = madmin.SRPolicyMapping{
+				IsGroup:     false,
+				UserOrGroup: svcU,
+				UserType:    int(svcUser),
 				Policy:      mp.Policies,
 				UpdatedAt:   mp.UpdatedAt,
 			}
@@ -5285,6 +5306,7 @@ func (c *SiteReplicationSys) healUserPolicies(ctx context.Context, objAPI Object
 			PolicyMapping: &madmin.SRPolicyMapping{
 				UserOrGroup: user,
 				IsGroup:     false,
+				UserType:    latestUserStat.userPolicy.UserType,
 				Policy:      latestUserStat.userPolicy.Policy,
 			},
 			UpdatedAt: lastUpdate,
@@ -5347,6 +5369,7 @@ func (c *SiteReplicationSys) healGroupPolicies(ctx context.Context, objAPI Objec
 			PolicyMapping: &madmin.SRPolicyMapping{
 				UserOrGroup: group,
 				IsGroup:     true,
+				UserType:    int(unknownIAMUserType),
 				Policy:      latestGroupStat.groupPolicy.Policy,
 			},
 			UpdatedAt: lastUpdate,


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
site replication must heal policy mappings with the correct userType

## Motivation and Context
userType information was missing, and all policy mappings 
are being treated as regular users, which can cause problems
when SSO gets involved, it has only STS users for the most 
part. Any changes to the STS policies get incorrectly 
remembered as a regular user, causing stale policies that 
are persisted. 

## How to test this PR?
Hard to test, but it is possible to setup Dex
and recreate this scenario, causing policy
evolution to fail. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
