### PR TITLE
Fix grid reconnection deadlock

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -531,10 +531,11 @@ func (c *Connection) shouldConnect() bool {
 	return h0 < h1
 }
 
-func (c *Connection) send(msg []byte) error {
+func (c *Connection) send(ctx context.Context, msg []byte) error {
 	select {
-	case <-c.ctx.Done():
-		return context.Cause(c.ctx)
+	case <-ctx.Done():
+		// Returning error here is too noisy.
+		return nil
 	case c.outQueue <- msg:
 		return nil
 	}
@@ -570,7 +571,7 @@ func (c *Connection) queueMsg(msg message, payload sender) error {
 		h := xxh3.Hash(dst)
 		dst = binary.LittleEndian.AppendUint32(dst, uint32(h))
 	}
-	return c.send(dst)
+	return c.send(c.ctx, dst)
 }
 
 // sendMsg will send

--- a/internal/grid/grid.go
+++ b/internal/grid/grid.go
@@ -184,12 +184,12 @@ func (m *lockedClientMap) Delete(id uint64) {
 
 func (m *lockedClientMap) Range(fn func(key uint64, value *muxClient) bool) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	for k, v := range m.m {
 		if !fn(k, v) {
 			break
 		}
 	}
-	m.mu.Unlock()
 }
 
 func (m *lockedClientMap) Clear() {


### PR DESCRIPTION
## Description

If network conditions have filled the output queue before a reconnect happens blocked sends could stop reconnects from happening. In short `respMu` would be held for a mux client while sending - if the queue is full this will never get released and closing the mux client will hang.

A) Use the mux client context instead of connection context for sends, so sends are unblocked when the mux client is canceled.

B) Use a `TryLock` on "close" and cancel the request if we cannot get the lock at once. This will unblock any attempts to send.

## How to test this PR?

High load + dropped connections

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
