### PR TITLE
debug: introduce support for configuring client connect WRITE deadline

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -393,6 +393,7 @@ func buildServerCtxt(ctx *cli.Context, ctxt *serverCtxt) (err error) {
 	ctxt.ConnReadDeadline = ctx.Duration("conn-read-deadline")
 	ctxt.ConnWriteDeadline = ctx.Duration("conn-write-deadline")
 	ctxt.ConnClientReadDeadline = ctx.Duration("conn-client-read-deadline")
+	ctxt.ConnClientWriteDeadline = ctx.Duration("conn-client-write-deadline")
 
 	ctxt.ShutdownTimeout = ctx.Duration("shutdown-timeout")
 	ctxt.IdleTimeout = ctx.Duration("idle-timeout")

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -160,10 +160,11 @@ type serverCtxt struct {
 	FTP  []string
 	SFTP []string
 
-	UserTimeout            time.Duration
-	ConnReadDeadline       time.Duration
-	ConnWriteDeadline      time.Duration
-	ConnClientReadDeadline time.Duration
+	UserTimeout             time.Duration
+	ConnReadDeadline        time.Duration
+	ConnWriteDeadline       time.Duration
+	ConnClientReadDeadline  time.Duration
+	ConnClientWriteDeadline time.Duration
 
 	ShutdownTimeout     time.Duration
 	IdleTimeout         time.Duration

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -107,6 +107,12 @@ var ServerFlags = []cli.Flag{
 		EnvVar: "MINIO_CONN_CLIENT_READ_DEADLINE",
 	},
 	cli.DurationFlag{
+		Name:   "conn-client-write-deadline",
+		Usage:  "custom connection WRITE deadline for outgoing requests",
+		Hidden: true,
+		EnvVar: "MINIO_CONN_CLIENT_WRITE_DEADLINE",
+	},
+	cli.DurationFlag{
 		Name:   "conn-read-deadline",
 		Usage:  "custom connection READ deadline",
 		Hidden: true,
@@ -356,9 +362,10 @@ func serverHandleCmdArgs(ctxt serverCtxt) {
 	})
 
 	globalTCPOptions = xhttp.TCPOptions{
-		UserTimeout:       int(ctxt.UserTimeout.Milliseconds()),
-		ClientReadTimeout: ctxt.ConnClientReadDeadline,
-		Interface:         ctxt.Interface,
+		UserTimeout:        int(ctxt.UserTimeout.Milliseconds()),
+		ClientReadTimeout:  ctxt.ConnClientReadDeadline,
+		ClientWriteTimeout: ctxt.ConnClientWriteDeadline,
+		Interface:          ctxt.Interface,
 	}
 
 	// On macOS, if a process already listens on LOCALIPADDR:PORT, net.Listen() falls back

--- a/internal/cachevalue/cache.go
+++ b/internal/cachevalue/cache.go
@@ -70,16 +70,16 @@ type Cache[T any] struct {
 	updating     sync.Mutex
 }
 
-// New allocates a new cached value instance. It must be initialized with
-// `.InitOnce`.
-func New[I any]() *Cache[I] {
-	return &Cache[I]{}
+// New allocates a new cached value instance. Tt must be initialized with
+// `.TnitOnce`.
+func New[T any]() *Cache[T] {
+	return &Cache[T]{}
 }
 
 // NewFromFunc allocates a new cached value instance and initializes it with an
 // update function, making it ready for use.
-func NewFromFunc[I any](ttl time.Duration, opts Opts, update func() (I, error)) *Cache[I] {
-	return &Cache[I]{
+func NewFromFunc[T any](ttl time.Duration, opts Opts, update func() (T, error)) *Cache[T] {
+	return &Cache[T]{
 		ttl:      ttl,
 		updateFn: update,
 		opts:     opts,
@@ -88,7 +88,7 @@ func NewFromFunc[I any](ttl time.Duration, opts Opts, update func() (I, error)) 
 
 // InitOnce initializes the cache with a TTL and an update function. It is
 // guaranteed to be called only once.
-func (t *Cache[I]) InitOnce(ttl time.Duration, opts Opts, update func() (I, error)) {
+func (t *Cache[T]) InitOnce(ttl time.Duration, opts Opts, update func() (T, error)) {
 	t.Once.Do(func() {
 		t.ttl = ttl
 		t.updateFn = update
@@ -97,8 +97,8 @@ func (t *Cache[I]) InitOnce(ttl time.Duration, opts Opts, update func() (I, erro
 }
 
 // Get will return a cached value or fetch a new one.
-// If the Update function returns an error the value is forwarded as is and not cached.
-func (t *Cache[I]) Get() (I, error) {
+// Tf the Update function returns an error the value is forwarded as is and not cached.
+func (t *Cache[T]) Get() (T, error) {
 	v := t.valErr.Load()
 	ttl := t.ttl
 	vTime := t.lastUpdateMs.Load()

--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -79,7 +79,8 @@ func (listener *httpListener) Accept() (conn net.Conn, err error) {
 	case result, ok := <-listener.acceptCh:
 		if ok {
 			return deadlineconn.New(result.conn).
-				WithReadDeadline(listener.opts.ClientReadTimeout), result.err
+				WithReadDeadline(listener.opts.ClientReadTimeout).
+				WithWriteDeadline(listener.opts.ClientWriteTimeout), result.err
 		}
 	case <-listener.ctx.Done():
 	}
@@ -124,10 +125,11 @@ func (listener *httpListener) Addrs() (addrs []net.Addr) {
 
 // TCPOptions specify customizable TCP optimizations on raw socket
 type TCPOptions struct {
-	UserTimeout       int              // this value is expected to be in milliseconds
-	ClientReadTimeout time.Duration    // When the net.Conn is idle for more than ReadTimeout duration, we close the connection on the client proactively.
-	Interface         string           // this is a VRF device passed via `--interface` flag
-	Trace             func(msg string) // Trace when starting.
+	UserTimeout        int              // this value is expected to be in milliseconds
+	ClientReadTimeout  time.Duration    // When the net.Conn is idle for more than ReadTimeout duration, we close the connection on the client proactively.
+	ClientWriteTimeout time.Duration    // When the net.Conn is idle for more than WriteTimeout duration, we close the connection on the client proactively.
+	Interface          string           // this is a VRF device passed via `--interface` flag
+	Trace              func(msg string) // Trace when starting.
 }
 
 // newHTTPListener - creates new httpListener object which is interface compatible to net.Listener.


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
debug: introduce support for configuring client connect WRITE deadline

## Motivation and Context
just like client-conn-read-deadline, added a new flag that 
does client-conn-write-deadline as well.

Both are not configured by default since we have yet 
to determine the correct value. Allowing this to be configurable
as needed for now, and by default, it's disabled.

## How to test this PR?
You need a slow client that does not read(), or has stopped reading()

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
