### PR TITLE
Add GetBucketInfo toStorageErr conversion

### DIFF
--- a/cmd/peer-s3-client.go
+++ b/cmd/peer-s3-client.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/minio/madmin-go/v3"
-	grid "github.com/minio/minio/internal/grid"
+	"github.com/minio/minio/internal/grid"
 	xhttp "github.com/minio/minio/internal/http"
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/minio/internal/rest"
@@ -400,7 +400,7 @@ func (client *remotePeerS3Client) GetBucketInfo(ctx context.Context, bucket stri
 
 	volInfo, err := headBucketHandler.Call(ctx, conn, mss)
 	if err != nil {
-		return BucketInfo{}, err
+		return BucketInfo{}, toStorageErr(err)
 	}
 
 	return BucketInfo{


### PR DESCRIPTION
## Description

Convert error to storageError since it is used for quorum calculations for example here: https://github.com/minio/minio/blob/ff80cfd83dc874f65e4436cf021186f04d44557e/cmd/peer-s3-client.go#L339

## How to test this PR?

Disconnect one client and try for example GetBucketACL

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
