### PR TITLE
ilm: Select an object when all AND tags are satisfied

### DIFF
--- a/internal/bucket/lifecycle/filter.go
+++ b/internal/bucket/lifecycle/filter.go
@@ -232,23 +232,20 @@ func (f Filter) TestTags(userTags string) bool {
 	}
 	tagsMap := parsedTags.ToMap()
 
-	// This filter has tags configured but this object
-	// does not have any tag, skip this object
-	if len(tagsMap) == 0 {
+	// Not enough tags on object to satisfy the rule filter's tags
+	if len(tagsMap) < len(f.cachedTags) {
 		return false
 	}
 
-	// Both filter and object have tags, ensure that
-	// all lifecycle tags rules are satisfied
-	var matchCount int
+	var mismatch bool
 	for k, cv := range f.cachedTags {
 		v, ok := tagsMap[k]
-		if ok && v == cv {
-			matchCount++
+		if !ok || v != cv {
+			mismatch = true
+			break
 		}
 	}
-
-	return matchCount == len(f.cachedTags)
+	return !mismatch
 }
 
 // BySize returns true if sz satisfies one of ObjectSizeGreaterThan,

--- a/internal/bucket/lifecycle/filter.go
+++ b/internal/bucket/lifecycle/filter.go
@@ -238,15 +238,17 @@ func (f Filter) TestTags(userTags string) bool {
 		return false
 	}
 
-	// Both filter and object have tags, find a match,
-	// skip this object otherwise
+	// Both filter and object have tags, ensure that
+	// all lifecycle tags rules are satisfied
+	var matchCount int
 	for k, cv := range f.cachedTags {
 		v, ok := tagsMap[k]
 		if ok && v == cv {
-			return true
+			matchCount++
 		}
 	}
-	return false
+
+	return matchCount == len(f.cachedTags)
 }
 
 // BySize returns true if sz satisfies one of ObjectSizeGreaterThan,

--- a/internal/bucket/lifecycle/filter_test.go
+++ b/internal/bucket/lifecycle/filter_test.go
@@ -241,3 +241,103 @@ func TestObjectSizeFilters(t *testing.T) {
 		})
 	}
 }
+
+func TestTestTags(t *testing.T) {
+	noTags := Filter{
+		set: true,
+		And: And{
+			Tags: []Tag{},
+		},
+		andSet: true,
+	}
+
+	oneTag := Filter{
+		set: true,
+		And: And{
+			Tags: []Tag{{Key: "FOO", Value: "1"}},
+		},
+		andSet: true,
+	}
+
+	twoTags := Filter{
+		set: true,
+		And: And{
+			Tags: []Tag{{Key: "FOO", Value: "1"}, {Key: "BAR", Value: "2"}},
+		},
+		andSet: true,
+	}
+
+	tests := []struct {
+		filter   Filter
+		userTags string
+		want     bool
+	}{
+		{
+			filter:   noTags,
+			userTags: "",
+			want:     true,
+		},
+		{
+			filter:   noTags,
+			userTags: "A=3",
+			want:     true,
+		},
+		{
+			filter:   oneTag,
+			userTags: "A=3",
+			want:     false,
+		},
+		{
+			filter:   oneTag,
+			userTags: "FOO=1",
+			want:     true,
+		},
+		{
+			filter:   oneTag,
+			userTags: "A=B&FOO=1",
+			want:     true,
+		},
+		{
+			filter:   twoTags,
+			userTags: "",
+			want:     false,
+		},
+		{
+			filter:   twoTags,
+			userTags: "FOO=1",
+			want:     false,
+		},
+		{
+			filter:   twoTags,
+			userTags: "BAR=2",
+			want:     false,
+		},
+		{
+			filter:   twoTags,
+			userTags: "FOO=2&BAR=2",
+			want:     false,
+		},
+		{
+			filter:   twoTags,
+			userTags: "F=1&B=2",
+			want:     false,
+		},
+		{
+			filter:   twoTags,
+			userTags: "FOO=1&BAR=2",
+			want:     true,
+		},
+		{
+			filter:   twoTags,
+			userTags: "BAR=2&FOO=1",
+			want:     true,
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("Test %d", i+1), func(t *testing.T) {
+			if got := test.filter.TestTags(test.userTags); got != test.want {
+				t.Errorf("Expected %v but got %v", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Currently if one object tag matches with one lifecycle tag filter, ILM will select it, 
however this is wrong. All the Tag filters in the lifecycle document should be satisfied.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
