### PR TITLE
consolidate localDrives instances for proper usage

### DIFF
--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -83,7 +83,7 @@ function start_minio_3_node() {
 }
 
 function check_online() {
-	if grep -q 'Unable to initialize sub-systems' ${WORK_DIR}/dist-minio-*.log; then
+	if ! grep -q 'Status:' ${WORK_DIR}/dist-minio-*.log; then
 		echo "1"
 	fi
 }

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -168,21 +168,6 @@ func (ahs *allHealState) getLocalHealingDisks() map[string]madmin.HealingDisk {
 	return dst
 }
 
-// getHealLocalDiskEndpoints() returns the list of disks that need
-// to be healed but there is no healing routine in progress on them.
-func (ahs *allHealState) getHealLocalDiskEndpoints() Endpoints {
-	ahs.RLock()
-	defer ahs.RUnlock()
-
-	var endpoints Endpoints
-	for ep, healing := range ahs.healLocalDisks {
-		if !healing {
-			endpoints = append(endpoints, ep)
-		}
-	}
-	return endpoints
-}
-
 // Set, in the memory, the state of the disk as currently healing or not
 func (ahs *allHealState) setDiskHealingStatus(ep Endpoint, healing bool) {
 	ahs.Lock()

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -740,7 +740,7 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		wg := sync.WaitGroup{}
+		var wg sync.WaitGroup
 		for i, disk := range disks {
 			if disk == nil {
 				done <- false

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -224,7 +224,8 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 
 		disks, _ := er.getOnlineDisksWithHealing(false)
 		if len(disks) == 0 {
-			logger.LogIf(ctx, fmt.Errorf("no online disks found to heal the bucket `%s`", bucket))
+			// all disks are healing in this set, assume object healing is done.
+			tracker.bucketDone(bucket)
 			continue
 		}
 

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -102,8 +102,6 @@ func (d *naughtyDisk) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return -1, -1, -1
 }
 
-func (d *naughtyDisk) SetDiskLoc(poolIdx, setIdx, diskIdx int) {}
-
 func (d *naughtyDisk) GetDiskID() (string, error) {
 	return d.disk.GetDiskID()
 }

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -740,7 +740,12 @@ func serverMain(ctx *cli.Context) {
 		getCert = globalTLSCerts.GetCertificate
 	}
 
-	// Initialize gridn
+	// Initialize local drives
+	bootstrapTrace("initLocalDrives", func() {
+		registerStorageLocalDrives(globalEndpoints)
+	})
+
+	// Initialize grid
 	bootstrapTrace("initGrid", func() {
 		logger.FatalIf(initGlobalGrid(GlobalContext, globalEndpoints), "Unable to configure server grid RPC services")
 	})

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -109,7 +109,6 @@ type StorageAPI interface {
 	// Read all.
 	ReadAll(ctx context.Context, volume string, path string) (buf []byte, err error)
 	GetDiskLoc() (poolIdx, setIdx, diskIdx int) // Retrieve location indexes.
-	SetDiskLoc(poolIdx, setIdx, diskIdx int)    // Set location indexes.
 	SetFormatData(b []byte)                     // Set formatData cached value
 }
 
@@ -158,9 +157,6 @@ func (p *unrecognizedDisk) SetFormatData(b []byte) {
 
 func (p *unrecognizedDisk) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return -1, -1, -1
-}
-
-func (p *unrecognizedDisk) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
 }
 
 func (p *unrecognizedDisk) Close() error {

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -164,21 +164,11 @@ type storageRESTClient struct {
 	formatMutex sync.RWMutex
 
 	diskInfoCache *cachevalue.Cache[DiskInfo]
-
-	// Indexes, will be -1 until assigned a set.
-	poolIndex, setIndex, diskIndex int
 }
 
 // Retrieve location indexes.
 func (client *storageRESTClient) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
-	return client.poolIndex, client.setIndex, client.diskIndex
-}
-
-// Set location indexes.
-func (client *storageRESTClient) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
-	client.poolIndex = poolIdx
-	client.setIndex = setIdx
-	client.diskIndex = diskIdx
+	return client.endpoint.PoolIdx, client.endpoint.SetIdx, client.endpoint.DiskIdx
 }
 
 // Wrapper to restClient.Call to handle network errors, in case of network error the connection is makred disconnected
@@ -884,7 +874,7 @@ func newStorageRESTClient(endpoint Endpoint, healthCheck bool, gm *grid.Manager)
 		return nil, fmt.Errorf("unable to find connection for %s in targets: %v", endpoint.GridHost(), gm.Targets())
 	}
 	return &storageRESTClient{
-		endpoint: endpoint, restClient: restClient, poolIndex: -1, setIndex: -1, diskIndex: -1,
+		endpoint: endpoint, restClient: restClient,
 		gridConn:      conn,
 		diskInfoCache: cachevalue.New[DiskInfo](),
 	}, nil

--- a/cmd/xl-storage-disk-id-check.go
+++ b/cmd/xl-storage-disk-id-check.go
@@ -253,10 +253,6 @@ func (p *xlStorageDiskIDCheck) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
 	return p.storage.GetDiskLoc()
 }
 
-func (p *xlStorageDiskIDCheck) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
-	p.storage.SetDiskLoc(poolIdx, setIdx, diskIdx)
-}
-
 func (p *xlStorageDiskIDCheck) Close() error {
 	p.diskCancel()
 	return p.storage.Close()

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -141,22 +141,6 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, data, allPart
 	return fi, nil
 }
 
-// getXLDiskLoc will return the pool/set/disk id if it can be located in the object layer.
-// Will return -1 for unknown values.
-func getXLDiskLoc(diskID string) (poolIdx, setIdx, diskIdx int) {
-	if api := newObjectLayerFn(); api != nil {
-		if globalIsErasureSD {
-			return 0, 0, 0
-		}
-		if ep, ok := api.(*erasureServerPools); ok {
-			if pool, set, disk, err := ep.getPoolAndSet(diskID); err == nil {
-				return pool, set, disk
-			}
-		}
-	}
-	return -1, -1, -1
-}
-
 // hashDeterministicString will return a deterministic hash for the map values.
 // Trivial collisions are avoided, but this is by no means a strong hash.
 func hashDeterministicString(m map[string]string) uint64 {

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -376,24 +376,14 @@ func (s *xlStorage) IsLocal() bool {
 
 // Retrieve location indexes.
 func (s *xlStorage) GetDiskLoc() (poolIdx, setIdx, diskIdx int) {
-	// If unset, see if we can locate it.
-	if s.poolIndex < 0 || s.setIndex < 0 || s.diskIndex < 0 {
-		return getXLDiskLoc(s.diskID)
-	}
-	return s.poolIndex, s.setIndex, s.diskIndex
+	// this position never changes
+	return s.endpoint.PoolIdx, s.endpoint.SetIdx, s.endpoint.DiskIdx
 }
 
 func (s *xlStorage) SetFormatData(b []byte) {
 	s.Lock()
 	defer s.Unlock()
 	s.formatData = b
-}
-
-// Set location indexes.
-func (s *xlStorage) SetDiskLoc(poolIdx, setIdx, diskIdx int) {
-	s.poolIndex = poolIdx
-	s.setIndex = setIdx
-	s.diskIndex = diskIdx
 }
 
 func (s *xlStorage) Healing() *healingTracker {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
consolidate localDrives instances for proper usage

## Motivation and Context
every position of a drive is static in MinIO, we do not need 
complex mechanisms to infer this value anymore. This PR 
is a collection of changes that shall come in to reduce 
our usage of 'format.json' and removal of duplicated 
instances of validation.

This PR fixes a bug that perhaps has been long introduced, 
with no visible workarounds. In any deployment, if an entire 
erasure set is deleted, there is no way the cluster recovers.

This required a re-arranging of various pieces related 
to drives and how they are updated/mutated.

## How to test this PR?
We had unit tests that were silently failing, this PR fixes it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
