### PR TITLE
Add missing yaml syntax highlighting to docs/metrics/prometheus/README.md

### DIFF
--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -67,14 +67,13 @@ scrape_configs:
 
 ##### Bucket centric
 
-```
+```yaml
 - job_name: minio-job-bucket
   bearer_token: <secret>
   metrics_path: /minio/v2/metrics/bucket
   scheme: http
   static_configs:
   - targets: ['localhost:9000']
-
 ```
 
 #### 3.2 Public Prometheus config


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add missing yaml syntax highlighting to docs/metrics/prometheus/README.md

## Motivation and Context
just saw the yaml syntax highlighting is missing

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
