### PR TITLE
Fix shared top locks client

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -460,6 +460,7 @@ func (sys *NotificationSys) GetLocks(ctx context.Context, r *http.Request) []*Pe
 	g := errgroup.WithNErrs(len(sys.peerClients))
 	for index, client := range sys.peerClients {
 		index := index
+		client := client
 		g.Go(func() error {
 			if client == nil {
 				return errPeerNotReachable


### PR DESCRIPTION
## Description

`client` is shared across goroutines.

## How to test this PR?

Seen with `mc support top locks` on minio built with `-race`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
