### PR TITLE
Fix panic in tagging request proxying

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -2409,8 +2409,7 @@ func proxyTaggingToRepTarget(ctx context.Context, bucket, object string, tags *t
 			taggedCount++
 			continue
 		}
-		errCode := minio.ToErrorResponse(err).Code
-		if errCode != "NoSuchKey" && errCode != "NoSuchVersion" {
+		if err != nil {
 			terr = err
 		}
 	}
@@ -2469,6 +2468,9 @@ func proxyGetTaggingToRepTarget(ctx context.Context, bucket, object string, opts
 		if err == nil {
 			tgs, _ = tags.MapToObjectTags(tagSlc[idx])
 		}
+	}
+	if len(errs) == 1 {
+		proxy.Err = errs[0]
 	}
 	return tgs, proxy
 }

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -3317,7 +3317,7 @@ func (api objectAPIHandlers) GetObjectTaggingHandler(w http.ResponseWriter, r *h
 				globalReplicationStats.incProxy(bucket, getObjectTaggingAPI, false)
 				// proxy to replication target if site replication is in place.
 				tags, gerr := proxyGetTaggingToRepTarget(ctx, bucket, object, opts, proxytgts)
-				if gerr.Err != nil {
+				if gerr.Err != nil || tags == nil {
 					globalReplicationStats.incProxy(bucket, getObjectTaggingAPI, true)
 					writeErrorResponse(ctx, w, toAPIError(ctx, gerr.Err), r.URL)
 					return


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
```
panic: "GET /test/ilm?tagging": runtime error: invalid memory address or nil pointer dereference
goroutine 2246 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x5e
github.com/minio/minio/cmd.serverMain.func8.setCriticalErrorHandler.func2.1()
        github.com/minio/minio/cmd/generic-handlers.go:555 +0x97
panic({0x266d540?, 0x6133980?})
        runtime/panic.go:914 +0x21f
github.com/minio/minio/cmd.objectAPIHandlers.GetObjectTaggingHandler({0xc095983938?}, {0x4aabc60?, 0xc090700300}, 0xc08f981f00)
        github.com/minio/minio/cmd/object-handlers.go:3338 +0x582
net/http.HandlerFunc.ServeHTTP(0x515db94?, {0x4aabc60?, 0xc090700300?}, 0xc000a08000?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.registerAPIRouter.httpTraceHdrs.httpTrace.func170({0x4aabc60, 0xc090700300}, 0xc0900ab348?)
        github.com/minio/minio/cmd/http-tracer.go:189 +0xef
net/http.HandlerFunc.ServeHTTP(0x2984b60?, {0x4aabc60?, 0xc090700300?}, 0x4?)
        net/http/server.go:2136 +0x29
github.com/klauspost/compress/gzhttp.NewWrapper.func1.1({0x4aaadd0, 0xc000e889c0}, 0xc000cc14a0?)
        github.com/klauspost/compress@v1.17.4/gzhttp/compress.go:501 +0x4fc
net/http.HandlerFunc.ServeHTTP(0xc0900ab5a0?, {0x4aaadd0?, 0xc000e889c0?}, 0x1?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.registerAPIRouter.maxClients.func26({0x4aaadd0, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/handler-api.go:331 +0x47e
net/http.HandlerFunc.ServeHTTP(0x61c1540?, {0x4aaadd0?, 0xc000e889c0?}, 0x2ac510d?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.registerAPIRouter.collectAPIStats.func27({0x4aaadd0?, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/handler-utils.go:307 +0x4a5
net/http.HandlerFunc.ServeHTTP(0xc08f82b230?, {0x4aaadd0?, 0xc000e889c0?}, 0xc090379d10?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setBucketForwardingMiddleware.func1({0x4aaadd0, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/generic-handlers.go:460 +0x2fc
net/http.HandlerFunc.ServeHTTP(0x2895b60?, {0x4aaadd0?, 0xc000e889c0?}, 0x8?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setUploadForwardingMiddleware.func1({0x4aaadd0?, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/generic-handlers.go:610 +0x6b4
net/http.HandlerFunc.ServeHTTP(0x299cde0?, {0x4aaadd0?, 0xc000e889c0?}, 0x39?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setRequestValidityMiddleware.func1({0x4aaadd0?, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/generic-handlers.go:443 +0x168d
net/http.HandlerFunc.ServeHTTP(0xc08f82b350?, {0x4aaadd0?, 0xc000e889c0?}, 0x0?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setRequestLimitMiddleware.func1({0x4aaadd0?, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/generic-handlers.go:134 +0x662
net/http.HandlerFunc.ServeHTTP(0x2ab5d81?, {0x4aaadd0?, 0xc000e889c0?}, 0x20b4b4b?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setCrossDomainPolicyMiddleware.func1({0x4aaadd0?, 0xc000e889c0?}, 0x1?)
        github.com/minio/minio/cmd/crossdomain-xml-handler.go:42 +0xf1
net/http.HandlerFunc.ServeHTTP(0xc08f981f00?, {0x4aaadd0?, 0xc000e889c0?}, 0x2000000000000000?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setBrowserRedirectMiddleware.func1({0x4aaadd0, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/generic-handlers.go:164 +0x19c
net/http.HandlerFunc.ServeHTTP(0x2647280?, {0x4aaadd0?, 0xc000e889c0?}, 0xaa?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.setAuthMiddleware.func1({0x4aaadd0?, 0xc000e889c0}, 0xc08f981f00)
        github.com/minio/minio/cmd/auth-handler.go:644 +0x94b
net/http.HandlerFunc.ServeHTTP(0x4ab1500?, {0x4aaadd0?, 0xc000e889c0?}, 0x4a89430?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.httpTracerMiddleware.func1({0x4aab870, 0xc09061aee0}, 0xc08f981e00)
        github.com/minio/minio/cmd/http-tracer.go:89 +0x3b4
net/http.HandlerFunc.ServeHTTP(0x2857cc0?, {0x4aab870?, 0xc09061aee0?}, 0xa?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.addCustomHeadersMiddleware.func1({0x4aab870, 0xc09061aee0}, 0xc08f82b2f0?)
        github.com/minio/minio/cmd/generic-handlers.go:538 +0x438
net/http.HandlerFunc.ServeHTTP(0xc08f981d00?, {0x4aab870?, 0xc09061aee0?}, 0x50e13f?)
        net/http/server.go:2136 +0x29
github.com/minio/mux.(*Router).ServeHTTP(0xc000000fc0, {0x4aab870, 0xc09061aee0}, 0xc08f981d00)
        github.com/minio/mux@v1.9.0/mux.go:214 +0x1f7
github.com/minio/minio/cmd.corsHandler.(*Cors).Handler.func2({0x4aab870, 0xc09061aee0}, 0xc08f981d00)
        github.com/rs/cors@v1.10.1/cors.go:281 +0x184
net/http.HandlerFunc.ServeHTTP(0x72?, {0x4aab870?, 0xc09061aee0?}, 0x0?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/cmd.serverMain.func8.setCriticalErrorHandler.func2({0x4aab870?, 0xc09061aee0?}, 0xc09037baf0?)
        github.com/minio/minio/cmd/generic-handlers.go:562 +0x78
net/http.HandlerFunc.ServeHTTP(0x10?, {0x4aab870?, 0xc09061aee0?}, 0xc09037bae8?)
        net/http/server.go:2136 +0x29
github.com/minio/minio/internal/http.(*Server).Init.func1({0x4aab870?, 0xc09061aee0?}, 0xc08fb79b80?)
        github.com/minio/minio/internal/http/server.go:127 +0x258
net/http.HandlerFunc.ServeHTTP(0x622de80?, {0x4aab870?, 0xc09061aee0?}, 0xc09037bb50?)
        net/http/server.go:2136 +0x29
net/http.serverHandler.ServeHTTP({0xc08f82b170?}, {0x4aab870?, 0xc09061aee0?}, 0x6?)
        net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc08f6f10e0, {0x4ab1500, 0xc000a262d0})
        net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 57
        net/http/server.go:3086 +0x5cb
        ```

## How to test this PR?
try GET tagging request on non-existent objects
PUT tagging on non-existent objects should return 404, not 200 OK
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
