### PR TITLE
Added P90 and P95 TTFB metrics

### DIFF
--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -158,6 +158,8 @@ For deployments with [bucket](https://min.io/docs/minio/linux/administration/buc
 | `minio_s3_requests_total`                     | Total number S3 requests.                                |
 | `minio_s3_requests_waiting_total`             | Number of S3 requests in the waiting queue.              |
 | `minio_s3_requests_ttfb_seconds_distribution` | Distribution of the time to first byte across API calls. |
+| `minio_s3_requests_ttfb_seconds_p90`          | p90 time to first byte across API calls.                 |
+| `minio_s3_requests_ttfb_seconds_p95`          | p95 time to first byte across API calls.                 |
 | `minio_s3_traffic_received_bytes`             | Total number of s3 bytes received.                       |
 | `minio_s3_traffic_sent_bytes`                 | Total number of s3 bytes sent.                           |
 
@@ -318,6 +320,8 @@ For deployments with [Site Replication](https://min.io/docs/minio/linux/operatio
 | `minio_bucket_requests_total`                     | Total number of S3 requests on a bucket.                        |
 | `minio_bucket_requests_canceled_total`            | Total number S3 requests canceled by the client.                |
 | `minio_bucket_requests_ttfb_seconds_distribution` | Distribution of time to first byte across API calls per bucket. |
+| `minio_bucket_requests_ttfb_seconds_p90`          | p90 time to first byte across API calls per bucket.             |
+| `minio_bucket_requests_ttfb_seconds_p95`          | p95 time to first byte across API calls per bucket.             |
 
 # Resource Metrics
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
New p90 and p95 TTFB metrics added for APIs

## Motivation and Context

## How to test this PR?
Create a bucket, load few objects, list bucket, load multi part objects and then check metrics
`mc admin prometheus metrics ALIAS | grep ttfb`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
