### PR TITLE
Helm: Add apiVersion and kind to the StatefulSets volumeClaimTemplates

### DIFF
--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -219,7 +219,9 @@ spec:
   volumeClaimTemplates:
     {{- if gt $drivesPerNode 1 }}
     {{- range $diskId := until $drivesPerNode}}
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim	
+      metadata:
         name: export-{{ $diskId }}
         {{- if $.Values.persistence.annotations }}
         annotations: {{- toYaml $.Values.persistence.annotations | nindent 10 }}
@@ -234,7 +236,9 @@ spec:
             storage: {{ $psize }}
     {{- end }}
     {{- else }}
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim	
+      metadata:
         name: export
         {{- if $.Values.persistence.annotations }}
         annotations: {{- toYaml $.Values.persistence.annotations | nindent 10 }}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The Minio Helm chart, when set up in its default "distributed" mode, generates a StatefulSet with two volumeClaimTemplates. When you deploy this Helm chart via ArgoCD it continually shows as out of sync because the apiVersion and kind are missing in those volumeClaimTemplates.

![image](https://github.com/minio/minio/assets/24322206/9afa382e-fd93-4669-9447-0f38dcc00cd6)

## Motivation and Context
We would like to have a proper "Synced" state in ArgoCD.

## How to test this PR?
Deploy a minio instance with using ArgoCD and the minio Helm chart.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
