### PR TITLE
Fix second muxclient context leak

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -359,6 +359,7 @@ func (c *Subroute) Request(ctx context.Context, h HandlerID, req []byte) ([]byte
 		if debugReqs {
 			fmt.Println(client.MuxID, c.String(), "Subroute.Request: DELETING MUX")
 		}
+		client.cancelFn(context.Canceled)
 		c.outgoing.Delete(client.MuxID)
 	}()
 	return client.traceRoundtrip(ctx, c.trace, h, req)


### PR DESCRIPTION
## Description

Subrouted requests were also leaking contexts in mux clients.

Similar to #18956

## How to test this PR?

High load, long running time

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
