### PR TITLE
Helm Chart: Add support for only one replica

### DIFF
--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -100,7 +100,7 @@ spec:
           command: [
             "/bin/sh",
             "-ce",
-            "/usr/bin/docker-entrypoint.sh minio server {{- range $i := until $poolCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{ else }}{{ $bucketRoot }}{{end }}{{- end }} -S {{ .Values.certsPath }} --address :{{ .Values.minioAPIPort }} --console-address :{{ .Values.minioConsolePort }} {{- template `minio.extraArgs` . }}"
+            "/usr/bin/docker-entrypoint.sh minio server {{- range $i := until $poolCount }}{{ $factor := mul $i $nodeCount }}{{ $endIndex := add $factor $nodeCount }}{{ $beginIndex := mul $i $nodeCount }}  {{ $scheme }}://{{ template `minio.fullname` $ }}-{{ if lt ($beginIndex) (sub $endIndex 1) }}{{ `{` }}{{ $beginIndex }}...{{ sub $endIndex 1 }}{{ `}`}}{{ else }}{{ $beginIndex }}{{ end }}.{{ template `minio.fullname` $ }}-svc.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}{{if (gt $drivesPerNode 1)}}{{ $bucketRoot }}-{{ `{` }}0...{{ sub $drivesPerNode 1 }}{{ `}` }}{{ else }}{{ $bucketRoot }}{{end }}{{- end }} -S {{ .Values.certsPath }} --address :{{ .Values.minioAPIPort }} --console-address :{{ .Values.minioConsolePort }} {{- template `minio.extraArgs` . }}"
           ]
           volumeMounts:
             {{- if $penabled }}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add support for only one replica in the helm chart

## Motivation and Context

using ``replicas: 1`` used to render something like this:
```
"/usr/bin/docker-entrypoint.sh minio server http://release-name-minio-{0...0}.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```

Where ``{0...0}`` is not supported by the minio server. Now extended with the if statement it will render out the following:
```
"/usr/bin/docker-entrypoint.sh minio server http://release-name-minio-0.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```

The line I edited is one big cluster fuck its basically looping over num pools and then creating a range for num replicas. And I added a additional if else statement in the loop saying it should not create a range if start and end are equal and instead just put the digit as is.

## How to test this PR?

I used the [helm template preview vscode extension](https://marketplace.visualstudio.com/items?itemName=VadzimNestsiarenka.helm-template-preview-and-more) to look at the rendered yaml. But any helm template renderer should work fine.

![image](https://github.com/minio/minio/assets/20344300/097d5919-eec5-4ea8-94ae-2c1b5f5ab753)

Then play with the ``pools:`` and ``replicas:`` amount and ensure it never produces invalid urls such as ``{0...0}`` while still maintaing multi pool support where every url is unique. Here a few examples so you don't have to do it:

The default
```yaml
replicas: 16
pools: 1
```
```
"/usr/bin/docker-entrypoint.sh minio server  http://release-name-minio-{0...15}.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```

The case im trying to fix which used to render {0...0}:
```yaml
replicas: 1
pools: 1
```
```
"/usr/bin/docker-entrypoint.sh minio server  http://release-name-minio-0.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```
Support for multiple pools is still kept:
```yaml
replicas: 1
pools: 2
```
```
 "/usr/bin/docker-entrypoint.sh minio server  http://release-name-minio-0.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export  http://release-name-minio-1.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```

And support for multi pool and multi node:
```yaml
replicas: 2
pools: 2
```
```
"/usr/bin/docker-entrypoint.sh minio server  http://release-name-minio-{0...1}.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export  http://release-name-minio-{2...3}.release-name-minio-svc.my-k8s-ns.svc.cluster.local/export -S /etc/minio/certs/ --address :9000 --console-address :9001"
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
