### PR TITLE
Fix ineffective recycling

### DIFF
--- a/internal/grid/types.go
+++ b/internal/grid/types.go
@@ -235,7 +235,6 @@ func (b *Bytes) UnmarshalMsg(bytes []byte) ([]byte, error) {
 		copy(*b, val)
 	} else {
 		if cap(*b) == 0 && len(val) <= maxBufferSize {
-			PutByteBuffer(*b)
 			*b = GetByteBuffer()[:0]
 		} else {
 			PutByteBuffer(*b)


### PR DESCRIPTION
## Description

Recycle would always be called on the dummy value `any(newRT())` instead of the actual value given to the recycle function.

Caught by race tests, but mostly harmless, except for reduced perf.

Other minor cleanups. Introduced in #18940 (unreleased)

Example failure: https://github.com/minio/minio/actions/runs/7756362822/job/21153512979?pr=18951

## How to test this PR?

Race tests with mint or similar.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
