### PR TITLE
feat: allow retaining parity SLA to be configurable

### DIFF
--- a/internal/config/storageclass/help.go
+++ b/internal/config/storageclass/help.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -35,6 +35,12 @@ var (
 		config.HelpKV{
 			Key:         ClassRRS,
 			Description: `set the parity count for reduced redundancy storage class` + defaultHelpPostfix(ClassRRS),
+			Optional:    true,
+			Type:        "string",
+		},
+		config.HelpKV{
+			Key:         ClassOptimize,
+			Description: `optimize parity calculation for standard storage class, set 'capacity' for capacity optimized (no additional parity)` + defaultHelpPostfix(ClassOptimize),
 			Optional:    true,
 			Type:        "string",
 		},


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
feat: allow retaining parity SLA to be configurable

## Motivation and Context
At scale, customers might start with failed drives, causing 
skew in the overall usage ratio per EC set.

Make this configurable so customers can turn it off as 
needed depending on how comfortable they are with the 
SLA.

## How to test this PR?

To turn off retaining parity SLA and optimize for capacity
for objects when drives have failed, do this only when you 
know what you are doing and usable space is more important 
to you than additional parity for objects.

```
mc admin config set alias/ storage_class optimize=capacity
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
