### PR TITLE
fix: a regression in loading replication creds

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -6207,12 +6207,11 @@ func (s *siteReplicatorCred) Get(ctx context.Context) (auth.Credentials, error) 
 		return s.Creds, nil
 	}
 	s.RUnlock()
-	s.Lock()
-	defer s.Unlock()
-	var m map[string]UserIdentity
+	m := make(map[string]UserIdentity)
 	if err := globalIAMSys.store.loadUser(ctx, siteReplicatorSvcAcc, svcUser, m); err != nil {
 		return auth.Credentials{}, err
 	}
+	s.Set(m[siteReplicatorSvcAcc].Credentials)
 	return m[siteReplicatorSvcAcc].Credentials, nil
 }
 


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: a regression in loading replication creds

## Motivation and Context
fixes #19200

generating STS credentials fail with site-replicated setup, 
with this error in a fresh environment.

## How to test this PR?
As per #19200 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression in #19111
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
