### PR TITLE
allow dynamically changing max_object_versions per object

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -55,6 +55,7 @@ type apiConfig struct {
 	gzipObjects                 bool
 	rootAccess                  bool
 	syncEvents                  bool
+	objectMaxVersions           int
 }
 
 const (
@@ -186,6 +187,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int) {
 	t.gzipObjects = cfg.GzipObjects
 	t.rootAccess = cfg.RootAccess
 	t.syncEvents = cfg.SyncEvents
+	t.objectMaxVersions = cfg.ObjectMaxVersions
 }
 
 func (t *apiConfig) odirectEnabled() bool {
@@ -385,4 +387,16 @@ func (t *apiConfig) isSyncEventsEnabled() bool {
 	defer t.mu.RUnlock()
 
 	return t.syncEvents
+}
+
+func (t *apiConfig) getObjectMaxVersions() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.objectMaxVersions <= 0 {
+		// defaults to 'maxObjectVersions' when unset.
+		return maxObjectVersions
+	}
+
+	return t.objectMaxVersions
 }

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -116,5 +116,11 @@ var (
 			Optional:    true,
 			Type:        "boolean",
 		},
+		config.HelpKV{
+			Key:         apiObjectMaxVersions,
+			Description: "set max allowed number of versions per object" + defaultHelpPostfix(apiObjectMaxVersions),
+			Optional:    true,
+			Type:        "number",
+		},
 	}
 )


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow dynamically changing max_object_versions per object

## Motivation and Context
we had default limits set via hidden ENV, which
required restarts. This PR fixes it by allowing
dynamic changes at runtime as needed.

## How to test this PR?

```
mc admin config set alias/ api object_max_versions=10
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
