### PR TITLE
Distribution bucket metrics with site replication

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -3174,20 +3174,20 @@ func getBucketUsageMetrics(opts MetricsGroupOpts) *MetricsGroup {
 						}
 					}
 				}
-				metrics = append(metrics, Metric{
-					Description:          getBucketObjectDistributionMD(),
-					Histogram:            usage.ObjectSizesHistogram,
-					HistogramBucketLabel: "range",
-					VariableLabels:       map[string]string{"bucket": bucket},
-				})
-
-				metrics = append(metrics, Metric{
-					Description:          getBucketObjectVersionsMD(),
-					Histogram:            usage.ObjectVersionsHistogram,
-					HistogramBucketLabel: "range",
-					VariableLabels:       map[string]string{"bucket": bucket},
-				})
 			}
+			metrics = append(metrics, Metric{
+				Description:          getBucketObjectDistributionMD(),
+				Histogram:            usage.ObjectSizesHistogram,
+				HistogramBucketLabel: "range",
+				VariableLabels:       map[string]string{"bucket": bucket},
+			})
+
+			metrics = append(metrics, Metric{
+				Description:          getBucketObjectVersionsMD(),
+				Histogram:            usage.ObjectVersionsHistogram,
+				HistogramBucketLabel: "range",
+				VariableLabels:       map[string]string{"bucket": bucket},
+			})
 		}
 		return
 	})


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
If site replication is enabled, we should still show the size and version distribution histogram metrics at bucket level.

## Motivation and Context
Issue: https://github.com/minio/minio/issues/18838

## How to test this PR?
Create two minio sites and setup site replication between them.
Add couple of bucket to first site and and load multiple objects with different sizes and also load multiple versions of the objects.
Now execute `mc admin prometheus metrics ALIAS-SITE-1 bucket | grep _size_distribution` and `mc admin prometheus metrics ALIAS-SITE-1 bucket | grep _version_distribution` and you should see metrics as below

```
# HELP minio_bucket_objects_size_distribution Distribution of object sizes in the bucket, includes label for the bucket name
# TYPE minio_bucket_objects_size_distribution gauge
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_1024B_AND_1_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_1024_B_AND_64_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_10_MB_AND_64_MB",server="127.0.0.1:9000"} 20
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_128_MB_AND_512_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_1_MB_AND_10_MB",server="127.0.0.1:9000"} 10
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_256_KB_AND_512_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_512_KB_AND_1_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_64_KB_AND_256_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket",range="BETWEEN_64_MB_AND_128_MB",server="127.0.0.1:9000"} 10
minio_bucket_objects_size_distribution{bucket="test-bucket",range="GREATER_THAN_512_MB",server="127.0.0.1:9000"} 10
minio_bucket_objects_size_distribution{bucket="test-bucket",range="LESS_THAN_1024_B",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_1024B_AND_1_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_1024_B_AND_64_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_10_MB_AND_64_MB",server="127.0.0.1:9000"} 20
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_128_MB_AND_512_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_1_MB_AND_10_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_256_KB_AND_512_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_512_KB_AND_1_MB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_64_KB_AND_256_KB",server="127.0.0.1:9000"} 0
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="BETWEEN_64_MB_AND_128_MB",server="127.0.0.1:9000"} 20
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="GREATER_THAN_512_MB",server="127.0.0.1:9000"} 10
minio_bucket_objects_size_distribution{bucket="test-bucket-ver",range="LESS_THAN_1024_B",server="127.0.0.1:9000"} 0
# HELP minio_bucket_objects_version_distribution Distribution of object sizes in the bucket, includes label for the bucket name
# TYPE minio_bucket_objects_version_distribution gauge
minio_bucket_objects_version_distribution{bucket="test-bucket",range="BETWEEN_1000_AND_10000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket",range="BETWEEN_100_AND_1000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket",range="BETWEEN_10_AND_100",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket",range="BETWEEN_2_AND_10",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket",range="GREATER_THAN_10000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket",range="SINGLE_VERSION",server="127.0.0.1:9000"} 50
minio_bucket_objects_version_distribution{bucket="test-bucket",range="UNVERSIONED",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="BETWEEN_1000_AND_10000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="BETWEEN_100_AND_1000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="BETWEEN_10_AND_100",server="127.0.0.1:9000"} 20
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="BETWEEN_2_AND_10",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="GREATER_THAN_10000",server="127.0.0.1:9000"} 0
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="SINGLE_VERSION",server="127.0.0.1:9000"} 30
minio_bucket_objects_version_distribution{bucket="test-bucket-ver",range="UNVERSIONED",server="127.0.0.1:9000"} 0
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
