### PR TITLE
audit: Add the count of drives from where the dangling object is removed

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -550,13 +550,22 @@ func (er erasureObjects) deleteIfDangling(ctx context.Context, bucket, object st
 			}, index)
 		}
 
-		removedFromDrivesCount := 0
-		for _, err := range g.Wait() {
-			if err == nil {
-				removedFromDrivesCount++
+		rmDisks := make(map[string]string, len(disks))
+		for index, err := range g.Wait() {
+			var errStr, diskName string
+			if err != nil {
+				errStr = err.Error()
+			} else {
+				errStr = "<nil>"
 			}
+			if disks[index] != nil {
+				diskName = disks[index].String()
+			} else {
+				diskName = fmt.Sprintf("disk-%d", index)
+			}
+			rmDisks[diskName] = errStr
 		}
-		tags["removedFromDrivesCount"] = removedFromDrivesCount
+		tags["cleanupResult"] = rmDisks
 	}
 	return m, err
 }

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -550,7 +550,13 @@ func (er erasureObjects) deleteIfDangling(ctx context.Context, bucket, object st
 			}, index)
 		}
 
-		g.Wait()
+		removedFromDrivesCount := 0
+		for _, err := range g.Wait() {
+			if err == nil {
+				removedFromDrivesCount++
+			}
+		}
+		tags["removedFromDrivesCount"] = removedFromDrivesCount
 	}
 	return m, err
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Add 'removedFromDrivesCount' to the audit log of a dangling object removal operation.

This means how many drives have been able to successfuly remove the dangling object.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
