### PR TITLE
upon RenameData() quorum error delete any partial success

### DIFF
--- a/cmd/mrf.go
+++ b/cmd/mrf.go
@@ -97,7 +97,7 @@ func (m *mrfState) healRoutine() {
 				// let recently failed networks to reconnect
 				// making MRF wait for 1s before retrying,
 				// i.e 4 reconnect attempts.
-				time.Sleep(1 * time.Second)
+				time.Sleep(time.Second)
 			}
 
 			// wait on timer per heal


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
upon RenameData() quorum error, delete any partial success
attempt an MRF heal upon RenameData() to remove danglingWrites

## Motivation and Context
There is potential for danglingWrites when quorum fails, where
only some drives took a successful write. Generally, this is left
to the healing routine to pick it up. However, it is better that
we delete it right away to avoid the potential for quorum issues on
version signature when there are many versions of an object.

## How to test this PR?
```
minio server /tmp/xl{1...4}
mc mb -l myminio/testbucket/

mc cp /etc/hosts myminio/testbucket/
chown -R root. /tmp/x{2,3,4}
mc cp /etc/hosts myminio/testbucket/

xl-meta /tmp/xl1/testbucket/hosts/xl.meta (there shouldn't be 2 versions)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
