### PR TITLE
Refresh tier config periodically

### DIFF
--- a/cmd/tier-handlers.go
+++ b/cmd/tier-handlers.go
@@ -140,6 +140,7 @@ func (api adminAPIHandlers) ListTierHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	w.Header().Set(tierCfgRefreshAtHdr, globalTierConfigMgr.refreshedAt().String())
 	writeSuccessResponseJSON(w, data)
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
- Increase the parity for tier-config.bin object
- Refresh globalTierConfigMgr cached value once every 15 mins


## Motivation and Context
When tier configuration wasn't loaded at the start up of MinIO server it never retries subsequently. 

## How to test this PR?
- Setup one or more tiers
- `mc ilm tier ls ...` multiple times if ALIAS is configured to a load balanced address to ensure that the list of tiers returned is up to date.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
