### PR TITLE
add batchSize support for webhook endpoints

### DIFF
--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -43,6 +43,7 @@ const (
 	AuthToken  = "auth_token"
 	ClientCert = "client_cert"
 	ClientKey  = "client_key"
+	BatchSize  = "batch_size"
 	QueueSize  = "queue_size"
 	QueueDir   = "queue_dir"
 	Proxy      = "proxy"
@@ -68,6 +69,7 @@ const (
 	EnvLoggerWebhookClientCert = "MINIO_LOGGER_WEBHOOK_CLIENT_CERT"
 	EnvLoggerWebhookClientKey  = "MINIO_LOGGER_WEBHOOK_CLIENT_KEY"
 	EnvLoggerWebhookProxy      = "MINIO_LOGGER_WEBHOOK_PROXY"
+	EnvLoggerWebhookBatchSize  = "MINIO_LOGGER_WEBHOOK_BATCH_SIZE"
 	EnvLoggerWebhookQueueSize  = "MINIO_LOGGER_WEBHOOK_QUEUE_SIZE"
 	EnvLoggerWebhookQueueDir   = "MINIO_LOGGER_WEBHOOK_QUEUE_DIR"
 
@@ -76,6 +78,7 @@ const (
 	EnvAuditWebhookAuthToken  = "MINIO_AUDIT_WEBHOOK_AUTH_TOKEN"
 	EnvAuditWebhookClientCert = "MINIO_AUDIT_WEBHOOK_CLIENT_CERT"
 	EnvAuditWebhookClientKey  = "MINIO_AUDIT_WEBHOOK_CLIENT_KEY"
+	EnvAuditWebhookBatchSize  = "MINIO_AUDIT_WEBHOOK_BATCH_SIZE"
 	EnvAuditWebhookQueueSize  = "MINIO_AUDIT_WEBHOOK_QUEUE_SIZE"
 	EnvAuditWebhookQueueDir   = "MINIO_AUDIT_WEBHOOK_QUEUE_DIR"
 
@@ -99,7 +102,10 @@ const (
 	auditTargetNamePrefix  = "audit-"
 )
 
-var errInvalidQueueSize = errors.New("invalid queue_size value")
+var (
+	errInvalidQueueSize = errors.New("invalid queue_size value")
+	errInvalidBatchSize = errors.New("invalid batch_size value")
+)
 
 // Default KVS for loggerHTTP and loggerAuditHTTP
 var (
@@ -127,6 +133,10 @@ var (
 		config.KV{
 			Key:   Proxy,
 			Value: "",
+		},
+		config.KV{
+			Key:   BatchSize,
+			Value: "1",
 		},
 		config.KV{
 			Key:   QueueSize,
@@ -158,6 +168,10 @@ var (
 		config.KV{
 			Key:   ClientKey,
 			Value: "",
+		},
+		config.KV{
+			Key:   BatchSize,
+			Value: "1",
 		},
 		config.KV{
 			Key:   QueueSize,
@@ -435,6 +449,14 @@ func lookupLoggerWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 		if queueSize <= 0 {
 			return cfg, errInvalidQueueSize
 		}
+		batchSizeCfgVal := getCfgVal(EnvLoggerWebhookBatchSize, k, kv.Get(BatchSize))
+		batchSize, err := strconv.Atoi(batchSizeCfgVal)
+		if err != nil {
+			return cfg, err
+		}
+		if batchSize <= 0 {
+			return cfg, errInvalidBatchSize
+		}
 		cfg.HTTP[k] = http.Config{
 			Enabled:    true,
 			Endpoint:   url,
@@ -442,6 +464,7 @@ func lookupLoggerWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 			ClientCert: clientCert,
 			ClientKey:  clientKey,
 			Proxy:      getCfgVal(EnvLoggerWebhookProxy, k, kv.Get(Proxy)),
+			BatchSize:  batchSize,
 			QueueSize:  queueSize,
 			QueueDir:   getCfgVal(EnvLoggerWebhookQueueDir, k, kv.Get(QueueDir)),
 			Name:       loggerTargetNamePrefix + k,
@@ -488,12 +511,21 @@ func lookupAuditWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 		if queueSize <= 0 {
 			return cfg, errInvalidQueueSize
 		}
+		batchSizeCfgVal := getCfgVal(EnvAuditWebhookBatchSize, k, kv.Get(BatchSize))
+		batchSize, err := strconv.Atoi(batchSizeCfgVal)
+		if err != nil {
+			return cfg, err
+		}
+		if batchSize <= 0 {
+			return cfg, errInvalidBatchSize
+		}
 		cfg.AuditWebhook[k] = http.Config{
 			Enabled:    true,
 			Endpoint:   url,
 			AuthToken:  getCfgVal(EnvAuditWebhookAuthToken, k, kv.Get(AuthToken)),
 			ClientCert: clientCert,
 			ClientKey:  clientKey,
+			BatchSize:  batchSize,
 			QueueSize:  queueSize,
 			QueueDir:   getCfgVal(EnvAuditWebhookQueueDir, k, kv.Get(QueueDir)),
 			Name:       auditTargetNamePrefix + k,

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -53,6 +53,12 @@ var (
 			Sensitive:   true,
 		},
 		config.HelpKV{
+			Key:         BatchSize,
+			Description: "Number of events per HTTP send to webhook target",
+			Optional:    true,
+			Type:        "number",
+		},
+		config.HelpKV{
 			Key:         QueueSize,
 			Description: "configure channel queue size for webhook targets",
 			Optional:    true,
@@ -106,6 +112,12 @@ var (
 			Optional:    true,
 			Type:        "string",
 			Sensitive:   true,
+		},
+		config.HelpKV{
+			Key:         BatchSize,
+			Description: "Number of events per HTTP send to webhook target",
+			Optional:    true,
+			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         QueueSize,

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -360,6 +360,7 @@ func (h *Target) startHTTPLogger(ctx context.Context) {
 			// when there are no incoming events on logCh we should flush out
 			// the entries.
 			if len(logCh) > 0 {
+				timer.Reset(3 * time.Second)
 				continue
 			}
 			if buf.Len() > 0 {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add batchSize support for webhook endpoints

## Motivation and Context
configure batch size to send audit/logger events
in batches instead of sending one event per connection.

this is mainly to optimize the number of requests
we make to webhook endpoint.

## How to test this PR?
By default nothing changes really, however with 
heavily loaded systems setting the batch-size
to like 10000 will automatically help in reducing
the number of connections made to the webhook endpoint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
