### PR TITLE
yml-config: Add support of rootUser and rootPassword

### DIFF
--- a/.github/workflows/replication.yaml
+++ b/.github/workflows/replication.yaml
@@ -36,6 +36,12 @@ jobs:
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make test-decom
 
+      - name: Test Config File
+        run: |
+          sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+          sudo sysctl net.ipv6.conf.default.disable_ipv6=0
+          make test-configfile
+
       - name: Test Replication
         run: |
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ test-decom: install-race
 	@env bash $(PWD)/docs/distributed/decom-encrypted-sse-s3.sh
 	@env bash $(PWD)/docs/distributed/decom-compressed-sse-s3.sh
 
+test-configfile: install-race
+	@env bash $(PWD)/docs/distributed/distributed-from-config-file.sh
+
 test-upgrade: install-race
 	@echo "Running minio upgrade tests"
 	@(env bash $(PWD)/buildscripts/minio-upgrade.sh)

--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -658,7 +658,7 @@ func loadEnvVarsFromFiles() {
 	}
 }
 
-func handleCommonEnvVars() {
+func serverHandleEnvVars() {
 	var err error
 	globalBrowserEnabled, err = config.ParseBool(env.Get(config.EnvBrowser, config.EnableOn))
 	if err != nil {
@@ -786,6 +786,10 @@ func handleCommonEnvVars() {
 		}
 	}
 
+	globalDisableFreezeOnBoot = env.Get("_MINIO_DISABLE_API_FREEZE_ON_BOOT", "") == "true" || serverDebugLog
+}
+
+func loadRootCredentials() {
 	// At this point, either both environment variables
 	// are defined or both are not defined.
 	// Check both cases and authenticate them if correctly defined
@@ -799,6 +803,9 @@ func handleCommonEnvVars() {
 	} else if env.IsSet(config.EnvAccessKey) && env.IsSet(config.EnvSecretKey) {
 		user = env.Get(config.EnvAccessKey, "")
 		password = env.Get(config.EnvSecretKey, "")
+		hasCredentials = true
+	} else if globalServerCtxt.RootUser != "" && globalServerCtxt.RootPwd != "" {
+		user, password = globalServerCtxt.RootUser, globalServerCtxt.RootPwd
 		hasCredentials = true
 	}
 	if hasCredentials {
@@ -819,8 +826,6 @@ func handleCommonEnvVars() {
 	} else {
 		globalActiveCred = auth.DefaultCredentials
 	}
-
-	globalDisableFreezeOnBoot = env.Get("_MINIO_DISABLE_API_FREEZE_ON_BOOT", "") == "true" || serverDebugLog
 }
 
 // Initialize KMS global variable after valiadating and loading the configuration.

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -146,6 +146,8 @@ type serverCtxt struct {
 	configDirSet, certsDirSet bool
 	Interface                 string
 
+	RootUser, RootPwd string
+
 	FTP  []string
 	SFTP []string
 

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -248,6 +248,10 @@ func mergeServerCtxtFromConfigFile(configFile string, ctxt *serverCtxt) error {
 	if cf.Version != "v1" {
 		return fmt.Errorf("unexpected version: %s", cf.Version)
 	}
+
+	ctxt.RootUser = cf.RootUser
+	ctxt.RootPwd = cf.RootPwd
+
 	if cf.Addr != "" {
 		ctxt.Addr = cf.Addr
 	}
@@ -351,11 +355,6 @@ func serverHandleCmdArgs(ctxt serverCtxt) {
 
 	globalConnReadDeadline = ctxt.ConnReadDeadline
 	globalConnWriteDeadline = ctxt.ConnWriteDeadline
-}
-
-func serverHandleEnvVars() {
-	// Handle common environment variables.
-	handleCommonEnvVars()
 }
 
 var globalHealStateLK sync.RWMutex
@@ -653,6 +652,10 @@ func serverMain(ctx *cli.Context) {
 
 	// Handle all server environment vars.
 	serverHandleEnvVars()
+
+	// Load the root credentials from the shell environment or from
+	// the config file if not defined, set the default one.
+	loadRootCredentials()
 
 	// Initialize globalConsoleSys system
 	bootstrapTrace("newConsoleLogger", func() {

--- a/docs/distributed/CONFIG.md
+++ b/docs/distributed/CONFIG.md
@@ -18,6 +18,8 @@ Following is an example YAML configuration structure.
 ```
 version: v1
 address: ':9000'
+rootUser: 'minioadmin'
+rootPassword: 'pBU94AGAY85e'
 console-address: ':9001'
 certs-dir: '/home/user/.minio/certs/'
 pools: # Specify the nodes and drives with pools

--- a/docs/distributed/distributed-from-config-file.sh
+++ b/docs/distributed/distributed-from-config-file.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -e
+
+cleanup() {
+	echo "Cleaning up instances of MinIO"
+	pkill minio || true
+	pkill -9 minio || true
+	rm -rf /tmp/xl/ || true
+	rm -rf /tmp/minio.configfile.{1,2,3,4} || true
+}
+
+cleanup
+
+unset MINIO_KMS_KES_CERT_FILE
+unset MINIO_KMS_KES_KEY_FILE
+unset MINIO_KMS_KES_ENDPOINT
+unset MINIO_KMS_KES_KEY_NAME
+
+export MINIO_CI_CD=1
+
+if [ ! -f ./mc ]; then
+	os="$(uname -s)"
+	arch="$(uname -m)"
+	wget -O mc https://dl.minio.io/client/mc/release/${os,,}-${arch,,}/mc &&
+		chmod +x mc
+fi
+
+for i in $(seq 1 4); do
+	s3Port="$((9000 + i))"
+	consolePort="$((s3Port + 1000))"
+
+	cat <<EOF >/tmp/minio.configfile.$i
+version: v1
+address: ':${s3Port}'
+console-address: ':${consolePort}'
+rootUser: 'minr0otUS2r'
+rootPassword: 'pBU94AGAY85e'
+pools: # Specify the nodes and drives with pools
+  -
+     - 'http://localhost:9001/tmp/xl/node9001/mnt/disk{1...4}/'
+     - 'http://localhost:9002/tmp/xl/node9002/mnt/disk{1,2,3,4}/'
+  -
+     - 'http://localhost:9003/tmp/xl/node9003/mnt/disk{1...4}/'
+     - 'http://localhost:9004/tmp/xl/node9004/mnt/disk1/'
+     - 'http://localhost:9004/tmp/xl/node9004/mnt/disk2/'
+     - 'http://localhost:9004/tmp/xl/node9004/mnt/disk3/'
+     - 'http://localhost:9004/tmp/xl/node9004/mnt/disk4/'
+EOF
+done
+
+minio server --config /tmp/minio.configfile.1 >/tmp/minio1_1.log 2>&1 &
+site1_pid=$!
+minio server --config /tmp/minio.configfile.2 >/tmp/minio2_1.log 2>&1 &
+site2_pid=$!
+minio server --config /tmp/minio.configfile.3 >/tmp/minio3_1.log 2>&1 &
+site3_pid=$!
+minio server --config /tmp/minio.configfile.4 >/tmp/minio4_1.log 2>&1 &
+site4_pid=$!
+
+sleep 5
+
+export MC_HOST_minio1=http://minr0otUS2r:pBU94AGAY85e@localhost:9001
+export MC_HOST_minio3=http://minr0otUS2r:pBU94AGAY85e@localhost:9003
+
+./mc ready minio1
+./mc ready minio3
+
+./mc mb minio1/testbucket
+# copy large upload to newbucket on minio1
+truncate -s 17M lrgfile
+expected_checksum=$(cat ./lrgfile | md5sum)
+
+./mc cp ./lrgfile minio1/testbucket
+
+actual_checksum=$(./mc cat minio3/testbucket/lrgfile | md5sum)
+
+if [ "${expected_checksum}" != "${actual_checksum}" ]; then
+	echo "unexpected object checksum, expected: ${expected_checksum} got: ${actual_checksum}"
+	exit
+fi
+
+# Compare the difference of the list of disks and their location, with the below exected output
+diff <(./mc admin info minio1 --json | jq -r '.info.servers[].drives[] | "\(.pool_index),\(.set_index),\(.disk_index) \(.endpoint)"' | sort) <(
+	cat <<EOF
+0,0,0 http://localhost:9001/tmp/xl/node9001/mnt/disk1
+0,0,1 http://localhost:9002/tmp/xl/node9002/mnt/disk1
+0,0,2 http://localhost:9001/tmp/xl/node9001/mnt/disk2
+0,0,3 http://localhost:9002/tmp/xl/node9002/mnt/disk2
+0,0,4 http://localhost:9001/tmp/xl/node9001/mnt/disk3
+0,0,5 http://localhost:9002/tmp/xl/node9002/mnt/disk3
+0,0,6 http://localhost:9001/tmp/xl/node9001/mnt/disk4
+0,0,7 http://localhost:9002/tmp/xl/node9002/mnt/disk4
+1,0,0 http://localhost:9003/tmp/xl/node9003/mnt/disk1
+1,0,1 http://localhost:9004/tmp/xl/node9004/mnt/disk1
+1,0,2 http://localhost:9003/tmp/xl/node9003/mnt/disk2
+1,0,3 http://localhost:9004/tmp/xl/node9004/mnt/disk2
+1,0,4 http://localhost:9003/tmp/xl/node9003/mnt/disk3
+1,0,5 http://localhost:9004/tmp/xl/node9004/mnt/disk3
+1,0,6 http://localhost:9003/tmp/xl/node9003/mnt/disk4
+1,0,7 http://localhost:9004/tmp/xl/node9004/mnt/disk4
+EOF
+)
+
+cleanup

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -32,6 +32,8 @@ type Opts struct {
 // ServerConfig represents a MinIO configuration file
 type ServerConfig struct {
 	Version     string     `yaml:"version"`
+	RootUser    string     `yaml:"rootUser"`
+	RootPwd     string     `yaml:"rootPassword"`
 	Addr        string     `yaml:"address"`
 	ConsoleAddr string     `yaml:"console-address"`
 	CertsDir    string     `yaml:"certs-dir"`


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Users can define the root user and password in the yaml configuration file; 
Root credentials defined in the environment variable still take precedence

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
