### PR TITLE
remove unnecessary re-connect/connect() disk routine

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"math/rand"
 	"net/http"
 	"reflect"
 	"strings"
@@ -39,7 +38,6 @@ import (
 	"github.com/minio/minio/internal/dsync"
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
-	"github.com/minio/pkg/v2/console"
 	"github.com/minio/pkg/v2/sync/errgroup"
 )
 
@@ -88,29 +86,6 @@ type erasureSets struct {
 	// Distribution algorithm of choice.
 	distributionAlgo string
 	deploymentID     [16]byte
-
-	lastConnectDisksOpTime time.Time
-}
-
-func (s *erasureSets) getDiskMap() map[Endpoint]StorageAPI {
-	diskMap := make(map[Endpoint]StorageAPI)
-
-	s.erasureDisksMu.RLock()
-	defer s.erasureDisksMu.RUnlock()
-
-	for i := 0; i < s.setCount; i++ {
-		for j := 0; j < s.setDriveCount; j++ {
-			disk := s.erasureDisks[i][j]
-			if disk == OfflineDisk {
-				continue
-			}
-			if !disk.IsOnline() {
-				continue
-			}
-			diskMap[disk.Endpoint()] = disk
-		}
-	}
-	return diskMap
 }
 
 // Initializes a new StorageAPI from the endpoint argument, returns
@@ -195,119 +170,6 @@ func findDiskIndex(refFormat, format *formatErasureV3) (int, int, error) {
 	return -1, -1, fmt.Errorf("DriveID: %s not found", format.Erasure.This)
 }
 
-// connectDisks - attempt to connect all the endpoints, loads format
-// and re-arranges the disks in proper position.
-func (s *erasureSets) connectDisks() {
-	defer func() {
-		s.lastConnectDisksOpTime = time.Now()
-	}()
-
-	var wg sync.WaitGroup
-	diskMap := s.getDiskMap()
-	for _, endpoint := range s.endpoints.Endpoints {
-		cdisk := diskMap[endpoint]
-		if cdisk != nil && cdisk.IsOnline() {
-			if s.lastConnectDisksOpTime.IsZero() {
-				continue
-			}
-
-			// An online-disk means its a valid disk but it may be a re-connected disk
-			// we verify that here based on LastConn(), however we make sure to avoid
-			// putting it back into the s.erasureDisks by re-placing the disk again.
-			_, setIndex, _ := cdisk.GetDiskLoc()
-			if setIndex != -1 {
-				continue
-			}
-		}
-		if cdisk != nil {
-			// Close previous offline disk.
-			cdisk.Close()
-		}
-
-		wg.Add(1)
-		go func(endpoint Endpoint) {
-			defer wg.Done()
-			disk, format, formatData, err := connectEndpoint(endpoint)
-			if err != nil {
-				if endpoint.IsLocal && errors.Is(err, errUnformattedDisk) {
-					globalBackgroundHealState.pushHealLocalDisks(endpoint)
-				} else {
-					printEndpointError(endpoint, err, true)
-				}
-				return
-			}
-			if disk.IsLocal() && disk.Healing() != nil {
-				globalBackgroundHealState.pushHealLocalDisks(disk.Endpoint())
-			}
-			s.erasureDisksMu.Lock()
-			setIndex, diskIndex, err := findDiskIndex(s.format, format)
-			if err != nil {
-				printEndpointError(endpoint, err, false)
-				disk.Close()
-				s.erasureDisksMu.Unlock()
-				return
-			}
-
-			if currentDisk := s.erasureDisks[setIndex][diskIndex]; currentDisk != nil {
-				if !reflect.DeepEqual(currentDisk.Endpoint(), disk.Endpoint()) {
-					err = fmt.Errorf("Detected unexpected drive ordering refusing to use the drive: expecting %s, found %s, refusing to use the drive",
-						currentDisk.Endpoint(), disk.Endpoint())
-					printEndpointError(endpoint, err, false)
-					disk.Close()
-					s.erasureDisksMu.Unlock()
-					return
-				}
-				s.erasureDisks[setIndex][diskIndex].Close()
-			}
-
-			disk.SetDiskID(format.Erasure.This)
-			disk.SetDiskLoc(s.poolIndex, setIndex, diskIndex)
-			disk.SetFormatData(formatData)
-			s.erasureDisks[setIndex][diskIndex] = disk
-			s.erasureDisksMu.Unlock()
-
-			if disk.IsLocal() && globalIsDistErasure {
-				globalLocalDrivesMu.Lock()
-				globalLocalSetDrives[s.poolIndex][setIndex][diskIndex] = disk
-				globalLocalDrivesMu.Unlock()
-			}
-		}(endpoint)
-	}
-
-	wg.Wait()
-}
-
-// monitorAndConnectEndpoints this is a monitoring loop to keep track of disconnected
-// endpoints by reconnecting them and making sure to place them into right position in
-// the set topology, this monitoring happens at a given monitoring interval.
-func (s *erasureSets) monitorAndConnectEndpoints(ctx context.Context, monitorInterval time.Duration) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	time.Sleep(time.Duration(r.Float64() * float64(time.Second)))
-
-	// Pre-emptively connect the disks if possible.
-	s.connectDisks()
-
-	monitor := time.NewTimer(monitorInterval)
-	defer monitor.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-monitor.C:
-			if serverDebugLog {
-				console.Debugln("running drive monitoring")
-			}
-
-			s.connectDisks()
-
-			// Reset the timer for next interval
-			monitor.Reset(monitorInterval)
-		}
-	}
-}
-
 func (s *erasureSets) GetLockers(setIndex int) func() ([]dsync.NetLocker, string) {
 	return func() ([]dsync.NetLocker, string) {
 		lockers := make([]dsync.NetLocker, len(s.erasureLockers[setIndex]))
@@ -339,10 +201,6 @@ func (s *erasureSets) GetDisks(setIndex int) func() []StorageAPI {
 		return disks
 	}
 }
-
-// defaultMonitorConnectEndpointInterval is the interval to monitor endpoint connections.
-// Must be bigger than defaultMonitorNewDiskInterval.
-const defaultMonitorConnectEndpointInterval = defaultMonitorNewDiskInterval + time.Second*5
 
 // Initialize new set of erasure coded sets.
 func newErasureSets(ctx context.Context, endpoints PoolEndpoints, storageDisks []StorageAPI, format *formatErasureV3, defaultParityCount, poolIdx int) (*erasureSets, error) {
@@ -481,11 +339,6 @@ func newErasureSets(ctx context.Context, endpoints PoolEndpoints, storageDisks [
 
 	// start cleanup of deleted objects.
 	go s.cleanupDeletedObjects(ctx)
-
-	// Start the disk monitoring and connect routine.
-	if !globalIsTesting {
-		go s.monitorAndConnectEndpoints(ctx, defaultMonitorConnectEndpointInterval)
-	}
 
 	return s, nil
 }


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
remove unnecessary re-connect/connect() disk routine

## Motivation and Context
- All underlying disks are static, and they are never 
  permanently taken offline; they are always able to 
  come back online.

- There is no reason to have an external connect() logic 
  while there is already an internal health check-in 
  progress per HTTP or Websocket connections.

## How to test this PR?
connect() logic was from a time when we did not
have reconnect() logic internal to MinIO, but now
that we have reconnect() logic at the network layer
there is no reason to have this support anymore.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
