### PR TITLE
site replication: remove extraneous log for missing group

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1298,7 +1298,7 @@ func (c *SiteReplicationSys) PeerGroupInfoChangeHandler(ctx context.Context, cha
 			}
 		}
 	}
-	if err != nil {
+	if err != nil && !errors.Is(err, errNoSuchGroup) {
 		return wrapSRErr(err)
 	}
 	return nil


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
Avoid non actionable log where group is present on a site without members. This cannot be synced to peer - user action should be to fix this by deleting the group.  
```
API:SRPeerReplicateIAMItem()
Time:03:43:20 UTC 01/14/2024
Level:ERROR
DeploymentID:776afbbe-023f-33da-66e2-88cd1fb44b28
Host:GVA-P-MIOAP-103-storage:9000
RemoteHost:10.41.116.118
UserAgent:MinIO (linux; amd64) madmin-go/2.0.0
Error:Specified group does not exist (cmd.SRError)
Backtrace:
1:
internal/logger/logger.go:258:logger.LogIf()
2:
cmd/admin-handlers-site-replication.go:188:cmd.adminAPIHandlers.SRPeerReplicateIAMItem()
3:
net/http/server.go:2136:http.HandlerFunc.ServeHTTP()
```

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
