### PR TITLE
add missing proper error return in WalkDir()

### DIFF
--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -407,12 +407,12 @@ func (client *storageRESTClient) WalkDir(ctx context.Context, opts WalkDirOption
 	opts.DiskID = client.diskID
 	b, err := opts.MarshalMsg(grid.GetByteBuffer()[:0])
 	if err != nil {
-		return err
+		return toStorageErr(err)
 	}
 
 	st, err := client.gridConn.NewStream(ctx, grid.HandlerWalkDir, b)
 	if err != nil {
-		return err
+		return toStorageErr(err)
 	}
 	return toStorageErr(st.Results(func(in []byte) error {
 		_, err := wr.Write(in)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -87,6 +87,8 @@ func toStorageErr(err error) error {
 	switch err.Error() {
 	case errFaultyDisk.Error():
 		return errFaultyDisk
+	case errFaultyRemoteDisk.Error():
+		return errFaultyRemoteDisk
 	case errFileCorrupt.Error():
 		return errFileCorrupt
 	case errUnexpected.Error():
@@ -135,6 +137,16 @@ func toStorageErr(err error) error {
 		return errDiskNotFound
 	case errDiskNotFound.Error():
 		return errDiskNotFound
+	case errMaxVersionsExceeded.Error():
+		return errMaxVersionsExceeded
+	case errInconsistentDisk.Error():
+		return errInconsistentDisk
+	case errDriveIsRoot.Error():
+		return errDriveIsRoot
+	case errDiskOngoingReq.Error():
+		return errDiskOngoingReq
+	case grid.ErrUnknownHandler.Error():
+		return errInconsistentDisk
 	}
 	return err
 }


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add missing proper error return in WalkDir()

## Motivation and Context
without this, the caller might end up returning
incorrect errors and not ignoring the drive
properly.

fixes https://github.com/minio/minio/issues/18858

## How to test this PR?
You need a disk to go down right when an active 
List() is in progress; testing is racy and more 
challenging. But we have seen `mint` CI/CD return 
these errors.

Refer https://github.com/minio/minio/issues/18858

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
