### PR TITLE
Improve caching

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -1203,7 +1203,8 @@ func (a adminAPIHandlers) AccountInfoHandler(w http.ResponseWriter, r *http.Requ
 		bucketStorageCache.TTL = 10 * time.Second
 
 		// Rely on older value if usage loading fails from disk.
-		bucketStorageCache.Relax = true
+		bucketStorageCache.ReturnLastGood = true
+		bucketStorageCache.NoWait = true
 		bucketStorageCache.Update = func() (DataUsageInfo, error) {
 			ctx, done := context.WithTimeout(context.Background(), 2*time.Second)
 			defer done()

--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -52,7 +52,8 @@ func (sys *BucketQuotaSys) Init(objAPI ObjectLayer) {
 		// does not update the bucket usage values frequently.
 		bucketStorageCache.TTL = 10 * time.Second
 		// Rely on older value if usage loading fails from disk.
-		bucketStorageCache.Relax = true
+		bucketStorageCache.ReturnLastGood = true
+		bucketStorageCache.NoWait = true
 		bucketStorageCache.Update = func() (DataUsageInfo, error) {
 			ctx, done := context.WithTimeout(context.Background(), 2*time.Second)
 			defer done()

--- a/cmd/data-usage.go
+++ b/cmd/data-usage.go
@@ -81,7 +81,8 @@ func loadPrefixUsageFromBackend(ctx context.Context, objAPI ObjectLayer, bucket 
 		prefixUsageCache.TTL = 30 * time.Second
 
 		// No need to fail upon Update() error, fallback to old value.
-		prefixUsageCache.Relax = true
+		prefixUsageCache.ReturnLastGood = true
+		prefixUsageCache.NoWait = true
 		prefixUsageCache.Update = func() (map[string]uint64, error) {
 			m := make(map[string]uint64)
 			for _, pool := range z.serverPools {

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -1851,7 +1851,8 @@ func (z *erasureServerPools) ListBuckets(ctx context.Context, opts BucketOptions
 		listBucketsCache.Once.Do(func() {
 			listBucketsCache.TTL = time.Second
 
-			listBucketsCache.Relax = true
+			listBucketsCache.ReturnLastGood = true
+			listBucketsCache.NoWait = true
 			listBucketsCache.Update = func() ([]BucketInfo, error) {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				buckets, err = z.s3Peer.ListBuckets(ctx, opts)

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -357,7 +357,7 @@ type MetricsGroupOpts struct {
 func (g *MetricsGroup) RegisterRead(read func(ctx context.Context) []Metric) {
 	g.metricsCache = cachevalue.New[[]Metric]()
 	g.metricsCache.Once.Do(func() {
-		g.metricsCache.Relax = true
+		g.metricsCache.ReturnLastGood = true
 		g.metricsCache.TTL = g.cacheInterval
 		g.metricsCache.Update = func() ([]Metric, error) {
 			if g.metricsGroupOpts.dependGlobalObjectAPI {

--- a/internal/cachevalue/cache_test.go
+++ b/internal/cachevalue/cache_test.go
@@ -51,7 +51,7 @@ func TestCache(t *testing.T) {
 func BenchmarkCache(b *testing.B) {
 	cache := New[time.Time]()
 	cache.Once.Do(func() {
-		cache.TTL = 1 * time.Microsecond
+		cache.TTL = 1 * time.Millisecond
 		cache.Update = func() (time.Time, error) {
 			return time.Now(), nil
 		}


### PR DESCRIPTION
## Description

* Remove lock for cached operations.
* Rename "Relax" to `ReturnLastGood`.
* Add `CacheError` to allow caching values even on errors.
* Add NoWait that will return current value with async fetching if within 2xTTL.
* Make benchmark somewhat representative.  Result with 1ms for both implementions:

```
Before: BenchmarkCache-12       16408370                63.12 ns/op            0 B/op
After:  BenchmarkCache-12       428282187                2.789 ns/op           0 B/op
```

* Remove `storageRESTClient.scanning`. Nonsensical - RPC clients will not have any idea about scanning.
* Always fetch remote diskinfo metrics and cache them. Seems most calls are requesting metrics.
* Do async fetching of usage caches.

## How to test this PR?

Regular operation.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
