### PR TITLE
fix: reject clients that do not send proper payload

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -716,7 +716,7 @@ func (set *erasureObjects) listObjectsToDecommission(ctx context.Context, bi dec
 		path:           bi.Prefix,
 		recursive:      true,
 		forwardTo:      "",
-		minDisks:       len(disks) / 2,
+		minDisks:       listQuorum,
 		reportNotFound: false,
 		agreed:         fn,
 		partial: func(entries metaCacheEntries, _ []error) {

--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -624,10 +624,12 @@ func (z *erasureServerPools) rebalanceBucket(ctx context.Context, bucket string,
 		go func() {
 			defer wg.Done()
 
+			listQuorum := (len(disks) + 1) / 2
+
 			// How to resolve partial results.
 			resolver := metadataResolutionParams{
-				dirQuorum: len(disks) / 2, // make sure to capture all quorum ratios
-				objQuorum: len(disks) / 2, // make sure to capture all quorum ratios
+				dirQuorum: listQuorum, // make sure to capture all quorum ratios
+				objQuorum: listQuorum, // make sure to capture all quorum ratios
 				bucket:    bucket,
 			}
 			err := listPathRaw(ctx, listPathRawOptions{
@@ -635,7 +637,7 @@ func (z *erasureServerPools) rebalanceBucket(ctx context.Context, bucket string,
 				bucket:         bucket,
 				recursive:      true,
 				forwardTo:      "",
-				minDisks:       len(disks) / 2, // to capture all quorum ratios
+				minDisks:       listQuorum,
 				reportNotFound: false,
 				agreed: func(entry metaCacheEntry) {
 					workers <- struct{}{}

--- a/internal/grid/manager.go
+++ b/internal/grid/manager.go
@@ -169,6 +169,7 @@ func (m *Manager) Handler() http.HandlerFunc {
 		msg, _, err := wsutil.ReadClientData(conn)
 		if err != nil {
 			logger.LogIf(ctx, fmt.Errorf("grid: reading connect: %w", err))
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		if debugPrint {
@@ -182,6 +183,7 @@ func (m *Manager) Handler() http.HandlerFunc {
 				fmt.Println("parse err:", err)
 			}
 			logger.LogIf(ctx, fmt.Errorf("handleMessages: parsing connect: %w", err))
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		if message.Op != OpConnect {
@@ -189,6 +191,7 @@ func (m *Manager) Handler() http.HandlerFunc {
 				fmt.Println("op err:", message.Op)
 			}
 			logger.LogIf(ctx, fmt.Errorf("handler: unexpected op: %v", message.Op))
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		var cReq connectReq
@@ -198,6 +201,7 @@ func (m *Manager) Handler() http.HandlerFunc {
 				fmt.Println("handler: creq err:", err)
 			}
 			logger.LogIf(ctx, fmt.Errorf("handleMessages: parsing ConnectReq: %w", err))
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		remote := m.targets[cReq.Host]
@@ -205,7 +209,7 @@ func (m *Manager) Handler() http.HandlerFunc {
 			if debugPrint {
 				fmt.Printf("%s: handler: unknown host: %v. Have %v\n", m.local, cReq.Host, m.targets)
 			}
-			logger.LogIf(ctx, fmt.Errorf("handler: unknown host: %v", cReq.Host))
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		if debugPrint {

--- a/internal/grid/muxserver.go
+++ b/internal/grid/muxserver.go
@@ -202,7 +202,7 @@ func newMuxStream(ctx context.Context, msg message, c *Connection, handler Strea
 				case <-t.C:
 					last := time.Since(time.Unix(atomic.LoadInt64(&m.LastPing), 0))
 					if last > lastPingThreshold {
-						logger.LogIf(m.ctx, fmt.Errorf("canceling remote mux %d not seen for %v", m.ID, last))
+						logger.LogIf(m.ctx, fmt.Errorf("canceling remote connection %s not seen for %v", m.parent, last))
 						m.close()
 						return
 					}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: reject clients that do not send a proper payload

## Motivation and Context
nodes trying to connect to hosts that do not
trust them must reject with 403's

Currently, there are places where we keep the connection
active and mux server has to reject the connection with
a deadline later.

## How to test this PR?
Start with a three-node setup and then expand with 2nd pool by adding 4th node but with the same three hosts from the previous pool with a new drive.

Please don't restart the first pool nodes, only start the second pool. Leads to random
errors showing up in the logs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
