### PR TITLE
add new drive I/O waiting/tokens metric

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -203,6 +203,8 @@ func getDisksInfo(disks []StorageAPI, endpoints []Endpoint, metrics bool) (disks
 				APICalls:                make(map[string]uint64, len(info.Metrics.APICalls)),
 				TotalErrorsAvailability: info.Metrics.TotalErrorsAvailability,
 				TotalErrorsTimeout:      info.Metrics.TotalErrorsTimeout,
+				TotalTokens:             info.Metrics.TotalTokens,
+				TotalWaiting:            info.Metrics.TotalWaiting,
 			}
 			for k, v := range info.Metrics.LastMinute {
 				if v.N > 0 {

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -170,16 +170,20 @@ For deployments with [bucket](https://min.io/docs/minio/linux/administration/buc
 
 ## Drive Metrics
 
-| Name                             | Description                                                         |
-|:---------------------------------|:--------------------------------------------------------------------|
-| `minio_node_drive_free_bytes`    | Total storage available on a drive.                                 |
-| `minio_node_drive_free_inodes`   | Total free inodes.                                                  |
-| `minio_node_drive_latency_us`    | Average last minute latency in µs for drive API storage operations. |
-| `minio_node_drive_offline_total` | Total drives offline in this node.                                  |
-| `minio_node_drive_online_total`  | Total drives online in this node.                                   |
-| `minio_node_drive_total`         | Total drives in this node.                                          |
-| `minio_node_drive_total_bytes`   | Total storage on a drive.                                           |
-| `minio_node_drive_used_bytes`    | Total storage used on a drive.                                      |
+| Name                                   | Description                                                                         |
+|:---------------------------------------|:------------------------------------------------------------------------------------|
+| `minio_node_drive_free_bytes`          | Total storage available on a drive.                                                 |
+| `minio_node_drive_free_inodes`         | Total free inodes.                                                                  |
+| `minio_node_drive_latency_us`          | Average last minute latency in µs for drive API storage operations.                 |
+| `minio_node_drive_offline_total`       | Total drives offline in this node.                                                  |
+| `minio_node_drive_online_total`        | Total drives online in this node.                                                   |
+| `minio_node_drive_total`               | Total drives in this node.                                                          |
+| `minio_node_drive_total_bytes`         | Total storage on a drive.                                                           |
+| `minio_node_drive_used_bytes`          | Total storage used on a drive.                                                      |
+| `minio_node_drive_errors_timeout`      | Total number of drive timeout errors since server start                             |
+| `minio_node_drive_errors_availability` | Total number of drive I/O errors, permission denied and timeouts since server start |
+| `minio_node_drive_io_waiting`          | Total number I/O operations waiting on drive                                        |
+| `minio_node_drive_io_tokens`           | Total number concurrent I/O operations configured on drive                          |
 
 ## Identity and Access Management (IAM) Metrics
 
@@ -228,6 +232,7 @@ For deployments with [bucket](https://min.io/docs/minio/linux/administration/buc
 | `minio_node_io_write_bytes`                | Total bytes written by the process to the underlying storage system, /proc/[pid]/io write_bytes.                |
 | `minio_node_process_cpu_total_seconds`     | Total user and system CPU time spent in seconds.                                                                |
 | `minio_node_process_resident_memory_bytes` | Resident memory size in bytes.                                                                                  |
+| `minio_node_process_virtual_memory_bytes`  | Virtual memory size in bytes.                                                                                   |
 | `minio_node_process_starttime_seconds`     | Start time for MinIO process per node, time in seconds since Unix epoc.                                         |
 | `minio_node_process_uptime_seconds`        | Uptime for MinIO process per node in seconds.                                                                   |
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/minio/dperf v0.5.3
 	github.com/minio/highwayhash v1.0.2
 	github.com/minio/kes-go v0.2.0
-	github.com/minio/madmin-go/v3 v3.0.38
+	github.com/minio/madmin-go/v3 v3.0.40-0.20240119195114-66fab65f959f
 	github.com/minio/minio-go/v7 v7.0.66
 	github.com/minio/mux v1.9.0
 	github.com/minio/pkg/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/kes-go v0.2.0 h1:HA33arq9s3MErbsj3PAXFVfFo4U4yw7lTKQ5kWFrpCA=
 github.com/minio/kes-go v0.2.0/go.mod h1:VorHLaIYis9/MxAHAtXN4d8PUMNKhIxTIlvFt0hBOEo=
-github.com/minio/madmin-go/v3 v3.0.38 h1:hgyQg43IkTq40ymFWoJwZyoqjYoT2GkiPlc1e7Bu+dY=
-github.com/minio/madmin-go/v3 v3.0.38/go.mod h1:4QN2NftLSV7MdlT50dkrenOMmNVHluxTvlqJou3hte8=
+github.com/minio/madmin-go/v3 v3.0.40-0.20240119195114-66fab65f959f h1:clgtVs6KUJTtKb4Xghq35gyJM/m10IwEmgfb4Do6BuY=
+github.com/minio/madmin-go/v3 v3.0.40-0.20240119195114-66fab65f959f/go.mod h1:4QN2NftLSV7MdlT50dkrenOMmNVHluxTvlqJou3hte8=
 github.com/minio/mc v0.0.0-20240111054932-d4305a5bf95e h1:vKnv5aBTcAAnDGYeJW/SPieXCerp/7MIYxuEUYt7iOE=
 github.com/minio/mc v0.0.0-20240111054932-d4305a5bf95e/go.mod h1:wFVJTmLJniMFDkcvPP0h/KvCxK+MiA2rc6q7KUefN28=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add new drive I/O waiting/tokens metric

## Motivation and Context
Bonus: add virtual memory used as well as part
of the system resource metrics.

## How to test this PR?
waiting on disk can only be tested via `xfs_freeze`
if you know how to use it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
