### PR TITLE
reject reference format from a different deployment

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -1111,6 +1111,13 @@ func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.H
 		return res, errNoHealRequired
 	}
 
+	if !reflect.DeepEqual(s.format, refFormat) {
+		// Format is corrupted and unrecognized by the running instance.
+		logger.LogIf(ctx, fmt.Errorf("Unable to heal the newly replaced drives due to format.json inconsistencies, please engage MinIO support for further assistance: %w",
+			errCorruptedFormat))
+		return res, errCorruptedFormat
+	}
+
 	formatOpID := mustGetUUID()
 
 	// Initialize a new set of set formats which will be written to disk.
@@ -1191,9 +1198,6 @@ func (s *erasureSets) HealFormat(ctx context.Context, dryRun bool) (res madmin.H
 				}
 			}
 		}
-
-		// Replace reference format with what was loaded from disks.
-		s.format = refFormat
 
 		s.erasureDisksMu.Unlock()
 	}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
reject reference format from a different deployment

## Motivation and Context
reference format is constant for any lifetime of
a MinIO cluster, we do not have ever to replace
it during HealFormat(), as it will never change.

additionally, we should reject the reference
formats that we need to understand early on.

## How to test this PR?
Nothing special

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
