### PR TITLE
fix: allow configuring excess versions alerting

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -602,6 +602,8 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		// update dynamic scanner values.
 		scannerIdleMode.Store(scannerCfg.IdleMode)
 		scannerCycle.Store(scannerCfg.Cycle)
+		scannerExcessObjectVersions.Store(scannerCfg.ExcessVersions)
+		scannerExcessFolders.Store(scannerCfg.ExcessFolders)
 		logger.LogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 	case config.LoggerWebhookSubSys:
 		loggerCfg, err := logger.LookupConfigForSubSys(ctx, s, config.LoggerWebhookSubSys)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2360,9 +2360,18 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		Host:         handlers.GetSourceIP(r),
 	}
 	sendEvent(evt)
-	if objInfo.NumVersions > dataScannerExcessiveVersionsThreshold {
+	if objInfo.NumVersions > int(scannerExcessObjectVersions.Load()) {
 		evt.EventName = event.ObjectManyVersions
 		sendEvent(evt)
+
+		auditLogInternal(context.Background(), AuditLogOptions{
+			Event:     "scanner:manyversions",
+			APIName:   "PutObject",
+			Bucket:    objInfo.Bucket,
+			Object:    objInfo.Name,
+			VersionID: objInfo.VersionID,
+			Status:    http.StatusText(http.StatusOK),
+		})
 	}
 
 	// Do not send checksums in events to avoid leaks.

--- a/internal/config/scanner/help.go
+++ b/internal/config/scanner/help.go
@@ -28,9 +28,21 @@ var (
 	Help = config.HelpKVS{
 		config.HelpKV{
 			Key:         Speed,
-			Description: `scanner speed` + defaultHelpPostfix(Speed),
+			Description: `customize scanner speed (default|slowest|slow|fast|fastest)` + defaultHelpPostfix(Speed),
 			Optional:    true,
-			Type:        "default|slowest|slow|fast|fastest",
+			Type:        "string",
+		},
+		config.HelpKV{
+			Key:         ExcessVersions,
+			Description: `alert per object beyond this many versions` + defaultHelpPostfix(ExcessVersions),
+			Optional:    true,
+			Type:        "int",
+		},
+		config.HelpKV{
+			Key:         ExcessFolders,
+			Description: `alert beyond this many sub-folders per folder in an erasure set` + defaultHelpPostfix(ExcessFolders),
+			Optional:    true,
+			Type:        "int",
 		},
 	}
 )


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: allow configuring excess versions alerting

## Motivation and Context
Bonus: enable audit alerts for object versions
beyond the configured value, the default is '100'
versions per object beyond which the scanner will
alert for each such object.

## How to test this PR?
Just as advertised

```
mc admin config set alias/ scanner alert_excess_versions=10
```

make sure to configured audit notification, this would
start sending alerts every scanner cycle per object visit.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
