### PR TITLE
fix: healthcheck to fail even if one erasure set doesn't have quorum

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -2406,18 +2406,21 @@ func (z *erasureServerPools) Health(ctx context.Context, opts HealthOptions) Hea
 				WriteQuorum:   poolWriteQuorums[poolIdx],
 			})
 
-			result.Healthy = erasureSetUpCount[poolIdx][setIdx].online >= poolWriteQuorums[poolIdx]
-			if !result.Healthy {
+			healthy := erasureSetUpCount[poolIdx][setIdx].online >= poolWriteQuorums[poolIdx]
+			if !healthy {
 				logger.LogIf(logger.SetReqInfo(ctx, reqInfo),
 					fmt.Errorf("Write quorum may be lost on pool: %d, set: %d, expected write quorum: %d",
 						poolIdx, setIdx, poolWriteQuorums[poolIdx]))
 			}
-			result.HealthyRead = erasureSetUpCount[poolIdx][setIdx].online >= poolReadQuorums[poolIdx]
-			if !result.HealthyRead {
+			result.Healthy = result.Healthy && healthy
+
+			healthyRead := erasureSetUpCount[poolIdx][setIdx].online >= poolReadQuorums[poolIdx]
+			if !healthyRead {
 				logger.LogIf(logger.SetReqInfo(ctx, reqInfo),
 					fmt.Errorf("Read quorum may be lost on pool: %d, set: %d, expected read quorum: %d",
 						poolIdx, setIdx, poolReadQuorums[poolIdx]))
 			}
+			result.HealthyRead = result.HealthyRead && healthyRead
 		}
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Currently, we send a 200 OK even if some erasure sets doesn't have quorum

## Motivation and Context

To properly fail the health checks if there isn't enough quorum in at least one erasure set

## How to test this PR?

- Start MinIO server with 8 disks and 2 erasure sets with `MINIO_ERASURE_SET_DRIVE_COUNT=4`

```sh
export MINIO_ERASURE_SET_DRIVE_COUNT=4
MINIO_CI_CD=1 MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 ./minio server /tmp/data{1...8}
```
- Take down drives from first erasure set

```
chmod 000 /tmp/data1
chmod 000 /tmp/data2
chmod 000 /tmp/data3
```
- You will still be seeing `mc ready myminio --json` returning 200 OK
- Apply this fix and check the same: you should be seeing `healthy: false` as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
