### PR TITLE
Fix handling of set-but-empty environment variables

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -477,7 +477,7 @@ func validateConfig(ctx context.Context, s config.Config, subSys string) error {
 func lookupConfigs(s config.Config, objAPI ObjectLayer) {
 	ctx := GlobalContext
 
-	dnsURL, dnsUser, dnsPass, err := env.LookupEnv(config.EnvDNSWebhook)
+	dnsURL, _, dnsUser, dnsPass, err := env.LookupEnv(config.EnvDNSWebhook)
 	if err != nil {
 		logger.LogIf(ctx, fmt.Errorf("Unable to initialize remote webhook DNS config %w", err))
 	}

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -222,13 +222,13 @@ EXAMPLES:
 }
 
 func serverCmdArgs(ctx *cli.Context) []string {
-	v, _, _, err := env.LookupEnv(config.EnvArgs)
+	v, _, _, _, err := env.LookupEnv(config.EnvArgs)
 	if err != nil {
 		logger.FatalIf(err, "Unable to validate passed arguments in %s:%s",
 			config.EnvArgs, os.Getenv(config.EnvArgs))
 	}
 	if v == "" {
-		v, _, _, err = env.LookupEnv(config.EnvVolumes)
+		v, _, _, _, err = env.LookupEnv(config.EnvVolumes)
 		if err != nil {
 			logger.FatalIf(err, "Unable to validate passed arguments in %s:%s",
 				config.EnvVolumes, os.Getenv(config.EnvVolumes))
@@ -236,7 +236,7 @@ func serverCmdArgs(ctx *cli.Context) []string {
 	}
 	if v == "" {
 		// Fall back to older environment value MINIO_ENDPOINTS
-		v, _, _, err = env.LookupEnv(config.EnvEndpoints)
+		v, _, _, _, err = env.LookupEnv(config.EnvEndpoints)
 		if err != nil {
 			logger.FatalIf(err, "Unable to validate passed arguments in %s:%s",
 				config.EnvEndpoints, os.Getenv(config.EnvEndpoints))


### PR DESCRIPTION
## Description

Fix handling of set-but-empty environment variables, particularly for configuration entries for which an empty string is a valid and desired value.

## Motivation and Context

The intended way to [enable compression for all compressible objects](https://min.io/docs/minio/linux/administration/object-management/data-compression.html#compress-all-compressible-objects) involves setting `extensions` and `mime_types` to empty strings (arrays). When using [environment variables](https://min.io/docs/minio/linux/reference/minio-server/settings/core.html#id12) for configuration, this involves setting `MINIO_COMPRESSION_EXTENSIONS=""` and `MINIO_COMPRESSION_MIME_TYPES=""`, which get erroneously ignored, leading to the default allowlists of extensions and MIME types being applied instead. This can be verified with `mc` and `console`:

```shell
$ mc admin config get local compression
# MINIO_COMPRESSION_ENABLE=on
compression enable=off allow_encryption=off extensions=.txt,.log,.csv,.json,.tar,.xml,.bin mime_types=text/*,application/json,application/xml,binary/octet-stream
```

![image](https://github.com/minio/minio/assets/38858901/adacade8-ea46-4dac-af28-3ed11efcba84)

Observe that `MINIO_COMPRESSION_EXTENSIONS` and `MINIO_COMPRESSION_MIME_TYPES` are absent, and I have verified that compression is not being applied to custom objects due to the default `extensions` and `mime_types` lists being used.

To resolve the issue, https://github.com/minio/pkg/pull/100 is needed for the environment variable handling to be able to (again) distinguish between unset variables and variables set to an empty string. This PR includes minor semantic changes to adapt to `env.LookupEnv`, and also fixes `getTargetEnvs` to handle empty values using its improved output. Variables explicitly marked as `HiddenIfEmpty` are properly ignored.

As a result, launching MinIO with

```
MINIO_COMPRESSION_EXTENSIONS=""
MINIO_COMPRESSION_MIME_TYPES=""
```

now results in the configuration being respected:

```shell
$ mc admin config get local compression
# MINIO_COMPRESSION_ENABLE=on
# MINIO_COMPRESSION_EXTENSIONS=
# MINIO_COMPRESSION_MIME_TYPES=
compression enable=off allow_encryption=off extensions=.txt,.log,.csv,.json,.tar,.xml,.bin mime_types=text/*,application/json,application/xml,binary/octet-stream
```

![image](https://github.com/minio/minio/assets/38858901/3a7a324a-77e8-4317-8c58-a0cba647f734)

and compression for all compressible objects works once again.

## How to test this PR?

1. Clone https://github.com/twelho/minio-pkg/tree/fix-env-empty-value
2. At the end of `go.mod`, add `replace github.com/minio/pkg/v2 => ./path/to/cloned/minio/pkg`
3. Run MinIO with `MINIO_COMPRESSION_EXTENSIONS=""` and `MINIO_COMPRESSION_MIME_TYPES=""`
4. Observe working behavior described above

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
