### PR TITLE
adding a missing return case to fix GetObjectTagging

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3318,6 +3318,9 @@ func (api objectAPIHandlers) GetObjectTaggingHandler(w http.ResponseWriter, r *h
 				} // overlay tags from peer site.
 				ot = tags
 				w.Header()[xhttp.MinIOTaggingProxied] = []string{"true"} // indicate that the request was proxied.
+			} else {
+				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+				return
 			}
 		} else {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Looking for tags on specific objects, that do not exist, triggers a pointer de-reference.
![image](https://github.com/minio/minio/assets/20964930/171818c4-5cf3-4118-af6d-10c6d8dc2650)



## Motivation and Context
Response to issue #18791 


## How to test this PR?
Call getObjectTagging on an object that does not exist.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)

