### PR TITLE
optimize startup sequence performance

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1958,11 +1958,7 @@ func (z *erasureServerPools) HealFormat(ctx context.Context, dryRun bool) (madmi
 }
 
 func (z *erasureServerPools) HealBucket(ctx context.Context, bucket string, opts madmin.HealOpts) (madmin.HealResultItem, error) {
-	// Attempt heal on the bucket metadata, ignore any failures
-	hopts := opts
-	hopts.Recreate = false
-	defer z.HealObject(ctx, minioMetaBucket, pathJoin(bucketMetaPrefix, bucket, bucketMetadataFile), "", hopts)
-
+	// .metadata.bin healing is not needed here, it is automatically healed via read() call.
 	return z.s3Peer.HealBucket(ctx, bucket, opts)
 }
 

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -313,7 +313,7 @@ func (client *storageRESTClient) DiskInfo(ctx context.Context, opts DiskInfoOpti
 
 	infop, err := storageDiskInfoHandler.Call(ctx, client.gridConn, &opts)
 	if err != nil {
-		return info, err
+		return info, toStorageErr(err)
 	}
 	info = *infop
 	if info.Error != "" {
@@ -442,10 +442,6 @@ func (client *storageRESTClient) CheckParts(ctx context.Context, volume string, 
 
 // RenameData - rename source path to destination path atomically, metadata and data file.
 func (client *storageRESTClient) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (sign uint64, err error) {
-	// Set a very long timeout for rename data.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
 	resp, err := storageRenameDataHandler.Call(ctx, client.gridConn, &RenameDataHandlerParams{
 		DiskID:    client.diskID,
 		SrcVolume: srcVolume,
@@ -704,10 +700,6 @@ func (client *storageRESTClient) DeleteVersions(ctx context.Context, volume stri
 
 // RenameFile - renames a file.
 func (client *storageRESTClient) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) (err error) {
-	// Set a very long timeout for rename file
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
 	_, err = storageRenameFileHandler.Call(ctx, client.gridConn, &RenameFileHandlerParams{
 		DiskID:      client.diskID,
 		SrcVolume:   srcVolume,

--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -175,8 +175,8 @@ func (c ContextDialer) DialContext(ctx context.Context, network, address string)
 
 const (
 	defaultOutQueue    = 10000
-	readBufferSize     = 16 << 10
-	writeBufferSize    = 16 << 10
+	readBufferSize     = 32 << 10 // 32 KiB is the most optimal on Linux
+	writeBufferSize    = 32 << 10 // 32 KiB is the most optimal on Linux
 	defaultDialTimeout = 2 * time.Second
 	connPingInterval   = 10 * time.Second
 	connWriteTimeout   = 3 * time.Second
@@ -654,7 +654,7 @@ func (c *Connection) connect() {
 				fmt.Printf("%v Connecting to %v: %v. Retrying.\n", c.Local, toDial, err)
 			}
 			sleep := defaultDialTimeout + time.Duration(rng.Int63n(int64(defaultDialTimeout)))
-			next := dialStarted.Add(sleep)
+			next := dialStarted.Add(sleep / 2)
 			sleep = time.Until(next).Round(time.Millisecond)
 			if sleep < 0 {
 				sleep = 0
@@ -950,7 +950,7 @@ func (c *Connection) handleMessages(ctx context.Context, conn net.Conn) {
 				cancel(ErrDisconnected)
 				return
 			}
-			if cap(msg) > readBufferSize*8 {
+			if cap(msg) > readBufferSize*4 {
 				// Don't keep too much memory around.
 				msg = nil
 			}

--- a/internal/grid/grid.go
+++ b/internal/grid/grid.go
@@ -45,7 +45,7 @@ const (
 	maxBufferSize = 64 << 10
 
 	// If there is a queue, merge up to this many messages.
-	maxMergeMessages = 20
+	maxMergeMessages = 30
 
 	// clientPingInterval will ping the remote handler every 15 seconds.
 	// Clients disconnect when we exceed 2 intervals.


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
optimize startup sequence performance

## Motivation and Context
- bucket metadata does not need to look for legacy 
  things if b.Created is non-zero

- stagger bucket metadata loads across lots of nodes to avoid 
  the current thundering herd problem.

- Remove deadlines for RenameData and RenameFile. These calls 
  should never be timed out and wait until completion or for 
  client timeout. Do not choose timeouts for applications during 
  the WRITE phase.

## How to test this PR?
Requires a large enough cluster to validate the changes fully

With the current release, this can go on for 2-3mins
```
minio289.minio.quest:9000 [server-main.go:969:serverMain.func17()] globalBucketMetadataSys.Init (duration: 2m)
```

With all the new changes, here is how much it takes now for a single
bucket metadata load across 300 nodes.
```
minio289.minio.quest:9000 [server-main.go:969:serverMain.func17()] globalBucketMetadataSys.Init (duration: 367.643456ms)
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
