### PR TITLE
Fix tracing send on closed channel

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1935,7 +1935,7 @@ func (a adminAPIHandlers) TraceHandler(w http.ResponseWriter, r *http.Request) {
 	peers, _ := newPeerRestClients(globalEndpoints)
 	err = globalTrace.SubscribeJSON(traceOpts.TraceTypes(), traceCh, ctx.Done(), func(entry madmin.TraceInfo) bool {
 		return shouldTrace(entry, traceOpts)
-	})
+	}, nil)
 	if err != nil {
 		writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, err), r.URL)
 		return

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -1017,7 +1017,7 @@ func (s *peerRESTServer) TraceHandler(ctx context.Context, payload []byte, _ <-c
 	}
 
 	// Wait for remote to cancel and SubscribeJSON to exit.
-	wg.Done()
+	wg.Wait()
 	return nil
 }
 

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -999,12 +1000,13 @@ func (s *peerRESTServer) TraceHandler(ctx context.Context, payload []byte, _ <-c
 	if err != nil {
 		return grid.NewRemoteErr(err)
 	}
+	var wg sync.WaitGroup
 
 	// Trace Publisher uses nonblocking publish and hence does not wait for slow subscribers.
 	// Use buffered channel to take care of burst sends or slow w.Write()
 	err = globalTrace.SubscribeJSON(traceOpts.TraceTypes(), out, ctx.Done(), func(entry madmin.TraceInfo) bool {
 		return shouldTrace(entry, traceOpts)
-	})
+	}, &wg)
 	if err != nil {
 		return grid.NewRemoteErr(err)
 	}
@@ -1013,8 +1015,9 @@ func (s *peerRESTServer) TraceHandler(ctx context.Context, payload []byte, _ <-c
 	if traceOpts.TraceTypes().Contains(madmin.TraceBootstrap) {
 		go globalBootstrapTracer.Publish(ctx, globalTrace)
 	}
-	// Wait for remote to cancel.
-	<-ctx.Done()
+
+	// Wait for remote to cancel and SubscribeJSON to exit.
+	wg.Done()
 	return nil
 }
 


### PR DESCRIPTION
## Description

Depending on when the context cancelation is picked up the handler may return and close the channel before `SubscribeJSON` returns, causing:

```
Feb 05 17:12:00 s3-us-node11 minio[3973657]: panic: send on closed channel
Feb 05 17:12:00 s3-us-node11 minio[3973657]: goroutine 378007076 [running]:
Feb 05 17:12:00 s3-us-node11 minio[3973657]: github.com/minio/minio/internal/pubsub.(*PubSub[...]).SubscribeJSON.func1()
Feb 05 17:12:00 s3-us-node11 minio[3973657]:         github.com/minio/minio/internal/pubsub/pubsub.go:139 +0x12d
Feb 05 17:12:00 s3-us-node11 minio[3973657]: created by github.com/minio/minio/internal/pubsub.(*PubSub[...]).SubscribeJSON in goroutine 378010884
Feb 05 17:12:00 s3-us-node11 minio[3973657]:         github.com/minio/minio/internal/pubsub/pubsub.go:124 +0x352
```

Wait explicitly for the goroutine to exit.

Bonus: Listen for `doneCh` when sending to not risk getting blocked there is channel isn't being emptied.

## How to test this PR?

`mc admin trace` on distributed setup.. Probably needs some load to trigger.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Fixes a regression #18903
