### PR TITLE
Set expected expiry date for ExpiredObjectAllVersions

### DIFF
--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -515,7 +515,7 @@ func ExpectedExpiryTime(modTime time.Time, days int) time.Time {
 func (lc Lifecycle) SetPredictionHeaders(w http.ResponseWriter, obj ObjectOpts) {
 	event := lc.eval(obj, time.Time{})
 	switch event.Action {
-	case DeleteAction, DeleteVersionAction:
+	case DeleteAction, DeleteVersionAction, DeleteAllVersionsAction:
 		w.Header()[xhttp.AmzExpiration] = []string{
 			fmt.Sprintf(`expiry-date="%s", rule-id="%s"`, event.Due.Format(http.TimeFormat), event.RuleID),
 		}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Set expected expiry date for ExpiredObjectAllVersions similar to other ILM actions.

# How to test this PR?
1. `mc mb myminio/bucket`
2. `mc version enable myminio/bucket`
3. `mc ilm rule add --expire-days 7 --expire-all-object-versions myminio/bucket`
4. Upload an object to bucket
5. `mc stat` on this object should have the `Expiration` field.
e.g,
```
...
Type      : file
Expiration: 2024-03-12 17:00:00 PDT (lifecycle-rule-id: cnjqo10d6vvek0c4tsig)
Metadata  :
  Content-Type: application/octet-stream
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
