### PR TITLE
sr: use service account cred for claims check

### DIFF
--- a/docs/site-replication/run-multi-site-minio-idp.sh
+++ b/docs/site-replication/run-multi-site-minio-idp.sh
@@ -164,7 +164,20 @@ if [ $? -ne 0 ]; then
 	exit_1
 fi
 
+./mc admin user svcacct add minio2 minio --access-key testsvc2 --secret-key testsvc123
+if [ $? -ne 0 ]; then
+	echo "adding root svc account testsvc2 failed, exiting.."
+	exit_1
+fi
+
 sleep 10
+
+export MC_HOST_rootsvc=http://testsvc2:testsvc123@localhost:9002
+./mc ls rootsvc
+if [ $? -ne 0 ]; then
+	echo "root service account not inherited root permissions, exiting.."
+	exit_1
+fi
 
 ./mc admin user svcacct info minio1 testsvc
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
PR #19111 overlaid service account secret with site replicator secret during token claims check.

Fixes : #19206

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
See #19206

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) PR #19111
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
