### PR TITLE
Fix CreateFile shared buffer corruption.

### DIFF
--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -458,7 +458,7 @@ func (p *xlStorageDiskIDCheck) CreateFile(ctx context.Context, volume, path stri
 	}
 	defer done(&err)
 
-	return p.storage.CreateFile(ctx, volume, path, size, xioutil.NewDeadlineReader(io.NopCloser(reader), globalDriveConfig.GetMaxTimeout()))
+	return p.storage.CreateFile(ctx, volume, path, size, io.NopCloser(reader))
 }
 
 func (p *xlStorageDiskIDCheck) ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error) {
@@ -480,7 +480,7 @@ func (p *xlStorageDiskIDCheck) ReadFileStream(ctx context.Context, volume, path 
 		return nil, err
 	}
 
-	return xioutil.NewDeadlineReader(rc, globalDriveConfig.GetMaxTimeout()), nil
+	return rc, nil
 }
 
 func (p *xlStorageDiskIDCheck) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) (err error) {

--- a/internal/ioutil/ioutil.go
+++ b/internal/ioutil/ioutil.go
@@ -104,13 +104,6 @@ type ioret struct {
 	err error
 }
 
-// DeadlineReader deadline reader with timeout
-type DeadlineReader struct {
-	io.ReadCloser
-	timeout time.Duration
-	err     error
-}
-
 // DeadlineWriter deadline writer with timeout
 type DeadlineWriter struct {
 	io.WriteCloser

--- a/internal/ioutil/ioutil_test.go
+++ b/internal/ioutil/ioutil_test.go
@@ -54,29 +54,6 @@ func (w *sleepWriter) Close() error {
 	return nil
 }
 
-func TestDeadlineReader(t *testing.T) {
-	r := NewDeadlineReader(&sleepReader{timeout: 500 * time.Millisecond}, 450*time.Millisecond)
-	buf := make([]byte, 4)
-	_, err := r.Read(buf)
-	r.Close()
-	if err != context.DeadlineExceeded {
-		t.Errorf("DeadlineReader shouldn't be successful %v - should return context.DeadlineExceeded", err)
-	}
-	_, err = r.Read(buf)
-	if err != context.DeadlineExceeded {
-		t.Errorf("DeadlineReader shouldn't be successful %v - should return context.DeadlineExceeded", err)
-	}
-	r = NewDeadlineReader(&sleepReader{timeout: 100 * time.Millisecond}, 600*time.Millisecond)
-	n, err := r.Read(buf)
-	r.Close()
-	if err != nil {
-		t.Errorf("DeadlineReader should succeed but failed with %s", err)
-	}
-	if n != 4 {
-		t.Errorf("DeadlineReader should succeed but should have only read 4 bytes, but returned %d instead", n)
-	}
-}
-
 func TestDeadlineWriter(t *testing.T) {
 	w := NewDeadlineWriter(&sleepWriter{timeout: 500 * time.Millisecond}, 450*time.Millisecond)
 	_, err := w.Write([]byte("1"))

--- a/internal/ioutil/ioutil_test.go
+++ b/internal/ioutil/ioutil_test.go
@@ -28,19 +28,6 @@ import (
 	"time"
 )
 
-type sleepReader struct {
-	timeout time.Duration
-}
-
-func (r *sleepReader) Read(p []byte) (n int, err error) {
-	time.Sleep(r.timeout)
-	return len(p), nil
-}
-
-func (r *sleepReader) Close() error {
-	return nil
-}
-
 type sleepWriter struct {
 	timeout time.Duration
 }


### PR DESCRIPTION
## Description

`(*xlStorageDiskIDCheck).CreateFile` wraps the incoming reader in `xioutil.NewDeadlineReader`.

The wrapped reader is handed to `(*xlStorage).CreateFile`. This performs a Read call via `writeAllDirect`, which reads into a `ODirectPool` buffer.

`(*DeadlineReader).Read` spawns an async read into the buffer. If a timeout is hit while reading the read operation returns to `writeAllDirect`. The operation returns an error and the buffer is reused.

However if the async `Read` call unblocks, it will write to the now recycled buffer.

Fix: Remove the `DeadlineReader` - it is inherently unsafe. Instead just rely on the network timeouts. This is not a disk timeout anyway.

Regression in https://github.com/minio/minio/pull/18411

## How to test this PR?

Triggered on slow uploads.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression #18411