### PR TITLE
[DRAFT] http webhook refactor 

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -646,7 +646,6 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			loggerCfg.AuditWebhook[n] = l
 		}
 
-		fmt.Println("UPDATING AUDIT FOR SUBSYSTEM", subSys)
 		if errs := logger.UpdateHTTPTargets(ctx, loggerCfg.AuditWebhook); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update audit webhook targets: %v", errs))
 		}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -621,12 +621,13 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		for n, l := range loggerCfg.HTTP {
 			if l.Enabled {
 				l.LogOnce = logger.LogOnceConsoleIf
+				l.Error = logger.Error
 				l.UserAgent = userAgent
 				l.Transport = NewHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			}
 			loggerCfg.HTTP[n] = l
 		}
-		if errs := logger.UpdateSystemTargets(ctx, loggerCfg); len(errs) > 0 {
+		if errs := logger.UpdateHTTPTargets(ctx, loggerCfg.HTTP); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update logger webhook config: %v", errs))
 		}
 	case config.AuditWebhookSubSys:
@@ -638,13 +639,15 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		for n, l := range loggerCfg.AuditWebhook {
 			if l.Enabled {
 				l.LogOnce = logger.LogOnceConsoleIf
+				l.Error = logger.Error
 				l.UserAgent = userAgent
 				l.Transport = NewHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			}
 			loggerCfg.AuditWebhook[n] = l
 		}
 
-		if errs := logger.UpdateAuditWebhookTargets(ctx, loggerCfg); len(errs) > 0 {
+		fmt.Println("UPDATING AUDIT FOR SUBSYSTEM", subSys)
+		if errs := logger.UpdateHTTPTargets(ctx, loggerCfg.AuditWebhook); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update audit webhook targets: %v", errs))
 		}
 	case config.AuditKafkaSubSys:

--- a/cmd/listen-notification-handlers.go
+++ b/cmd/listen-notification-handlers.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -35,7 +34,6 @@ import (
 
 func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := newContext(r, w, "ListenNotification")
-	fmt.Println("MAJOR HERE!")
 
 	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
 
@@ -173,7 +171,6 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 	)
 
 	if p := values.Get("ping"); p != "" {
-		fmt.Println("keepalive enabled")
 		pingInterval, err := strconv.Atoi(p)
 		if err != nil {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidQueryParams), r.URL)
@@ -183,13 +180,11 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidQueryParams), r.URL)
 			return
 		}
-		fmt.Println("new ping with custom time")
 		t := time.NewTicker(time.Duration(pingInterval) * time.Second)
 		defer t.Stop()
 		emptyEventTicker = t.C
 	} else {
 		// Deprecated Apr 2023
-		fmt.Println("new ping non custom")
 		t := time.NewTicker(500 * time.Millisecond)
 		defer t.Stop()
 		keepAliveTicker = t.C
@@ -199,7 +194,6 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 	for {
 		select {
 		case ev := <-mergeCh:
-			fmt.Println("merge chan")
 			_, err := w.Write(ev)
 			if err != nil {
 				return
@@ -210,13 +204,11 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 			}
 			grid.PutByteBuffer(ev)
 		case <-emptyEventTicker:
-			fmt.Println("empty event ticker")
 			if err := enc.Encode(struct{ Records []event.Event }{}); err != nil {
 				return
 			}
 			w.(http.Flusher).Flush()
 		case <-keepAliveTicker:
-			fmt.Println("keepalive!")
 			if _, err := w.Write([]byte(" ")); err != nil {
 				return
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -116,9 +116,8 @@ func sendItems(target Target, keyCh <-chan Key, doneCh <-chan struct{}, logger l
 					target.Name())
 			}
 
-			// Retrying after 3secs back-off
-
 			select {
+			// Retrying after 3secs back-off
 			case <-retryTicker.C:
 			case <-doneCh:
 				return false


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
NOTE: this description is a short one and temporary. I will write a much better one tomorrow but for now I kind of just want eyes on this.

The audit_webhook implementation was kind of broken, it would miss a lot of important errors and drop messages when configurations were reloaded. 

The new implementation will carry over old messages both from the original logCh and from a temp buffer created to hold messages that are in transit. The configurations can now be updated and removed live without loss of log entries. 
Additionally, the logic around spawning and de-spawning additional log workers was refactored to be a bit more responsive.

This change is applied for ALL http webhooks, not just audit logs. 

I've tested the performance by transferring at full speed on my local system and no problems yet. But I would like this to be tested on a system with more transfer capabilities. 



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

