### PR TITLE
add X-Content-Length

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -898,7 +898,9 @@ func writeResponse(w http.ResponseWriter, statusCode int, response []byte, mType
 	if mType != mimeNone {
 		w.Header().Set(xhttp.ContentType, string(mType))
 	}
-	w.Header().Set(xhttp.ContentLength, strconv.Itoa(len(response)))
+	mLength := strconv.Itoa(len(response))
+	w.Header().Set(xhttp.ContentLength, mLength)
+	w.Header().Set(xhttp.XContentLength, mLength)
 	w.WriteHeader(statusCode)
 	if response != nil {
 		w.Write(response)

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -27,6 +27,7 @@ const (
 	ContentEncoding    = "Content-Encoding"
 	Expires            = "Expires"
 	ContentLength      = "Content-Length"
+	XContentLength     = "X-Content-Length"
 	ContentLanguage    = "Content-Language"
 	ContentRange       = "Content-Range"
 	Connection         = "Connection"


### PR DESCRIPTION
Some proxy server like cloudflare remove Content-Length header for the cache. So `mc cat` always fail like below.

>specified offset (0) bigger than file (-1)

The mc command gets the file size from the content-length header given in the response of HEAD request, but the proxy server removes the header without knowing that this is the file size that mc command use.

This change add X-Content-Length to recover Content-Length. All of minio client should handle this X-Content-Length if Content-Length is not found.
