### PR TITLE
Mux: Send async mux ack and fix stream error responses

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -1504,6 +1504,9 @@ func (c *Connection) handleMuxServerMsg(ctx context.Context, m message) {
 		})
 	}
 	if m.Flags&FlagEOF != 0 {
+		if v.cancelFn != nil {
+			v.cancelFn(errStreamEOF)
+		}
 		v.close()
 		if debugReqs {
 			fmt.Println(m.MuxID, c.String(), "handleMuxServerMsg: DELETING MUX")

--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -1504,7 +1504,7 @@ func (c *Connection) handleMuxServerMsg(ctx context.Context, m message) {
 		})
 	}
 	if m.Flags&FlagEOF != 0 {
-		if v.cancelFn != nil {
+		if v.cancelFn != nil && m.Flags&FlagPayloadIsErr == 0 {
 			v.cancelFn(errStreamEOF)
 		}
 		v.close()

--- a/internal/grid/stream.go
+++ b/internal/grid/stream.go
@@ -77,7 +77,10 @@ func (s *Stream) Results(next func(b []byte) error) (err error) {
 	for {
 		select {
 		case <-s.ctx.Done():
-			return context.Cause(s.ctx)
+			if err := context.Cause(s.ctx); !errors.Is(err, errStreamEOF) {
+				return err
+			}
+			// Fall through to be sure we have returned all responses.
 		case resp, ok := <-s.responses:
 			if !ok {
 				done = true

--- a/internal/grid/stream.go
+++ b/internal/grid/stream.go
@@ -74,13 +74,15 @@ func (s *Stream) Results(next func(b []byte) error) (err error) {
 			}
 		}
 	}()
+	doneCh := s.ctx.Done()
 	for {
 		select {
-		case <-s.ctx.Done():
+		case <-doneCh:
 			if err := context.Cause(s.ctx); !errors.Is(err, errStreamEOF) {
 				return err
 			}
 			// Fall through to be sure we have returned all responses.
+			doneCh = nil
 		case resp, ok := <-s.responses:
 			if !ok {
 				done = true


### PR DESCRIPTION
## Description

Streams can return errors if the cancelation is picked up before the response stream close is picked up. Under extreme load this could lead to missing responses.

Send server mux ack async so a blocked send cannot block newMuxStream call. Stream will not progress until mux has been acked.

## Motivation and Context

Stability under high load.

## How to test this PR?

High node, latency, high load.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
