### PR TITLE
scanner: Add a config to disable short sleep between objects scan 

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -600,6 +600,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			return fmt.Errorf("Unable to apply scanner config: %w", err)
 		}
 		// update dynamic scanner values.
+		scannerIdleMode.Store(scannerCfg.IdleMode)
 		scannerCycle.Store(scannerCfg.Cycle)
 		logger.LogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 	case config.LoggerWebhookSubSys:

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -65,8 +65,9 @@ var (
 	globalHealConfig heal.Config
 
 	// Sleeper values are updated when config is loaded.
-	scannerSleeper = newDynamicSleeper(2, time.Second, true) // Keep defaults same as config defaults
-	scannerCycle   = uatomic.NewDuration(dataScannerStartDelay)
+	scannerSleeper  = newDynamicSleeper(2, time.Second, true) // Keep defaults same as config defaults
+	scannerCycle    = uatomic.NewDuration(dataScannerStartDelay)
+	scannerIdleMode = uatomic.NewInt32(0) // default is throttled when idle
 )
 
 // initDataScanner will start the scanner in the background.

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -286,8 +286,7 @@ func (p *xlStorageDiskIDCheck) NSScanner(ctx context.Context, cache dataUsageCac
 	}
 
 	weSleep := func() bool {
-		// Entire queue is full, so we sleep.
-		return cap(p.health.tokens) == len(p.health.tokens)
+		return scannerIdleMode.Load() == 0
 	}
 
 	return p.storage.NSScanner(ctx, cache, updates, scanMode, weSleep)

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -130,9 +130,9 @@ var (
 			Value: "5m",
 		},
 		config.KV{
-			Key:        apiDisableODirect,
-			Value:      "",
-			Deprecated: true,
+			Key:           apiDisableODirect,
+			Value:         "",
+			HiddenIfEmpty: true,
 		},
 		config.KV{
 			Key:   apiODirect,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,7 +274,7 @@ type KV struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 
-	Deprecated bool `json:"-"`
+	HiddenIfEmpty bool `json:"-"`
 }
 
 func (kv KV) String() string {
@@ -1447,7 +1447,7 @@ func (cs *SubsysInfo) WriteTo(b *strings.Builder, off bool) {
 			continue
 		}
 		// Ignore empty and deprecated values
-		if dkv.Deprecated && kv.Value == "" {
+		if dkv.HiddenIfEmpty && kv.Value == "" {
 			continue
 		}
 		// Do not need to print if state is on

--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -31,6 +31,9 @@ const (
 	Speed    = "speed"
 	EnvSpeed = "MINIO_SCANNER_SPEED"
 
+	IdleSpeed    = "idle_speed"
+	EnvIdleSpeed = "MINIO_SCANNER_IDLE_SPEED"
+
 	// All below are deprecated in October 2022 and
 	// replaced them with a single speed parameter
 	Delay            = "delay"
@@ -47,6 +50,8 @@ const (
 type Config struct {
 	// Delay is the sleep multiplier.
 	Delay float64 `json:"delay"`
+	// Behavior of the scanner when there is no other parallel S3 requests
+	IdleMode int32 // 0 => throttling, 1 => full speed
 	// MaxWait is maximum wait time between operations
 	MaxWait time.Duration
 	// Cycle is the time.Duration between each scanner cycles
@@ -59,23 +64,28 @@ var DefaultKVS = config.KVS{
 		Key:   Speed,
 		Value: "default",
 	},
-	// Deprecated Oct 2022
 	config.KV{
-		Key:        Delay,
-		Value:      "",
-		Deprecated: true,
+		Key:           IdleSpeed,
+		Value:         "",
+		HiddenIfEmpty: true,
 	},
 	// Deprecated Oct 2022
 	config.KV{
-		Key:        MaxWait,
-		Value:      "",
-		Deprecated: true,
+		Key:           Delay,
+		Value:         "",
+		HiddenIfEmpty: true,
 	},
 	// Deprecated Oct 2022
 	config.KV{
-		Key:        Cycle,
-		Value:      "",
-		Deprecated: true,
+		Key:           MaxWait,
+		Value:         "",
+		HiddenIfEmpty: true,
+	},
+	// Deprecated Oct 2022
+	config.KV{
+		Key:           Cycle,
+		Value:         "",
+		HiddenIfEmpty: true,
 	},
 }
 
@@ -107,6 +117,16 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	default:
 		return cfg, fmt.Errorf("unknown '%s' value", speed)
 	}
+
+	switch idleSpeed := env.Get(EnvIdleSpeed, kvs.GetWithDefault(IdleSpeed, DefaultKVS)); idleSpeed {
+	case "", "throttled": // Empty is the default mode;
+		cfg.IdleMode = 0
+	case "full":
+		cfg.IdleMode = 1
+	default:
+		return cfg, fmt.Errorf("unknown value: '%s'", idleSpeed)
+	}
+
 	return
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add a hidden configuration under the scanner sub section to configure if
the scanner should sleep between two objects scan. The configuration has
only effect when there is no drive activity related to s3 requests or
healing.

By default, the code will keep the current behavior which is doing
sleep between objects.

To forcefully enable the full scan speed in idle mode, you can do this:
   `mc admin config set myminio scanner idle_speed=full`

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
