### PR TITLE
Add Storage Class override

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -213,7 +213,9 @@ func setObjectHeaders(w http.ResponseWriter, objInfo ObjectInfo, rs *HTTPRangeSp
 	if objInfo.IsRemote() {
 		// Check if object is being restored. For more information on x-amz-restore header see
 		// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax
-		w.Header()[xhttp.AmzStorageClass] = []string{objInfo.TransitionedObject.Tier}
+		w.Header()[xhttp.AmzStorageClass] = []string{globalAPIConfig.storageClass(objInfo.TransitionedObject.Tier)}
+		// Returns the object's tier name always, not affected by api.force_storage_class.
+		w.Header()[xhttp.MinIOTierName] = []string{objInfo.TransitionedObject.Tier}
 	}
 
 	if lc, err := globalLifecycleSys.Get(objInfo.Bucket); err == nil {

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -45,6 +45,7 @@ type apiConfig struct {
 	// total drives per erasure set across pools.
 	totalDriveCount       int
 	replicationPriority   string
+	forceStorageClass     string
 	replicationMaxWorkers int
 	transitionWorkers     int
 
@@ -121,6 +122,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 		corsAllowOrigin = []string{"*"}
 	}
 	t.corsAllowOrigins = corsAllowOrigin
+	t.forceStorageClass = cfg.ForceStorageClass
 
 	maxSetDrives := 0
 	for _, setDriveCount := range setDriveCounts {
@@ -191,6 +193,18 @@ func (t *apiConfig) odirectEnabled() bool {
 	defer t.mu.RUnlock()
 
 	return t.enableODirect
+}
+
+// storageClass will override the storage class if forceStorageClass is set.
+// Otherwise it will return the input storage class.
+func (t *apiConfig) storageClass(s string) string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.forceStorageClass != "" {
+		return t.forceStorageClass
+	}
+	return s
 }
 
 func (t *apiConfig) shouldGzipObjects() bool {

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -775,7 +775,7 @@ func (api objectAPIHandlers) getObjectAttributesHandler(ctx context.Context, obj
 	}
 
 	if _, ok := opts.ObjectAttributes[xhttp.StorageClass]; ok {
-		OA.StorageClass = objInfo.StorageClass
+		OA.StorageClass = globalAPIConfig.storageClass(objInfo.StorageClass)
 	}
 
 	objInfo.decryptPartsChecksums()

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -49,6 +49,7 @@ const (
 	apiGzipObjects                 = "gzip_objects"
 	apiRootAccess                  = "root_access"
 	apiSyncEvents                  = "sync_events"
+	apiForceStorageClass           = "force_storage_class"
 
 	EnvAPIRequestsMax                 = "MINIO_API_REQUESTS_MAX"
 	EnvAPIRequestsDeadline            = "MINIO_API_REQUESTS_DEADLINE"
@@ -69,6 +70,7 @@ const (
 	EnvAPIGzipObjects                 = "MINIO_API_GZIP_OBJECTS"
 	EnvAPIRootAccess                  = "MINIO_API_ROOT_ACCESS" // default config.EnableOn
 	EnvAPISyncEvents                  = "MINIO_API_SYNC_EVENTS" // default "off"
+	EnvForceStorageClass              = "MINIO_FORCE_STORAGE_CLASS"
 )
 
 // Deprecated key and ENVs
@@ -130,6 +132,10 @@ var (
 			Value: "5m",
 		},
 		config.KV{
+			Key:   apiForceStorageClass,
+			Value: "",
+		},
+		config.KV{
 			Key:           apiDisableODirect,
 			Value:         "",
 			HiddenIfEmpty: true,
@@ -172,6 +178,7 @@ type Config struct {
 	GzipObjects                 bool          `json:"gzip_objects"`
 	RootAccess                  bool          `json:"root_access"`
 	SyncEvents                  bool          `json:"sync_events"`
+	ForceStorageClass           string        `json:"force_storage_class"`
 }
 
 // UnmarshalJSON - Validate SS and RRS parity when unmarshalling JSON.
@@ -233,6 +240,8 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	if requestsMax < 0 {
 		return cfg, errors.New("invalid API max requests value")
 	}
+
+	cfg.ForceStorageClass = env.Get(EnvForceStorageClass, kvs.GetWithDefault(apiForceStorageClass, DefaultKVS))
 
 	requestsDeadline, err := time.ParseDuration(env.Get(EnvAPIRequestsDeadline, kvs.GetWithDefault(apiRequestsDeadline, DefaultKVS)))
 	if err != nil {

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -237,6 +237,8 @@ const (
 	// predicted date/time of transition
 	MinIOTransition            = "X-Minio-Transition"
 	MinIOLifecycleCfgUpdatedAt = "X-Minio-LifecycleConfig-UpdatedAt"
+	// MinIOTierName - indicates name of tier where the object has been tiered to
+	MinIOTierName = "X-Minio-Tier"
 	// MinIOCompressed is returned when object is compressed
 	MinIOCompressed = "X-Minio-Compressed"
 


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
- Add `force_storage_class` api config. Allows to force a specific storage class to always be returned. Fix for clients that only expect certain storage classes to be returned and using tiering.

- Return `x-minio-tier` response header to indicate an object's tier, when applicable.

Thanks @klauspost for the initial PR.

## How to test this PR?
`mc admin config set myminio api force_storage_class=KLAUS` - run listings, etc.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
