### PR TITLE
Correct a mistake in the value.yaml of minio helm chart

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -84,7 +84,7 @@ priorityClassName: ""
 runtimeClassName: ""
 
 ## Set default rootUser, rootPassword
-## AccessKey and secretKey is generated when not set
+## rootUser and rootPassword is generated when not set
 ## Distributed MinIO ref: https://min.io/docs/minio/linux/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html
 ##
 rootUser: ""


### PR DESCRIPTION
Only rootUser and rootPassword will be generated when not set.  No secretKey nor accessKey will be created.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Only rootUser and rootPassword will be generated when not set.  No secretKey nor accessKey will be created.

## Motivation and Context
Provide the correct documentation and remove confusion. 

## How to test this PR?
Install the helm chart without rootUser & rootPassword

## Types of changes
- [ Y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ Y] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
