### PR TITLE
Enable expired-object-all-versions

### DIFF
--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -23,12 +23,11 @@ import (
 )
 
 var (
-	errLifecycleInvalidDate              = Errorf("Date must be provided in ISO 8601 format")
-	errLifecycleInvalidDays              = Errorf("Days must be positive integer when used with Expiration")
-	errLifecycleInvalidExpiration        = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
-	errLifecycleInvalidDeleteMarker      = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
-	errLifecycleInvalidDeleteAllVersions = Errorf("Delete all versions cannot be specified with Days or Date in a Lifecycle Expiration Policy")
-	errLifecycleDateNotMidnight          = Errorf("'Date' must be at midnight GMT")
+	errLifecycleInvalidDate         = Errorf("Date must be provided in ISO 8601 format")
+	errLifecycleInvalidDays         = Errorf("Days must be positive integer when used with Expiration")
+	errLifecycleInvalidExpiration   = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
+	errLifecycleInvalidDeleteMarker = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
+	errLifecycleDateNotMidnight     = Errorf("'Date' must be at midnight GMT")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration
@@ -176,11 +175,6 @@ func (e Expiration) Validate() error {
 	// DeleteMarker cannot be specified if date or dates are specified.
 	if (!e.IsDaysNull() || !e.IsDateNull()) && e.DeleteMarker.set {
 		return errLifecycleInvalidDeleteMarker
-	}
-
-	// DeleteAll cannot be specified if date or dates are specified.
-	if (!e.IsDaysNull() || !e.IsDateNull()) && e.DeleteAll.set {
-		return errLifecycleInvalidDeleteAllVersions
 	}
 
 	if !e.DeleteMarker.set && !e.DeleteAll.set && e.IsDaysNull() && e.IsDateNull() {

--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -23,11 +23,12 @@ import (
 )
 
 var (
-	errLifecycleInvalidDate         = Errorf("Date must be provided in ISO 8601 format")
-	errLifecycleInvalidDays         = Errorf("Days must be positive integer when used with Expiration")
-	errLifecycleInvalidExpiration   = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
-	errLifecycleInvalidDeleteMarker = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
-	errLifecycleDateNotMidnight     = Errorf("'Date' must be at midnight GMT")
+	errLifecycleInvalidDate              = Errorf("Date must be provided in ISO 8601 format")
+	errLifecycleInvalidDays              = Errorf("Days must be positive integer when used with Expiration")
+	errLifecycleInvalidExpiration        = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
+	errLifecycleInvalidDeleteMarker      = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
+	errLifecycleInvalidDeleteAllVersions = Errorf("Delete all versions cannot be specified with Days or Date in a Lifecycle Expiration Policy")
+	errLifecycleDateNotMidnight          = Errorf("'Date' must be at midnight GMT")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration
@@ -177,7 +178,12 @@ func (e Expiration) Validate() error {
 		return errLifecycleInvalidDeleteMarker
 	}
 
-	if !e.DeleteMarker.set && e.IsDaysNull() && e.IsDateNull() {
+	// DeleteAll cannot be specified if date or dates are specified.
+	if (!e.IsDaysNull() || !e.IsDateNull()) && e.DeleteAll.set {
+		return errLifecycleInvalidDeleteAllVersions
+	}
+
+	if !e.DeleteMarker.set && !e.DeleteAll.set && e.IsDaysNull() && e.IsDateNull() {
 		return errXMLNotWellFormed
 	}
 

--- a/internal/bucket/lifecycle/expiration_test.go
+++ b/internal/bucket/lifecycle/expiration_test.go
@@ -94,6 +94,20 @@ func TestInvalidExpiration(t *testing.T) {
                                     </Expiration>`,
 			expectedErr: errLifecycleInvalidDeleteMarker,
 		},
+		{ // Expiration with a valid number of days and ExpiredObjectAllVersions
+			inputXML: `<Expiration>
+									<Days>3</Days>
+			            <ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>
+                                    </Expiration>`,
+			expectedErr: nil,
+		},
+		{ // Expiration with a valid ISO 8601 date and ExpiredObjectAllVersions
+			inputXML: `<Expiration>
+									<Date>2019-04-20T00:00:00Z</Date>
+			            <ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>
+                                    </Expiration>`,
+			expectedErr: nil,
+		},
 	}
 	for i, tc := range validationTestCases {
 		t.Run(fmt.Sprintf("Test %d", i+1), func(t *testing.T) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR enables new flag to allow setting an ILM rule which would remove all versions of an expired object. 

## Motivation and Context
There was no way to explicitly set ILM rule using commandline/client to enable removal of all versions of an expired object.

## How to test this PR?
Follow instructions in `mc` PR https://github.com/minio/mc/pull/4840 to test the feature.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
