### PR TITLE
 sr: use site replicator svcacct to sign STS session tokens

### DIFF
--- a/cmd/auth-handler.go
+++ b/cmd/auth-handler.go
@@ -306,6 +306,13 @@ func checkClaimsFromToken(r *http.Request, cred auth.Credentials) (map[string]in
 	}
 
 	if token != "" {
+		var err error
+		if globalSiteReplicationSys.isEnabled() && cred.AccessKey != siteReplicatorSvcAcc {
+			secret, err = getTokenSigningKey()
+			if err != nil {
+				return nil, toAPIErrorCode(r.Context(), err)
+			}
+		}
 		claims, err := getClaimsFromTokenWithSecret(token, secret)
 		if err != nil {
 			return nil, toAPIErrorCode(r.Context(), err)

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -311,7 +311,8 @@ var (
 	// Time when the server is started
 	globalBootTime = UTCNow()
 
-	globalActiveCred auth.Credentials
+	globalActiveCred         auth.Credentials
+	globalSiteReplicatorCred siteReplicatorCred
 
 	// Captures if root credentials are set via ENV.
 	globalCredViaEnv bool

--- a/docs/site-replication/README.md
+++ b/docs/site-replication/README.md
@@ -58,6 +58,6 @@ mc admin replicate info minio1
 ```
 
 ** Note **
-Previously, site replication required root credentials of peer sites be identical. This is no longer required due to STS tokens now being signed with the site replicator service account credentials vs the root credentials, thus allowing flexibility in independent manageement of root accounts across sites, as well as the ability to disable root account eventually.
+Previously, site replication required the root credentials of peer sites to be identical. This is no longer necessary because STS tokens are now signed with the site replicator service account credentials, thus allowing flexibility in the independent management of root accounts across sites and the ability to disable root accounts eventually.
 
  However, this means that STS tokens signed previously by root credentials will no longer be valid upon upgrade to the latest version with this change. Also, if site replication is ever removed - the STS tokens previously signed by site replicator service account credentials will no longer be valid.

--- a/docs/site-replication/README.md
+++ b/docs/site-replication/README.md
@@ -60,4 +60,4 @@ mc admin replicate info minio1
 ** Note **
 Previously, site replication required the root credentials of peer sites to be identical. This is no longer necessary because STS tokens are now signed with the site replicator service account credentials, thus allowing flexibility in the independent management of root accounts across sites and the ability to disable root accounts eventually.
 
- However, this means that STS tokens signed previously by root credentials will no longer be valid upon upgrade to the latest version with this change. Also, if site replication is ever removed - the STS tokens previously signed by site replicator service account credentials will no longer be valid.
+However, this means that STS tokens signed previously by root credentials will no longer be valid upon upgrading to the latest version with this change. Please re-generate them as you usually do. Additionally, if site replication is ever removed - the STS tokens will become invalid, regenerate them as you usually do.

--- a/docs/site-replication/README.md
+++ b/docs/site-replication/README.md
@@ -22,7 +22,7 @@ The following Bucket features will **not be replicated**, is designed to differ 
 ## Pre-requisites
 
 - Initially, only **one** of the sites added for replication may have data. After site-replication is successfully configured, this data is replicated to the other (initially empty) sites. Subsequently, objects may be written to any of the sites, and they will be replicated to all other sites.
-- All sites **must** have the same deployment credentials (i.e. `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`).
+
 - **Removing a site** is not allowed from a set of replicated sites once configured.
 - All sites must be using the **same** external IDP(s) if any.
 - For [SSE-S3 or SSE-KMS encryption via KMS](https://min.io/docs/minio/linux/operations/server-side-encryption.html "MinIO KMS Guide"), all sites **must**  have access to a central KMS deployment. This can be achieved via a central KES server or multiple KES servers (say one per site) connected via a central KMS (Vault) server.
@@ -56,3 +56,8 @@ mc admin replicate add minio1 minio2 minio3
 ```sh
 mc admin replicate info minio1
 ```
+
+** Note **
+Previously, site replication required root credentials of peer sites be identical. This is no longer required due to STS tokens now being signed with the site replicator service account credentials vs the root credentials, thus allowing flexibility in independent manageement of root accounts across sites, as well as the ability to disable root account eventually.
+
+ However, this means that STS tokens signed previously by root credentials will no longer be valid upon upgrade to the latest version with this change. Also, if site replication is ever removed - the STS tokens previously signed by site replicator service account credentials will no longer be valid.

--- a/docs/site-replication/run-multi-site-oidc.sh
+++ b/docs/site-replication/run-multi-site-oidc.sh
@@ -6,13 +6,10 @@ exit_1() {
 
 	echo "minio1 ============"
 	cat /tmp/minio1_1.log
-	cat /tmp/minio1_2.log
 	echo "minio2 ============"
 	cat /tmp/minio2_1.log
-	cat /tmp/minio2_2.log
 	echo "minio3 ============"
 	cat /tmp/minio3_1.log
-	cat /tmp/minio3_2.log
 
 	exit 1
 }


### PR DESCRIPTION
 This change is to decouple need for root credentials to match between
 site replication deployments.

 Also ensuring site replication config initialization is re-tried until
 it succeeds, this dependency is critical to STS flow in site replication
 scenario.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?
setup site replication with root credentials different across sites
STS tokens generated should replicate

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
