### PR TITLE
fix: regression in internode bytes counting

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -757,6 +757,10 @@ func (c *Connection) receive(conn net.Conn, r receiver) error {
 	if op != ws.OpBinary {
 		return fmt.Errorf("unexpected connect response type %v", op)
 	}
+	if c.incomingBytes != nil {
+		c.incomingBytes(int64(len(b)))
+	}
+
 	var m message
 	_, _, err = m.parse(b)
 	if err != nil {
@@ -937,9 +941,6 @@ func (c *Connection) handleMessages(ctx context.Context, conn net.Conn) {
 				cancel(ErrDisconnected)
 				logger.LogIfNot(ctx, fmt.Errorf("ws read: %w", err), net.ErrClosed, io.EOF)
 				return
-			}
-			if c.incomingBytes != nil {
-				c.incomingBytes(int64(len(msg)))
 			}
 			// Parse the received message
 			var m message

--- a/internal/grid/manager.go
+++ b/internal/grid/manager.go
@@ -105,16 +105,18 @@ func NewManager(ctx context.Context, o ManagerOptions) (*Manager, error) {
 			continue
 		}
 		m.targets[host] = newConnection(connectionParams{
-			ctx:          ctx,
-			id:           m.ID,
-			local:        o.Local,
-			remote:       host,
-			dial:         o.Dialer,
-			handlers:     &m.handlers,
-			auth:         o.AddAuth,
-			blockConnect: o.BlockConnect,
-			tlsConfig:    o.TLSConfig,
-			publisher:    o.TraceTo,
+			ctx:           ctx,
+			id:            m.ID,
+			local:         o.Local,
+			remote:        host,
+			dial:          o.Dialer,
+			handlers:      &m.handlers,
+			auth:          o.AddAuth,
+			blockConnect:  o.BlockConnect,
+			tlsConfig:     o.TLSConfig,
+			publisher:     o.TraceTo,
+			incomingBytes: o.Incoming,
+			outgoingBytes: o.Outgoing,
 		})
 	}
 	if !found {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: regression in internode bytes counting

## Motivation and Context
wire up missing metrics since #18461

Bonus: fix trace output inconsistency

## How to test this PR?
Just by usual means of metrics monitoring via
grafana dashboard, new deployments show internode
to be empty fix it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes 18461
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
