### PR TITLE
Add separate grid reconnection mutex

### DIFF
--- a/internal/grid/grid_test.go
+++ b/internal/grid/grid_test.go
@@ -535,7 +535,6 @@ func testStreamDeadline(t *testing.T, local, remote *Manager) {
 				err = resp.Err
 			}
 			clientCanceled <- time.Since(started)
-			t.Log("Client Context canceled")
 		}()
 		serverEnd := <-serverCanceled
 		clientEnd := <-clientCanceled


### PR DESCRIPTION
## Description

Give more safety around reconnects and make sure a state change isn't missed. In principle several incoming requests could be processed at the same time under strange network conditions.

Adds separate mutex and doesn't mix in the testing mutex.

## How to test this PR?

Tested with several runs of `λ go test -race -v -count=500` which includes reconnection test.

## Types of changes
- [x] Bug fix/ Safety (non-breaking change which fixes an issue)
