### PR TITLE
Add two bucket quota metrics

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -199,6 +199,7 @@ const (
 	writeTotal        MetricName = "write_total"
 	total             MetricName = "total"
 	freeInodes        MetricName = "free_inodes"
+	usedPerc          MetricName = "used_perc"
 
 	lastMinFailedCount  MetricName = "last_minute_failed_count"
 	lastMinFailedBytes  MetricName = "last_minute_failed_bytes"
@@ -687,6 +688,26 @@ func getBucketUsageQuotaTotalBytesMD() MetricDescription {
 		Subsystem: quotaSubsystem,
 		Name:      totalBytes,
 		Help:      "Total bucket quota size in bytes",
+		Type:      gaugeMetric,
+	}
+}
+
+func getBucketUsageQuotaUsagePercMD() MetricDescription {
+	return MetricDescription{
+		Namespace: bucketMetricNamespace,
+		Subsystem: quotaSubsystem,
+		Name:      usedPerc,
+		Help:      "Percentage of used bucket quota",
+		Type:      gaugeMetric,
+	}
+}
+
+func getBucketQuotaFreeBytesMD() MetricDescription {
+	return MetricDescription{
+		Namespace: bucketMetricNamespace,
+		Subsystem: quotaSubsystem,
+		Name:      freeBytes,
+		Help:      "Total free bucket quota size in bytes",
 		Type:      gaugeMetric,
 	}
 }
@@ -3278,6 +3299,18 @@ func getBucketUsageMetrics(opts MetricsGroupOpts) *MetricsGroup {
 				metrics = append(metrics, Metric{
 					Description:    getBucketUsageQuotaTotalBytesMD(),
 					Value:          float64(quota.Quota),
+					VariableLabels: map[string]string{"bucket": bucket},
+				})
+
+				metrics = append(metrics, Metric{
+					Description:    getBucketQuotaFreeBytesMD(),
+					Value:          float64(quota.Quota) - float64(usage.Size),
+					VariableLabels: map[string]string{"bucket": bucket},
+				})
+
+				metrics = append(metrics, Metric{
+					Description:    getBucketUsageQuotaUsagePercMD(),
+					Value:          math.Round(float64(usage.Size*100*100)/float64(quota.Quota)) / 100,
 					VariableLabels: map[string]string{"bucket": bucket},
 				})
 			}

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -325,13 +325,15 @@ For deployments with [Site Replication](https://min.io/docs/minio/linux/operatio
 	
 ## Usage Metrics
 
-| Name                                    | Description                                       |
-|:----------------------------------------|:--------------------------------------------------|
-| `minio_bucket_usage_object_total`       | Total number of objects.                          |
-| `minio_bucket_usage_version_total`      | Total number of versions (includes delete marker) |
-| `minio_bucket_usage_deletemarker_total` | Total number of delete markers.                   |
-| `minio_bucket_usage_total_bytes`        | Total bucket size in bytes.                       |
-| `minio_bucket_quota_total_bytes`        | Total bucket quota size in bytes.                 |
+| Name                                    | Description                                         |
+|:----------------------------------------|:----------------------------------------------------|
+| `minio_bucket_usage_object_total`       | Total number of objects.                            |
+| `minio_bucket_usage_version_total`      | Total number of versions (includes delete marker)   |
+| `minio_bucket_usage_deletemarker_total` | Total number of delete markers.                     |
+| `minio_bucket_usage_total_bytes`        | Total bucket size in bytes.                         |
+| `minio_bucket_quota_total_bytes`        | Total bucket quota size in bytes.                   |
+| `minio_bucket_quota_free_bytes`         | Total free bucket quota size in bytes.              |
+| `minio_bucket_quota_used_perc`          | Percentage of used bucket quota.                    |
 
 ## Requests Metrics
 


### PR DESCRIPTION
Add two bucket quota metrics.
```
minio_bucket_quota_free_bytes
minio_bucket_quota_used_perc
```
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
