### PR TITLE
preserve conflicting objects when parent object is being deleted

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -1146,7 +1146,7 @@ func (s *xlStorage) deleteVersions(ctx context.Context, volume, path string, fis
 		return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
 	}
 
-	return s.deleteFile(volumeDir, pathJoin(volumeDir, path), true, false)
+	return s.deleteFile(volumeDir, pathJoin(volumeDir, path, xlStorageFormatFile), true, false)
 }
 
 // DeleteVersions deletes slice of versions, it can be same object
@@ -1307,7 +1307,7 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 		return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
 	}
 
-	return s.deleteFile(volumeDir, filePath, true, false)
+	return s.deleteFile(volumeDir, pathJoin(volumeDir, path, xlStorageFormatFile), true, false)
 }
 
 // Updates only metadata for a given version.


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
preserve conflicting objects when the parent object is being deleted

## Motivation and Context
```
a/prefix
a/prefix/1.txt
```

where `a/prefix` is an object that does not have `/` 
in the end, we do not have to aggressively recursively 
delete all the sub-folders as well. Instead, convert 
the call into self-contained to delete 'xl.meta' 
and then subsequently attempt to Remove the parent.

## How to test this PR?
Well create conflicting objects such as these

```
mc cp /etc/hosts myminio/testbucket/prefix (first object)
mc cp /etc/hosts myminio/testbucket/prefix/hosts (conflicting object, with parent as object)
```

```
mc rm myminio/testbucket/prefix --force
```

Would end up deleting `prefix/hosts` as well in the current release, 
changing this behavior to only delete `myminio/testbucket/prefix` 
not the conflicting object. 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
