### PR TITLE
remove unnecessary re-connect/connect() disk routine

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -344,6 +344,19 @@ func (l EndpointServerPools) Localhost() string {
 	return fmt.Sprintf("%s://%s", getURLScheme(globalIsTLS), net.JoinHostPort(host, globalMinioPort))
 }
 
+// LocalDrives returns all the local drives.
+func (l EndpointServerPools) LocalDrives() []Endpoint {
+	var drives []Endpoint
+	for _, ep := range l {
+		for _, endpoint := range ep.Endpoints {
+			if endpoint.IsLocal {
+				drives = append(drives, endpoint)
+			}
+		}
+	}
+	return drives
+}
+
 // LocalDisksPaths returns the disk paths of the local disks
 func (l EndpointServerPools) LocalDisksPaths() []string {
 	var disks []string

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -743,10 +743,9 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 		wg := sync.WaitGroup{}
 		for i, disk := range disks {
 			if disk == nil {
-				done <- false
-				continue
-			}
-			if !disk.IsOnline() {
+				rw.Lock()
+				errs[i] = errDiskNotFound
+				rw.Unlock()
 				done <- false
 				continue
 			}

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -326,7 +326,7 @@ func loadFormatErasureAll(storageDisks []StorageAPI, heal bool) ([]*formatErasur
 			if storageDisks[index] == nil {
 				return errDiskNotFound
 			}
-			format, formatData, err := loadFormatErasureWithData(storageDisks[index], heal)
+			format, _, err := loadFormatErasureWithData(storageDisks[index], heal)
 			if err != nil {
 				return err
 			}
@@ -335,7 +335,6 @@ func loadFormatErasureAll(storageDisks []StorageAPI, heal bool) ([]*formatErasur
 				// If no healing required, make the disks valid and
 				// online.
 				storageDisks[index].SetDiskID(format.Erasure.This)
-				storageDisks[index].SetFormatData(formatData)
 			}
 			return nil
 		}, index)
@@ -375,7 +374,6 @@ func saveFormatErasure(disk StorageAPI, format *formatErasureV3, healID string) 
 	}
 
 	disk.SetDiskID(format.Erasure.This)
-	disk.SetFormatData(formatData)
 	if healID != "" {
 		ctx := context.Background()
 		ht := initHealingTracker(disk, healID)

--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -48,6 +48,7 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	result := objLayer.Health(ctx, opts)
 	w.Header().Set(xhttp.MinIOWriteQuorum, strconv.Itoa(result.WriteQuorum))
+	w.Header().Set(xhttp.MinIOReadQuorum, strconv.Itoa(result.ReadQuorum))
 	w.Header().Set(xhttp.MinIOStorageClassDefaults, strconv.FormatBool(result.UsingDefaults))
 	// return how many drives are being healed if any
 	if result.HealingDrives > 0 {
@@ -69,7 +70,7 @@ func ClusterCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 // ClusterReadCheckHandler returns if the server is ready for requests.
 func ClusterReadCheckHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := newContext(r, w, "ClusterReadCheckHandler")
+	ctx := newContext(r, w, "ClusterCheckHandler")
 
 	objLayer := newObjectLayerFn()
 	if objLayer == nil {
@@ -81,12 +82,29 @@ func ClusterReadCheckHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(ctx, globalAPIConfig.getClusterDeadline())
 	defer cancel()
 
-	result := objLayer.ReadHealth(ctx)
-	if !result {
-		writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
+	opts := HealthOptions{
+		Maintenance:    r.Form.Get("maintenance") == "true",
+		DeploymentType: r.Form.Get("deployment-type"),
+	}
+	result := objLayer.Health(ctx, opts)
+	w.Header().Set(xhttp.MinIOWriteQuorum, strconv.Itoa(result.WriteQuorum))
+	w.Header().Set(xhttp.MinIOReadQuorum, strconv.Itoa(result.ReadQuorum))
+	w.Header().Set(xhttp.MinIOStorageClassDefaults, strconv.FormatBool(result.UsingDefaults))
+	// return how many drives are being healed if any
+	if result.HealingDrives > 0 {
+		w.Header().Set(xhttp.MinIOHealingDrives, strconv.Itoa(result.HealingDrives))
+	}
+	if !result.HealthyRead {
+		// As a maintenance call we are purposefully asked to be taken
+		// down, this is for orchestrators to know if we can safely
+		// take this server down, return appropriate error.
+		if opts.Maintenance {
+			writeResponse(w, http.StatusPreconditionFailed, nil, mimeNone)
+		} else {
+			writeResponse(w, http.StatusServiceUnavailable, nil, mimeNone)
+		}
 		return
 	}
-
 	writeResponse(w, http.StatusOK, nil, mimeNone)
 }
 

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -102,14 +102,8 @@ func (d *naughtyDisk) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return -1, -1, -1
 }
 
-func (d *naughtyDisk) SetDiskLoc(poolIdx, setIdx, diskIdx int) {}
-
 func (d *naughtyDisk) GetDiskID() (string, error) {
 	return d.disk.GetDiskID()
-}
-
-func (d *naughtyDisk) SetFormatData(b []byte) {
-	d.disk.SetFormatData(b)
 }
 
 func (d *naughtyDisk) SetDiskID(id string) {

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -287,7 +287,6 @@ type ObjectLayer interface {
 
 	// Returns health of the backend
 	Health(ctx context.Context, opts HealthOptions) HealthResult
-	ReadHealth(ctx context.Context) bool
 
 	// Metadata operations
 	PutObjectMetadata(context.Context, string, string, ObjectOptions) (ObjectInfo, error)

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -109,8 +109,6 @@ type StorageAPI interface {
 	// Read all.
 	ReadAll(ctx context.Context, volume string, path string) (buf []byte, err error)
 	GetDiskLoc() (poolIdx, setIdx, diskIdx int) // Retrieve location indexes.
-	SetDiskLoc(poolIdx, setIdx, diskIdx int)    // Set location indexes.
-	SetFormatData(b []byte)                     // Set formatData cached value
 }
 
 type unrecognizedDisk struct {
@@ -153,14 +151,8 @@ func (p *unrecognizedDisk) NSScanner(ctx context.Context, cache dataUsageCache, 
 	return dataUsageCache{}, errDiskNotFound
 }
 
-func (p *unrecognizedDisk) SetFormatData(b []byte) {
-}
-
 func (p *unrecognizedDisk) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return -1, -1, -1
-}
-
-func (p *unrecognizedDisk) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
 }
 
 func (p *unrecognizedDisk) Close() error {

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -165,21 +165,11 @@ type storageRESTClient struct {
 	diskID      string
 	formatData  []byte
 	formatMutex sync.RWMutex
-
-	// Indexes, will be -1 until assigned a set.
-	poolIndex, setIndex, diskIndex int
 }
 
 // Retrieve location indexes.
 func (client *storageRESTClient) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
-	return client.poolIndex, client.setIndex, client.diskIndex
-}
-
-// Set location indexes.
-func (client *storageRESTClient) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
-	client.poolIndex = poolIdx
-	client.setIndex = setIdx
-	client.diskIndex = diskIdx
+	return client.endpoint.PoolIdx, client.endpoint.SetIdx, client.endpoint.DiskIdx
 }
 
 // Wrapper to restClient.Call to handle network errors, in case of network error the connection is makred disconnected
@@ -266,14 +256,6 @@ func (client *storageRESTClient) NSScanner(ctx context.Context, cache dataUsageC
 		return cache, errors.New("no final cache")
 	}
 	return *final, nil
-}
-
-func (client *storageRESTClient) SetFormatData(b []byte) {
-	if client.IsOnline() {
-		client.formatMutex.Lock()
-		client.formatData = b
-		client.formatMutex.Unlock()
-	}
 }
 
 func (client *storageRESTClient) GetDiskID() (string, error) {
@@ -859,7 +841,7 @@ func newStorageRESTClient(endpoint Endpoint, healthCheck bool, gm *grid.Manager)
 		return nil, fmt.Errorf("unable to find connection for %s in targets: %v", endpoint.GridHost(), gm.Targets())
 	}
 	return &storageRESTClient{
-		endpoint: endpoint, restClient: restClient, poolIndex: -1, setIndex: -1, diskIndex: -1,
+		endpoint: endpoint, restClient: restClient,
 		gridConn: conn,
 	}, nil
 }

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -247,16 +247,8 @@ func (p *xlStorageDiskIDCheck) NSScanner(ctx context.Context, cache dataUsageCac
 	return p.storage.NSScanner(ctx, cache, updates, scanMode, weSleep)
 }
 
-func (p *xlStorageDiskIDCheck) SetFormatData(b []byte) {
-	p.storage.SetFormatData(b)
-}
-
 func (p *xlStorageDiskIDCheck) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return p.storage.GetDiskLoc()
-}
-
-func (p *xlStorageDiskIDCheck) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
-	p.storage.SetDiskLoc(poolIdx, setIdx, diskIdx)
 }
 
 func (p *xlStorageDiskIDCheck) Close() error {

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -141,22 +141,6 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data, allPart
 	return fi, nil
 }
 
-// getXLDiskLoc will return the pool/set/disk id if it can be located in the object layer.
-// Will return -1 for unknown values.
-func getXLDiskLoc(diskID string) (poolIdx, setIdx, diskIdx int) {
-	if api := newObjectLayerFn(); api != nil {
-		if globalIsErasureSD {
-			return 0, 0, 0
-		}
-		if ep, ok := api.(*erasureServerPools); ok {
-			if pool, set, disk, err := ep.getPoolAndSet(diskID); err == nil {
-				return pool, set, disk
-			}
-		}
-	}
-	return -1, -1, -1
-}
-
 // hashDeterministicString will return a deterministic hash for the map values.
 // Trivial collisions are avoided, but this is by no means a strong hash.
 func hashDeterministicString(m map[string]string) uint64 {

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,6 @@ github.com/minio/minio-go/v7 v7.0.66 h1:bnTOXOHjOqv/gcMuiVbN9o2ngRItvqE774dG9nq0
 github.com/minio/minio-go/v7 v7.0.66/go.mod h1:DHAgmyQEGdW3Cif0UooKOyrT3Vxs82zNdV6tkKhRtbs=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/mux v1.9.0/go.mod h1:1pAare17ZRL5GpmNL+9YmqHoWnLmMZF9C/ioUCfy0BQ=
-github.com/minio/pkg/v2 v2.0.9-0.20240130164631-ac3f1be23e94 h1:nBZkkmq9HPfs2ZUDcRqPahe2js1mvMUR/7cBfW17Jik=
-github.com/minio/pkg/v2 v2.0.9-0.20240130164631-ac3f1be23e94/go.mod h1:yayUTo82b0RK+e97hGb1naC787mOtUEyDs3SIcwSyHI=
 github.com/minio/pkg/v2 v2.0.9-0.20240209124402-7990a27fd79d h1:xGtyFgqwGy7Lc/i5udOKKeqsyRpQPlKQY2Pf4RiUDtk=
 github.com/minio/pkg/v2 v2.0.9-0.20240209124402-7990a27fd79d/go.mod h1:yayUTo82b0RK+e97hGb1naC787mOtUEyDs3SIcwSyHI=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -192,6 +192,9 @@ const (
 	// Writes expected write quorum
 	MinIOWriteQuorum = "x-minio-write-quorum"
 
+	// Reads expected read quorum
+	MinIOReadQuorum = "x-minio-read-quorum"
+
 	// Indicates if we are using default storage class and there was problem loading config
 	// if this header is set to "true"
 	MinIOStorageClassDefaults = "x-minio-storage-class-defaults"


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
remove unnecessary re-connect/connect() disk routine

## Motivation and Context
- all underlying disks are static, and they are never taken 
  offline permanently, they are always able to come back online.

- there is no reason to have an external connect() logic while 
  there is already an internal health check per HTTP or 
  Websocket connections.

- re-imagine the role of 'format.json'


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
