### PR TITLE
Add DeleteAll with expiry days non zero value only

### DIFF
--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -28,7 +28,7 @@ var (
 	errLifecycleInvalidExpiration   = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
 	errLifecycleInvalidDeleteMarker = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
 	errLifecycleDateNotMidnight     = Errorf("'Date' must be at midnight GMT")
-	errLifecycleInvalidDeleteAll    = Errorf("Days (positive integer) should be present inside Expiration with DeleteAll.")
+	errLifecycleInvalidDeleteAll    = Errorf("Days (positive integer) should be present inside Expiration with ExpiredObjectAllVersions.")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration

--- a/internal/bucket/lifecycle/expiration.go
+++ b/internal/bucket/lifecycle/expiration.go
@@ -28,6 +28,7 @@ var (
 	errLifecycleInvalidExpiration   = Errorf("Exactly one of Days (positive integer) or Date (positive ISO 8601 format) should be present inside Expiration.")
 	errLifecycleInvalidDeleteMarker = Errorf("Delete marker cannot be specified with Days or Date in a Lifecycle Expiration Policy")
 	errLifecycleDateNotMidnight     = Errorf("'Date' must be at midnight GMT")
+	errLifecycleInvalidDeleteAll    = Errorf("Days (positive integer) should be present inside Expiration with DeleteAll.")
 )
 
 // ExpirationDays is a type alias to unmarshal Days in Expiration
@@ -184,6 +185,11 @@ func (e Expiration) Validate() error {
 	// Both expiration days and date are specified
 	if !e.IsDaysNull() && !e.IsDateNull() {
 		return errLifecycleInvalidExpiration
+	}
+
+	// DeleteAll set without expiration days
+	if e.DeleteAll.set && e.IsDaysNull() {
+		return errLifecycleInvalidDeleteAll
 	}
 
 	return nil

--- a/internal/bucket/lifecycle/expiration_test.go
+++ b/internal/bucket/lifecycle/expiration_test.go
@@ -106,7 +106,7 @@ func TestInvalidExpiration(t *testing.T) {
 									<Date>2019-04-20T00:00:00Z</Date>
 			            <ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>
                                     </Expiration>`,
-			expectedErr: nil,
+			expectedErr: errLifecycleInvalidDeleteAll,
 		},
 	}
 	for i, tc := range validationTestCases {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
DeleteAll should be set with expiry days only to have an effect for removal of all expired object versions.

## Motivation and Context


## How to test this PR?
1. Load objects to a bucket in old date
2. Add ILM rules as `mc ilm rule add ALIAS/BUCKET --expire-all-object-versions --expire-days 1` and wait for object versions to expire and etting removed
3. `mc ilm rule add ALIAS/BUCKET --expire-all-object-versions` should fail with error `mc: <ERROR> Unable to add this lifecycle rule. Days (positive integer) should be present inside Expiration with DeleteAll.`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
