### PR TITLE
Improve object reuse for grid messages

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -152,10 +152,12 @@ func (client *bootstrapRESTClient) Verify(ctx context.Context, srcCfg *ServerSys
 		return nil
 	}
 
-	recvCfg, err := serverVerifyHandler.Call(ctx, client.gridConn, grid.NewMSSWith(map[string]string{}))
+	recvCfg, err := serverVerifyHandler.Call(ctx, client.gridConn, grid.NewMSS())
 	if err != nil {
 		return err
 	}
+	// We do not need the response after returning.
+	defer serverVerifyHandler.PutResponse(recvCfg)
 
 	return srcCfg.Diff(recvCfg)
 }

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1061,7 +1061,7 @@ func (s *peerRESTServer) ListenHandler(ctx context.Context, v *grid.URLValues, o
 				logger.LogOnceIf(ctx, err, "event: Encode failed")
 				continue
 			}
-			out <- grid.NewBytesWith(append(grid.GetByteBuffer()[:0], buf.Bytes()...))
+			out <- grid.NewBytesWithCopyOf(buf.Bytes())
 		}
 	}
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -346,6 +346,7 @@ func (client *storageRESTClient) StatVol(ctx context.Context, volume string) (vo
 		return vol, toStorageErr(err)
 	}
 	vol = *v
+	// Performs shallow copy, so we can reuse.
 	storageStatVolHandler.PutResponse(v)
 	return vol, nil
 }
@@ -455,6 +456,7 @@ func (client *storageRESTClient) RenameData(ctx context.Context, srcVolume, srcP
 	if err != nil {
 		return 0, toStorageErr(err)
 	}
+	defer storageRenameDataHandler.PutResponse(resp)
 	return resp.Signature, nil
 }
 

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -201,7 +201,7 @@ func (s *storageRESTServer) HealthHandler(w http.ResponseWriter, r *http.Request
 // DiskInfo types.
 // DiskInfo.Metrics elements are shared, so we cannot reuse.
 var storageDiskInfoHandler = grid.NewSingleHandler[*DiskInfoOptions, *DiskInfo](grid.HandlerDiskInfo, func() *DiskInfoOptions { return &DiskInfoOptions{} },
-	func() *DiskInfo { return &DiskInfo{} }).WithSharedResponse()
+	func() *DiskInfo { return &DiskInfo{} }).WithSharedResponse().AllowCallRequestPool(true)
 
 // DiskInfoHandler - returns disk info.
 func (s *storageRESTServer) DiskInfoHandler(opts *DiskInfoOptions) (*DiskInfo, *grid.RemoteErr) {
@@ -495,7 +495,7 @@ func (s *storageRESTServer) CheckPartsHandler(p *CheckPartsHandlerParams) (grid.
 
 var storageReadAllHandler = grid.NewSingleHandler[*ReadAllHandlerParams, *grid.Bytes](grid.HandlerReadAll, func() *ReadAllHandlerParams {
 	return &ReadAllHandlerParams{}
-}, grid.NewBytes)
+}, grid.NewBytes).AllowCallRequestPool(true)
 
 // ReadAllHandler - read all the contents of a file.
 func (s *storageRESTServer) ReadAllHandler(p *ReadAllHandlerParams) (*grid.Bytes, *grid.RemoteErr) {
@@ -673,7 +673,7 @@ func (s *storageRESTServer) ListDirHandler(w http.ResponseWriter, r *http.Reques
 
 var storageDeleteFileHandler = grid.NewSingleHandler[*DeleteFileHandlerParams, grid.NoPayload](grid.HandlerDeleteFile, func() *DeleteFileHandlerParams {
 	return &DeleteFileHandlerParams{}
-}, grid.NewNoPayload)
+}, grid.NewNoPayload).AllowCallRequestPool(true)
 
 // DeleteFileHandler - delete a file.
 func (s *storageRESTServer) DeleteFileHandler(p *DeleteFileHandlerParams) (grid.NoPayload, *grid.RemoteErr) {
@@ -751,7 +751,7 @@ func (s *storageRESTServer) RenameDataHandler(p *RenameDataHandlerParams) (*Rena
 
 var storageRenameFileHandler = grid.NewSingleHandler[*RenameFileHandlerParams, grid.NoPayload](grid.HandlerRenameFile, func() *RenameFileHandlerParams {
 	return &RenameFileHandlerParams{}
-}, grid.NewNoPayload)
+}, grid.NewNoPayload).AllowCallRequestPool(true)
 
 // RenameFileHandler - rename a file from source to destination
 func (s *storageRESTServer) RenameFileHandler(p *RenameFileHandlerParams) (grid.NoPayload, *grid.RemoteErr) {

--- a/internal/grid/trace.go
+++ b/internal/grid/trace.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -131,22 +130,26 @@ func (c *muxClient) traceRoundtrip(ctx context.Context, t *tracer, h HandlerID, 
 	}
 	// If the context contains a TraceParamsKey, add it to the trace path.
 	v := ctx.Value(TraceParamsKey{})
-	if p, ok := v.(*MSS); ok && p != nil {
-		trace.Path += p.ToQuery()
-		trace.HTTP.ReqInfo.Path = trace.Path
-	} else if p, ok := v.(map[string]string); ok {
-		m := MSS(p)
+	// Should match SingleHandler.Call checks.
+	switch typed := v.(type) {
+	case *MSS:
+		trace.Path += typed.ToQuery()
+	case map[string]string:
+		m := MSS(typed)
 		trace.Path += m.ToQuery()
-		trace.HTTP.ReqInfo.Path = trace.Path
-	} else if v != nil {
-		// Print exported fields as single request to path.
-		obj := fmt.Sprintf("%+v", v)
-		if len(obj) > 1024 {
-			obj = obj[:1024] + "..."
+	case *URLValues:
+		trace.Path += typed.Values().Encode()
+	case *NoPayload:
+	case *Bytes:
+		if typed != nil {
+			trace.Path = fmt.Sprintf("%s?bytes=%d", trace.Path, len(*typed))
 		}
-		trace.Path = fmt.Sprintf("%s?req=%s", trace.Path, url.QueryEscape(obj))
-		trace.HTTP.ReqInfo.Path = trace.Path
+	case string:
+		trace.Path = fmt.Sprintf("%s?%s", trace.Path, typed)
+	default:
 	}
+	trace.HTTP.ReqInfo.Path = trace.Path
+
 	t.Publisher.Publish(trace)
 	return resp, err
 }

--- a/internal/grid/types.go
+++ b/internal/grid/types.go
@@ -242,7 +242,8 @@ func (b *Bytes) UnmarshalMsg(bytes []byte) ([]byte, error) {
 			*b = make([]byte, 0, len(val))
 		}
 		in := *b
-		*b = append(in[:0], val...)
+		in = append(in[:0], val...)
+		*b = in
 	}
 	return bytes, nil
 }

--- a/internal/grid/types.go
+++ b/internal/grid/types.go
@@ -29,7 +29,7 @@ import (
 
 // Recycler will override the internal reuse in typed handlers.
 // When this is supported, the handler will not do internal pooling of objects,
-// call Recycle() when then object is no longer needed.
+// call Recycle() when the object is no longer needed.
 // The recycler should handle nil pointers.
 type Recycler interface {
 	Recycle()


### PR DESCRIPTION
## Description

Allow internal types to support a `Recycler` interface, which will allow for sharing of common types across handlers.

This means that all `grid.MSS` (and similar) objects are shared across in a common pool instead of a per-handler pool.

Add internal request reuse of internal types. Add for safe (pointerless) types explicitly.

Only log params for internal types. Doing Sprint(obj) is just a bit too messy.

Add a few helpers.

## How to test this PR?

Race testing should catch mistakes.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
