### PR TITLE
send proper IPv6 names avoid bracketing notation

### DIFF
--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -121,7 +121,7 @@ func getConditionValues(r *http.Request, lc string, cred auth.Credentials) map[s
 		"CurrentTime":      {currTime.Format(time.RFC3339)},
 		"EpochTime":        {strconv.FormatInt(currTime.Unix(), 10)},
 		"SecureTransport":  {strconv.FormatBool(r.TLS != nil)},
-		"SourceIp":         {handlers.GetSourceIP(r)},
+		"SourceIp":         {handlers.GetSourceIPRaw(r)},
 		"UserAgent":        {r.UserAgent()},
 		"Referer":          {r.Referer()},
 		"principaltype":    {principalType},

--- a/internal/handlers/proxy.go
+++ b/internal/handlers/proxy.go
@@ -113,16 +113,27 @@ func GetSourceIPFromHeaders(r *http.Request) string {
 	return addr
 }
 
-// GetSourceIP retrieves the IP from the request headers
+// GetSourceIPRaw retrieves the IP from the request headers
 // and falls back to r.RemoteAddr when necessary.
-func GetSourceIP(r *http.Request) string {
+// however returns without bracketing.
+func GetSourceIPRaw(r *http.Request) string {
 	addr := GetSourceIPFromHeaders(r)
-	if addr != "" {
-		return addr
+	if addr == "" {
+		addr = r.RemoteAddr
 	}
 
 	// Default to remote address if headers not set.
-	addr, _, _ = net.SplitHostPort(r.RemoteAddr)
+	raddr, _, _ := net.SplitHostPort(addr)
+	if raddr == "" {
+		return addr
+	}
+	return raddr
+}
+
+// GetSourceIP retrieves the IP from the request headers
+// and falls back to r.RemoteAddr when necessary.
+func GetSourceIP(r *http.Request) string {
+	addr := GetSourceIPRaw(r)
 	if strings.ContainsRune(addr, ':') {
 		return "[" + addr + "]"
 	}

--- a/internal/handlers/proxy_test.go
+++ b/internal/handlers/proxy_test.go
@@ -62,10 +62,10 @@ func TestGetSourceIP(t *testing.T) {
 		{xForwardedFor, "8.8.8.8, 8.8.4.4", "8.8.8.8"},                                // Multiple
 		{xForwardedFor, "", ""},                                                       // None
 		{xRealIP, "8.8.8.8", "8.8.8.8"},                                               // Single address
-		{xRealIP, "[2001:db8:cafe::17]:4711", "[2001:db8:cafe::17]:4711"},             // IPv6 address
+		{xRealIP, "[2001:db8:cafe::17]:4711", "[2001:db8:cafe::17]"},                  // IPv6 address
 		{xRealIP, "", ""},                                                             // None
 		{forwarded, `for="_gazonk"`, "_gazonk"},                                       // Hostname
-		{forwarded, `For="[2001:db8:cafe::17]:4711`, `[2001:db8:cafe::17]:4711`},      // IPv6 address
+		{forwarded, `For="[2001:db8:cafe::17]:4711`, `[2001:db8:cafe::17]`},           // IPv6 address
 		{forwarded, `for=192.0.2.60;proto=http;by=203.0.113.43`, `192.0.2.60`},        // Multiple params
 		{forwarded, `for=192.0.2.43, for=198.51.100.17`, "192.0.2.43"},                // Multiple params
 		{forwarded, `for="workstation.local",for=198.51.100.17`, "workstation.local"}, // Hostname


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
send proper IPv6 names and avoid bracketing notation

## Motivation and Context
Following policies, if present

```
       "Condition": {
         "IpAddress": {
            "aws:SourceIp": [
              "54.240.143.0/24",
               "2001:DB8:1234:5678::/64"
             ]
          }
        }
```

A client requesting MinIO via IPv6 can potentially crash the server.

Workarounds are turn-off IPv6 and use only IPv4.

## How to test this PR?
As mentioned in the previous section

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
