### PR TITLE
fix: trans cancel error into interval error when context is not cancaled

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -2158,7 +2158,8 @@ func toAPIErrorCode(ctx context.Context, err error) (apiErr APIErrorCode) {
 	case errKMSDefaultKeyAlreadyConfigured:
 		apiErr = ErrKMSDefaultKeyAlreadyConfigured
 	case context.Canceled:
-		apiErr = ErrClientDisconnected
+		// the ctx is not Canceled. But the error is Canceled. We should assume that this error is errInternalError
+		apiErr = ErrInternalError
 	case context.DeadlineExceeded:
 		apiErr = ErrRequestTimedout
 	case objectlock.ErrInvalidRetentionDate:


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
before , we have this.
```go
	// Only return ErrClientDisconnected if the provided context is actually canceled.
	// This way downstream context.Canceled will still report ErrRequestTimedout
	if contextCanceled(ctx) && errors.Is(ctx.Err(), context.Canceled) {
		return ErrClientDisconnected
	}
```
So the context is no canceled when:
```go
	case context.Canceled:
		apiErr = ErrClientDisconnected
```
fix: trans cancel error into interval error when context is not cancaled
When we got `Client disconnected before response was ready`, we can't found that if the client do cancel really.
It's  a timeout between the minio-servers maybe.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
