### PR TITLE
Fix inspect format.json exclusion

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -3092,7 +3092,7 @@ func (a adminAPIHandlers) InspectDataHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// save the format.json as part of inspect by default
-	if volume != minioMetaBucket && file != formatConfigFile {
+	if !(volume == minioMetaBucket && file == formatConfigFile) {
 		err = o.GetRawData(ctx, minioMetaBucket, formatConfigFile, rawDataFn)
 	}
 	if !errors.Is(err, errFileNotFound) {


### PR DESCRIPTION
## Description

Right now the `format.json` is excluded if anything within `.minio.sys` is requested.

I assume the check was meant to exclude only if it was actually requesting it.

## Motivation and Context

Include it unless it is the only thing being requested.

## How to test this PR?

`mc support inspect myminio/.minio.sys/buckets/**`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
