### PR TITLE
Improve handling of compression inclusion for objects

### DIFF
--- a/docs/compression/README.md
+++ b/docs/compression/README.md
@@ -59,6 +59,14 @@ export MINIO_COMPRESSION_EXTENSIONS=".txt,.log,.csv,.json,.tar,.xml,.bin"
 export MINIO_COMPRESSION_MIME_TYPES="text/*,application/json,application/xml"
 ```
 
+> [!NOTE]
+> To enable compression for all content when using environment variables, set either or both of the extensions and MIME types to `*` instead of an empty string:
+> ```bash
+> export MINIO_COMPRESSION_ENABLE="on"
+> export MINIO_COMPRESSION_EXTENSIONS="*"
+> export MINIO_COMPRESSION_MIME_TYPES="*"
+> ```
+
 ### 3. Compression + Encryption
 
 Combining encryption and compression is not safe in all setups.


### PR DESCRIPTION
## Description

Attempt 2 of https://github.com/minio/minio/pull/19233. Instead of adding support for empty environment variables, it is now possible to enable compression for all compressible objects with

```
MINIO_COMPRESSION_EXTENSIONS="*"
MINIO_COMPRESSION_MIME_TYPES="*"
```

either **individually** or **together**. Either one alone is sufficient for catching all objects (that are not part of the fixed built-in exclusion-list). This maintains the existing behavior, with the exception of adding the wildcard match to the extension handling in order for `MINIO_COMPRESSION_EXTENSIONS="*"` to be sufficient on its own for enabling catch-all compression (as the user expects). `hasStringSuffixInSlice` is otherwise only used for the fixed built-in extension list, which does not contain a wildcard, and thus its behavior is unchanged.

For the configuration variables, in addition to setting `compression extensions= mime_types=` as the current preference for enabling catch-all compression, this should also allow `compression extensions=* mime_types=*` to be used.

## How to test this PR?

1. Build MinIO from https://github.com/twelho/minio/tree/fix-compression-envs-2
2. Run with one of or both of the environment variables above, observe desired behavior according to https://github.com/minio/minio/pull/19233.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
