### PR TITLE
Read new key license_v2 from SUBNET response

### DIFF
--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -89,7 +89,7 @@ func performLicenseUpdate(ctx context.Context, objectAPI ObjectLayer) {
 		return
 	}
 
-	r := gjson.Parse(resp).Get("license")
+	r := gjson.Parse(resp).Get("license_v2")
 	if r.Index == 0 {
 		logger.LogIf(ctx, fmt.Errorf("license not found in response from %s", url))
 		return


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

SUBNET now has a v2 of license that is returned in the new key `license_v2`. mc will start reading and storing the same. (The old key `license` is deprecated but is still available in SUBNET response to ensure that the current released version of minio doesn't break)

## Motivation and Context

Stay up-to-date with license changes in SUBNET

## How to test this PR?

- Change code to reduce frequency of license update job to a smaller value (say 1 min)
- Start the minio server
- Register a cluster
- Remove the license value from subnet config
- Run `mc license info --airgap` to verify that license information is not displayed
- Wait for some time (longer than the configured frequency)
- Run `mc license info --airgap` again to verify that license information is now displayed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
