### PR TITLE
Webhook targets refactor and bug fixes

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -644,7 +644,6 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			loggerCfg.AuditWebhook[n] = l
 		}
 
-		fmt.Println("UPDATING AUDIT FOR SUBSYSTEM", subSys)
 		if errs := logger.UpdateAuditWebhooks(ctx, loggerCfg.AuditWebhook); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update audit webhook targets: %v", errs))
 		}

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -620,13 +620,13 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		userAgent := getUserAgent(getMinioMode())
 		for n, l := range loggerCfg.HTTP {
 			if l.Enabled {
-				l.LogOnce = logger.LogOnceConsoleIf
+				l.LogOnceIf = logger.LogOnceConsoleIf
 				l.UserAgent = userAgent
 				l.Transport = NewHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			}
 			loggerCfg.HTTP[n] = l
 		}
-		if errs := logger.UpdateSystemTargets(ctx, loggerCfg); len(errs) > 0 {
+		if errs := logger.UpdateHTTPWebhooks(ctx, loggerCfg.HTTP); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update logger webhook config: %v", errs))
 		}
 	case config.AuditWebhookSubSys:
@@ -637,14 +637,15 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		userAgent := getUserAgent(getMinioMode())
 		for n, l := range loggerCfg.AuditWebhook {
 			if l.Enabled {
-				l.LogOnce = logger.LogOnceConsoleIf
+				l.LogOnceIf = logger.LogOnceConsoleIf
 				l.UserAgent = userAgent
 				l.Transport = NewHTTPTransportWithClientCerts(l.ClientCert, l.ClientKey)
 			}
 			loggerCfg.AuditWebhook[n] = l
 		}
 
-		if errs := logger.UpdateAuditWebhookTargets(ctx, loggerCfg); len(errs) > 0 {
+		fmt.Println("UPDATING AUDIT FOR SUBSYSTEM", subSys)
+		if errs := logger.UpdateAuditWebhooks(ctx, loggerCfg.AuditWebhook); len(errs) > 0 {
 			logger.LogIf(ctx, fmt.Errorf("Unable to update audit webhook targets: %v", errs))
 		}
 	case config.AuditKafkaSubSys:

--- a/cmd/listen-notification-handlers.go
+++ b/cmd/listen-notification-handlers.go
@@ -214,7 +214,6 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 			}
 			w.(http.Flusher).Flush()
 		case <-ctx.Done():
-
 			return
 		}
 	}

--- a/cmd/listen-notification-handlers.go
+++ b/cmd/listen-notification-handlers.go
@@ -214,6 +214,7 @@ func (api objectAPIHandlers) ListenNotificationHandler(w http.ResponseWriter, r 
 			}
 			w.(http.Flusher).Flush()
 		case <-ctx.Done():
+
 			return
 		}
 	}

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -343,7 +343,7 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 				if err := enc.Encode(&entry); err != nil {
 					h.config.LogOnceIf(
 						ctx,
-						fmt.Errorf("unable to decode webhook log entry, err  '%w' entry: %v\n", err, entry),
+						fmt.Errorf("unable to encode webhook log entry, err  '%w' entry: %v\n", err, entry),
 						h.Name(),
 					)
 					atomic.AddInt64(&h.failedMessages, 1)

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -111,9 +111,9 @@ type Target struct {
 	// If this webhook is being re-configured we will
 	// assign the new webhook target to this field.
 	// The Send() method will then re-direct entries
-	// to the new target when the current on has
-	// been seet to status "statusClosed".
-	// Once the glogal webhook slice has been update
+	// to the new target when the current one
+	// has been set to status "statusClosed".
+	// Once the glogal target slice has been migrated
 	// the current target will stop receiving entries.
 	migrateTarget *Target
 
@@ -172,6 +172,12 @@ func (h *Target) Stats() types.TargetStats {
 	}
 
 	return stats
+}
+
+// AssignMigrateTraget assigns a target
+// which will eventually replcae the current target.
+func (h *Target) AssignMigrateTraget(migrateTgt *Target) {
+	h.migrateTarget = migrateTgt
 }
 
 // Init validate and initialize the http target

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -174,16 +174,6 @@ func (h *Target) Stats() types.TargetStats {
 	return stats
 }
 
-// // InitDiskStore initializes the disk storage option
-// func (h *Target) InitDiskStore(ctx context.Context) (err error) {
-// 	return h.initQueueOnce.DoWithContext(ctx, h.initDiskStore)
-// }
-//
-// // InitMemoryStore initializes the channel storage option
-// func (h *Target) InitMemoryStore(ctx context.Context) (err error) {
-// 	return h.initQueueOnce.DoWithContext(ctx, h.initMemoryStore)
-// }
-
 // Init validate and initialize the http target
 func (h *Target) Init(ctx context.Context) (err error) {
 	if h.config.QueueDir != "" {
@@ -524,27 +514,27 @@ func CreateOrAdjustGlobalBuffer(currentTgt *Target, newTgt *Target) {
 			"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
 			fmt.Sprintf("|| new (%p)", newTgt),
 		)
-	}
 
-	if len(currentBuff) > 0 {
-	drain:
-		for {
-			select {
-			case v, ok := <-currentBuff:
-				if !ok {
+		if len(currentBuff) > 0 {
+		drain:
+			for {
+				select {
+				case v, ok := <-currentBuff:
+					if !ok {
+						break drain
+					}
+					logChBuffers[newTgt.Name()] <- v
+				default:
 					break drain
 				}
-				logChBuffers[newTgt.Name()] <- v
-			default:
-				break drain
 			}
+			fmt.Println(
+				"GLOBAL DRAIN ||",
+				fmt.Sprintf("name (%s)", newTgt.String()),
+				"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
+				fmt.Sprintf("|| cur. (%p) new (%p)", currentTgt, newTgt),
+			)
 		}
-		fmt.Println(
-			"GLOBAL DRAIN ||",
-			fmt.Sprintf("name (%s)", newTgt.String()),
-			"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
-			fmt.Sprintf("|| cur. (%p) new (%p)", currentTgt, newTgt),
-		)
 	}
 }
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -508,7 +508,7 @@ func New(config Config) (*Target, error) {
 		)
 
 		if err := queueStore.Open(); err != nil {
-			return nil, fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
+			return h, fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
 		}
 
 		h.store = queueStore

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -193,7 +193,7 @@ func (h *Target) initDiskStore(ctx context.Context) (err error) {
 	h.storeCtxCancel = cancel
 	h.lastStarted = time.Now()
 	go h.startQueueProcessor(ctx, true)
-	go store.StreamItems(h.store, h, ctx.Done(), h.config.LogOnceIf)
+	store.StreamItems(h.store, h, ctx.Done(), h.config.LogOnceIf)
 	return nil
 }
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -174,9 +174,9 @@ func (h *Target) Stats() types.TargetStats {
 	return stats
 }
 
-// AssignMigrateTraget assigns a target
-// which will eventually replcae the current target.
-func (h *Target) AssignMigrateTraget(migrateTgt *Target) {
+// AssignMigrateTarget assigns a target
+// which will eventually replace the current target.
+func (h *Target) AssignMigrateTarget(migrateTgt *Target) {
 	h.migrateTarget = migrateTgt
 }
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -497,9 +497,7 @@ func New(config Config) (*Target, error) {
 		h.config.Transport = ctransport
 	}
 
-	ctransport := h.config.Transport.(*http.Transport).Clone()
-	ctransport.TLSClientConfig.InsecureSkipVerify = true
-	h.client = &http.Client{Transport: ctransport}
+	h.client = &http.Client{Transport: h.config.Transport}
 
 	if h.config.QueueDir != "" {
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -524,27 +524,27 @@ func CreateOrAdjustGlobalBuffer(currentTgt *Target, newTgt *Target) {
 			"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
 			fmt.Sprintf("|| new (%p)", newTgt),
 		)
+	}
 
-		if len(currentBuff) > 0 {
-		drain:
-			for {
-				select {
-				case v, ok := <-currentBuff:
-					if !ok {
-						break drain
-					}
-					logChBuffers[newTgt.Name()] <- v
-				default:
+	if len(currentBuff) > 0 {
+	drain:
+		for {
+			select {
+			case v, ok := <-currentBuff:
+				if !ok {
 					break drain
 				}
+				logChBuffers[newTgt.Name()] <- v
+			default:
+				break drain
 			}
-			fmt.Println(
-				"GLOBAL DRAIN ||",
-				fmt.Sprintf("name (%s)", newTgt.String()),
-				"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
-				fmt.Sprintf("|| cur. (%p) new (%p)", currentTgt, newTgt),
-			)
 		}
+		fmt.Println(
+			"GLOBAL DRAIN ||",
+			fmt.Sprintf("name (%s)", newTgt.String()),
+			"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
+			fmt.Sprintf("|| cur. (%p) new (%p)", currentTgt, newTgt),
+		)
 	}
 }
 

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -20,11 +20,8 @@ package http
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -63,6 +60,11 @@ const (
 	statusClosed
 )
 
+var (
+	logChBuffers = make(map[string]chan interface{})
+	logChLock    = sync.Mutex{}
+)
+
 // Config http logger target
 type Config struct {
 	Enabled    bool              `json:"enabled"`
@@ -79,7 +81,7 @@ type Config struct {
 	Transport  http.RoundTripper `json:"-"`
 
 	// Custom logger
-	LogOnce func(ctx context.Context, err error, id string, errKind ...interface{}) `json:"-"`
+	LogOnceIf func(ctx context.Context, err error, id string, errKind ...interface{}) `json:"-"`
 }
 
 // Target implements logger.Target and sends the json
@@ -93,9 +95,10 @@ type Target struct {
 	status         int32
 
 	// Worker control
-	workers       int64
-	workerStartMu sync.Mutex
-	lastStarted   time.Time
+	workers    int64
+	maxWorkers int64
+	// workerStartMu sync.Mutex
+	lastStarted time.Time
 
 	wg sync.WaitGroup
 
@@ -105,23 +108,29 @@ type Target struct {
 	logCh   chan interface{}
 	logChMu sync.RWMutex
 
+	// If this webhook is being re-configured we will
+	// assign the new webhook target to this field.
+	// The Send() method will then re-direct entries
+	// to the new target when the current on has
+	// been seet to status "statusClosed".
+	// Once the glogal webhook slice has been update
+	// the current target will stop receiving entries.
+	migrateTarget *Target
+
 	// Number of events per HTTP send to webhook target
 	// this is ideally useful only if your endpoint can
 	// support reading multiple events on a stream for example
 	// like : Splunk HTTP Event collector, if you are unsure
 	// set this to '1'.
-	batchSize int
-
-	// If the first init fails, this starts a goroutine that
-	// will attempt to establish the connection.
-	revive sync.Once
+	batchSize   int
+	payloadType string
 
 	// store to persist and replay the logs to the target
 	// to avoid missing events when the target is down.
 	store          store.Store[interface{}]
 	storeCtxCancel context.CancelFunc
 
-	initQueueStoreOnce once.Init
+	initQueueOnce once.Init
 
 	config Config
 	client *http.Client
@@ -130,6 +139,11 @@ type Target struct {
 // Name returns the name of the target
 func (h *Target) Name() string {
 	return "minio-http-" + h.config.Name
+}
+
+// Type - returns type of the target
+func (h *Target) Type() types.TargetType {
+	return types.TargetHTTP
 }
 
 // Endpoint returns the backend endpoint
@@ -146,19 +160,6 @@ func (h *Target) IsOnline(ctx context.Context) bool {
 	return atomic.LoadInt32(&h.status) == statusOnline
 }
 
-// ping returns true if the target is reachable.
-func (h *Target) ping(ctx context.Context) bool {
-	if err := h.send(ctx, []byte(`{}`), "application/json", webhookCallTimeout); err != nil {
-		return !xnet.IsNetworkOrHostDown(err, false) && !xnet.IsConnRefusedErr(err)
-	}
-	// We are online.
-	h.workerStartMu.Lock()
-	h.lastStarted = time.Now()
-	h.workerStartMu.Unlock()
-	go h.startHTTPLogger(ctx)
-	return true
-}
-
 // Stats returns the target statistics.
 func (h *Target) Stats() types.TargetStats {
 	h.logChMu.RLock()
@@ -173,56 +174,38 @@ func (h *Target) Stats() types.TargetStats {
 	return stats
 }
 
+// // InitDiskStore initializes the disk storage option
+// func (h *Target) InitDiskStore(ctx context.Context) (err error) {
+// 	return h.initQueueOnce.DoWithContext(ctx, h.initDiskStore)
+// }
+//
+// // InitMemoryStore initializes the channel storage option
+// func (h *Target) InitMemoryStore(ctx context.Context) (err error) {
+// 	return h.initQueueOnce.DoWithContext(ctx, h.initMemoryStore)
+// }
+
 // Init validate and initialize the http target
 func (h *Target) Init(ctx context.Context) (err error) {
 	if h.config.QueueDir != "" {
-		return h.initQueueStoreOnce.DoWithContext(ctx, h.initQueueStore)
+		return h.initQueueOnce.DoWithContext(ctx, h.initDiskStore)
 	}
-	return h.init(ctx)
+	return h.initQueueOnce.DoWithContext(ctx, h.initMemoryStore)
 }
 
-func (h *Target) initQueueStore(ctx context.Context) (err error) {
-	var queueStore store.Store[interface{}]
-	queueDir := filepath.Join(h.config.QueueDir, h.Name())
-	queueStore = store.NewQueueStore[interface{}](queueDir, uint64(h.config.QueueSize), httpLoggerExtension)
-	if err = queueStore.Open(); err != nil {
-		return fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
-	}
+func (h *Target) initDiskStore(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
-	h.store = queueStore
 	h.storeCtxCancel = cancel
-	store.StreamItems(h.store, h, ctx.Done(), h.config.LogOnce)
-	return
+	h.lastStarted = time.Now()
+	go h.startQueueProcessor(ctx, true)
+	go store.StreamItems(h.store, h, ctx.Done(), h.config.LogOnceIf)
+	return nil
 }
 
-func (h *Target) init(ctx context.Context) (err error) {
-	switch atomic.LoadInt32(&h.status) {
-	case statusOnline:
-		return nil
-	case statusClosed:
-		return errors.New("target is closed")
-	}
-
-	if !h.ping(ctx) {
-		// Start a goroutine that will continue to check if we can reach
-		h.revive.Do(func() {
-			go func() {
-				// Avoid stamping herd, add jitter.
-				t := time.NewTicker(time.Second + time.Duration(rand.Int63n(int64(5*time.Second))))
-				defer t.Stop()
-
-				for range t.C {
-					if atomic.LoadInt32(&h.status) != statusOffline {
-						return
-					}
-					if h.ping(ctx) {
-						return
-					}
-				}
-			}()
-		})
-		return err
-	}
+func (h *Target) initMemoryStore(ctx context.Context) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	h.storeCtxCancel = cancel
+	h.lastStarted = time.Now()
+	go h.startQueueProcessor(ctx, true)
 	return nil
 }
 
@@ -275,90 +258,318 @@ func (h *Target) send(ctx context.Context, payload []byte, payloadType string, t
 	}
 }
 
-func (h *Target) logEntry(ctx context.Context, payload []byte, payloadType string) {
-	const maxTries = 3
-	tries := 0
-	for tries < maxTries {
-		if atomic.LoadInt32(&h.status) == statusClosed {
-			// Don't retry when closing...
-			return
-		}
-		// sleep = (tries+2) ^ 2 milliseconds.
-		sleep := time.Duration(math.Pow(float64(tries+2), 2)) * time.Millisecond
-		if sleep > time.Second {
-			sleep = time.Second
-		}
-		time.Sleep(sleep)
-		tries++
-		err := h.send(ctx, payload, payloadType, webhookCallTimeout)
-		if err == nil {
-			return
-		}
-		h.config.LogOnce(ctx, err, h.Endpoint())
+func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
+	h.logChMu.RLock()
+	if h.logCh == nil {
+		h.logChMu.RUnlock()
+		return
 	}
-	if tries == maxTries {
-		// Even with multiple retries, count failed messages as only one.
-		atomic.AddInt64(&h.failedMessages, 1)
-	}
-}
+	h.logChMu.RUnlock()
 
-func (h *Target) startHTTPLogger(ctx context.Context) {
 	atomic.AddInt64(&h.workers, 1)
 	defer atomic.AddInt64(&h.workers, -1)
 
-	h.logChMu.RLock()
-	logCh := h.logCh
-	if logCh != nil {
-		// We are not allowed to add when logCh is nil
-		h.wg.Add(1)
-		defer h.wg.Done()
-	}
-	h.logChMu.RUnlock()
-	if logCh == nil {
-		return
-	}
+	h.wg.Add(1)
+	defer h.wg.Done()
+
+	entries := make([]interface{}, 0)
+	name := h.Name()
+
+	defer func() {
+		// re-load the global buffer pointer
+		// in case it was modified by a new target.
+
+		logChLock.Lock()
+		currentGlobalBuffer, ok := logChBuffers[name]
+		logChLock.Unlock()
+		if !ok {
+			return
+		}
+
+		fmt.Println(
+			"DRAIN ||",
+			"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+			"tmpBuff (", len(entries), ") || ",
+			"global (", len(currentGlobalBuffer), "/", cap(currentGlobalBuffer), ") || ",
+			fmt.Sprintf("|| P:%p", &h),
+		)
+
+		totalDrained := 0
+		for _, v := range entries {
+			select {
+			case currentGlobalBuffer <- v:
+				totalDrained++
+			default:
+			}
+		}
+
+		if mainWorker {
+		drain:
+			for {
+				select {
+				case v, ok := <-h.logCh:
+					if !ok {
+						break drain
+					}
+
+					currentGlobalBuffer <- v
+					totalDrained++
+				default:
+					break drain
+				}
+			}
+		}
+		fmt.Println(
+			"--TARGET ||",
+			"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+			"tmpBuff (", len(entries), ") || ",
+			"global (", len(currentGlobalBuffer), "/", cap(currentGlobalBuffer), ") || ",
+			fmt.Sprintf("drained: (%d)", totalDrained),
+			fmt.Sprintf("|| P:%p", &h),
+		)
+	}()
+
+	var entry interface{}
+	var ok bool
+	var err error
+	lastBatchProcess := time.Now()
 
 	buf := bytebufferpool.Get()
+	enc := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(buf)
 	defer bytebufferpool.Put(buf)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	enc := json.NewEncoder(buf)
-	batchSize := h.batchSize
-	if batchSize <= 0 {
-		batchSize = 1
+	isDirQueue := false
+	if h.config.QueueDir != "" {
+		isDirQueue = true
 	}
 
-	payloadType := "application/json"
-	if batchSize > 1 {
-		payloadType = ""
-	}
+	// globalBuffer is always created or adjusted
+	// before this method is launched.
+	logChLock.Lock()
+	globalBuffer := logChBuffers[name]
+	logChLock.Unlock()
+	fmt.Println(
+		"++TARGET ||",
+		"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+		"tmpBuff (", len(entries), ") || ",
+		"global (", len(globalBuffer), "/", cap(globalBuffer), ") || ",
+		fmt.Sprintf("|| P:%p", &h),
+	)
 
-	var nevents int
-	// Send messages until channel is closed.
-	for entry := range logCh {
-		atomic.AddInt64(&h.totalMessages, 1)
-		nevents++
-		if err := enc.Encode(&entry); err != nil {
-			atomic.AddInt64(&h.failedMessages, 1)
-			nevents--
-			continue
+	newTicker := time.NewTicker(time.Second)
+	isTick := false
+
+	for {
+		isTick = false
+		select {
+		case _ = <-newTicker.C:
+			isTick = true
+		case entry, _ = <-globalBuffer:
+		case entry, ok = <-h.logCh:
+			if !ok {
+				return
+			}
+		case <-ctx.Done():
+			return
 		}
-		if (nevents == batchSize || len(logCh) == 0) && buf.Len() > 0 {
-			h.logEntry(ctx, buf.Bytes(), payloadType)
+
+		if !isTick {
+			atomic.AddInt64(&h.totalMessages, 1)
+
+			if !isDirQueue {
+				if err := enc.Encode(&entry); err != nil {
+					h.config.LogOnceIf(
+						ctx,
+						fmt.Errorf("unable to decode webhook log entry, err  '%w' entry: %v\n", err, entry),
+						h.Name(),
+					)
+					atomic.AddInt64(&h.failedMessages, 1)
+					continue
+				}
+			}
+
+			entries = append(entries, entry)
+		}
+
+		if len(entries) != h.batchSize {
+			if len(h.logCh) > 0 || len(globalBuffer) > 0 || len(entries) == 0 {
+				continue
+			}
+
+			if h.batchSize > 1 {
+				// If we are doing batching, we should wait
+				// at least one second before sending.
+				// Even if there is nothing in the queue.
+				if time.Since(lastBatchProcess).Seconds() < 1 {
+					continue
+				}
+			}
+		}
+
+		lastBatchProcess = time.Now()
+
+	retry:
+		if isDirQueue {
+			le, _ := h.store.List()
+			fmt.Println(
+				"DIS ||",
+				"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+				"tmpBuff (", len(entries), ") || ",
+				"global (", len(globalBuffer), "/", cap(globalBuffer), ") || ",
+				"store (", len(le), "/ ", h.config.QueueSize, ")",
+				fmt.Sprintf("|| P:%p", &h),
+			)
+		} else {
+			fmt.Println(
+				"MEM ||",
+				"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+				"tmpBuff (", len(entries), ") || ",
+				"global (", len(globalBuffer), "/", cap(globalBuffer), ") || ",
+				fmt.Sprintf("|| P:%p", &h),
+			)
+		}
+
+		// If the channel reaches above half capacity
+		// we spawn more workers. The workers spawned
+		// from this main worker routine will exit
+		// once the channel drops below half capacity
+		// and when it's been at least 30 seconds since
+		// we launched a new worker.
+		if mainWorker && len(h.logCh) > cap(h.logCh)/2 {
+			nWorkers := atomic.LoadInt64(&h.workers)
+			if nWorkers < h.maxWorkers {
+				if time.Since(h.lastStarted).Milliseconds() > 10 {
+					h.lastStarted = time.Now()
+					fmt.Println(
+						"++W ||",
+						"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+						"tmpBuff (", len(entries), ") || ",
+						"global (", len(globalBuffer), "/", cap(globalBuffer), ") || ",
+						fmt.Sprintf("|| P:%p", &h),
+					)
+					go h.startQueueProcessor(ctx, false)
+				}
+			}
+		}
+
+		if !isDirQueue {
+			err = h.send(ctx, buf.Bytes(), h.payloadType, webhookCallTimeout)
+		} else {
+			err = h.store.PutMultiple(entries)
+		}
+
+		if err != nil {
+
+			h.config.LogOnceIf(
+				context.Background(),
+				fmt.Errorf("unable to send webhook log entry to '%s' err '%w'", name, err),
+				name,
+			)
+
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
+			time.Sleep(3 * time.Second)
+			goto retry
+		}
+
+		entries = make([]interface{}, 0)
+
+		if !isDirQueue {
 			buf.Reset()
-			nevents = 0
+		}
+
+		if !mainWorker && len(h.logCh) < cap(h.logCh)/2 {
+			if time.Since(h.lastStarted).Seconds() > 30 {
+				fmt.Println(
+					"--W ||",
+					"logCh (", len(h.logCh), "/", cap(h.logCh), ") || ",
+					"tmpBuff (", len(entries), ") || ",
+					"global (", len(globalBuffer), "/", cap(globalBuffer), ") || ",
+					fmt.Sprintf("|| P:%p", &h),
+				)
+				return
+			}
+		}
+
+	}
+}
+
+// CreateOrAdjustGlobalBuffer will create or adjust the global log entry buffers
+// which are used to migrate log entries between old and new targets.
+func CreateOrAdjustGlobalBuffer(currentTgt *Target, newTgt *Target) {
+	logChLock.Lock()
+	defer logChLock.Unlock()
+
+	requiredCap := currentTgt.config.QueueSize + (currentTgt.config.BatchSize * int(currentTgt.maxWorkers))
+	currentCap := 0
+	name := newTgt.Name()
+
+	currentBuff, ok := logChBuffers[name]
+	if !ok {
+		logChBuffers[name] = make(chan interface{}, requiredCap)
+		currentCap = requiredCap
+	} else {
+		currentCap = cap(currentBuff)
+		requiredCap += len(currentBuff)
+	}
+
+	if requiredCap > currentCap {
+		logChBuffers[name] = make(chan interface{}, requiredCap)
+
+		fmt.Println(
+			"NEW GLOBAL ||",
+			fmt.Sprintf("name (%s)", newTgt.Name()),
+			"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
+			fmt.Sprintf("|| new (%p)", newTgt),
+		)
+
+		if len(currentBuff) > 0 {
+		drain:
+			for {
+				select {
+				case v, ok := <-currentBuff:
+					if !ok {
+						break drain
+					}
+					logChBuffers[newTgt.Name()] <- v
+				default:
+					break drain
+				}
+			}
+			fmt.Println(
+				"GLOBAL DRAIN ||",
+				fmt.Sprintf("name (%s)", newTgt.String()),
+				"gBuff (", len(logChBuffers[name]), "/", cap(logChBuffers[name]), ") || ",
+				fmt.Sprintf("|| cur. (%p) new (%p)", currentTgt, newTgt),
+			)
 		}
 	}
 }
 
 // New initializes a new logger target which
 // sends log over http to the specified endpoint
-func New(config Config) *Target {
+func New(config Config) (*Target, error) {
+	maxWorkers := maxWorkers
+	if config.BatchSize > 100 {
+		maxWorkers = maxWorkersWithBatchEvents
+	} else if config.BatchSize <= 0 {
+		config.BatchSize = 1
+	}
+
 	h := &Target{
-		logCh:     make(chan interface{}, config.QueueSize),
-		config:    config,
-		status:    statusOffline,
-		batchSize: config.BatchSize,
+		logCh:      make(chan interface{}, config.QueueSize),
+		config:     config,
+		status:     statusOffline,
+		batchSize:  config.BatchSize,
+		maxWorkers: int64(maxWorkers),
+	}
+
+	if config.BatchSize > 1 {
+		h.payloadType = ""
+	} else {
+		h.payloadType = "application/json"
 	}
 
 	// If proxy available, set the same
@@ -369,32 +580,39 @@ func New(config Config) *Target {
 		ctransport.Proxy = http.ProxyURL(proxyURL)
 		h.config.Transport = ctransport
 	}
-	h.client = &http.Client{Transport: h.config.Transport}
 
-	return h
+	ctransport := h.config.Transport.(*http.Transport).Clone()
+	ctransport.TLSClientConfig.InsecureSkipVerify = true
+	h.client = &http.Client{Transport: ctransport}
+
+	queueStore := store.NewQueueStore[interface{}](
+		filepath.Join(h.config.QueueDir, h.Name()),
+		uint64(h.config.QueueSize),
+		httpLoggerExtension,
+	)
+
+	if err := queueStore.Open(); err != nil {
+		return nil, fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
+	}
+
+	h.store = queueStore
+
+	return h, nil
 }
 
 // SendFromStore - reads the log from store and sends it to webhook.
 func (h *Target) SendFromStore(key store.Key) (err error) {
-	var eventData interface{}
-	eventData, err = h.store.Get(key.Name)
+	var eventData []byte
+	eventData, err = h.store.GetRaw(key.Name)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
-	atomic.AddInt64(&h.totalMessages, 1)
-	logJSON, err := json.Marshal(&eventData)
-	if err != nil {
+
+	if err := h.send(context.Background(), eventData, h.payloadType, webhookCallTimeout); err != nil {
 		atomic.AddInt64(&h.failedMessages, 1)
-		return
-	}
-	if err := h.send(context.Background(), logJSON, "application/json", webhookCallTimeout); err != nil {
-		atomic.AddInt64(&h.failedMessages, 1)
-		if xnet.IsNetworkOrHostDown(err, true) {
-			return store.ErrNotConnected
-		}
 		return err
 	}
 	// Delete the event from store.
@@ -406,22 +624,17 @@ func (h *Target) SendFromStore(key store.Key) (err error) {
 // If Cancel has been called the message is ignored.
 func (h *Target) Send(ctx context.Context, entry interface{}) error {
 	if atomic.LoadInt32(&h.status) == statusClosed {
+		if h.migrateTarget != nil {
+			return h.migrateTarget.Send(ctx, entry)
+		}
 		return nil
 	}
-	if h.store != nil {
-		// save the entry to the queue store which will be replayed to the target.
-		return h.store.Put(entry)
-	}
+
 	h.logChMu.RLock()
 	defer h.logChMu.RUnlock()
 	if h.logCh == nil {
 		// We are closing...
 		return nil
-	}
-
-	mworkers := maxWorkers
-	if h.batchSize > 100 {
-		mworkers = maxWorkersWithBatchEvents
 	}
 
 retry:
@@ -435,16 +648,8 @@ retry:
 		}
 		return nil
 	default:
-		nWorkers := atomic.LoadInt64(&h.workers)
-		if nWorkers < int64(mworkers) {
-			// Only have one try to start at the same time.
-			h.workerStartMu.Lock()
-			if time.Since(h.lastStarted) > time.Second {
-				h.lastStarted = time.Now()
-				go h.startHTTPLogger(ctx)
-			}
-			h.workerStartMu.Unlock()
-
+		if h.workers < h.maxWorkers {
+			fmt.Print(".")
 			goto retry
 		}
 		atomic.AddInt64(&h.totalMessages, 1)
@@ -460,12 +665,10 @@ retry:
 // All messages sent to the target after this function has been called will be dropped.
 func (h *Target) Cancel() {
 	atomic.StoreInt32(&h.status, statusClosed)
+	h.storeCtxCancel()
 
-	// If queuestore is configured, cancel it's context to
-	// stop the replay go-routine.
-	if h.store != nil {
-		h.storeCtxCancel()
-	}
+	// Wait for messages to be sent...
+	h.wg.Wait()
 
 	// Set logch to nil and close it.
 	// This will block all Send operations,
@@ -475,12 +678,4 @@ func (h *Target) Cancel() {
 	xioutil.SafeClose(h.logCh)
 	h.logCh = nil
 	h.logChMu.Unlock()
-
-	// Wait for messages to be sent...
-	h.wg.Wait()
-}
-
-// Type - returns type of the target
-func (h *Target) Type() types.TargetType {
-	return types.TargetHTTP
 }

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -205,7 +205,7 @@ func updateHTTPTargets(ctx context.Context, cfgs map[string]http.Config, targetL
 		for ii := range tgts {
 			if currentTgt.Name() == tgts[ii].Name() {
 				newTgt = tgts[ii]
-				currentTgt.AssignMigrateTraget(newTgt)
+				currentTgt.AssignMigrateTarget(newTgt)
 				http.CreateOrAdjustGlobalBuffer(currentTgt, newTgt)
 				break
 			}

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -205,6 +205,7 @@ func updateHTTPTargets(ctx context.Context, cfgs map[string]http.Config, targetL
 		for ii := range tgts {
 			if currentTgt.Name() == tgts[ii].Name() {
 				newTgt = tgts[ii]
+				currentTgt.AssignMigrateTraget(newTgt)
 				http.CreateOrAdjustGlobalBuffer(currentTgt, newTgt)
 				break
 			}

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -44,13 +44,18 @@ type Target interface {
 }
 
 var (
-	swapAuditMuRW  sync.RWMutex
-	swapSystemMuRW sync.RWMutex
 
 	// systemTargets is the set of enabled loggers.
 	// Must be immutable at all times.
 	// Can be swapped to another while holding swapMu
-	systemTargets = []Target{}
+	systemTargets  = []Target{}
+	swapSystemMuRW sync.RWMutex
+
+	// auditTargets is the list of enabled audit loggers
+	// Must be immutable at all times.
+	// Can be swapped to another while holding swapMu
+	auditTargets  = []Target{}
+	swapAuditMuRW sync.RWMutex
 
 	// This is always set represent /dev/console target
 	consoleTgt Target
@@ -103,13 +108,6 @@ func CurrentStats() map[string]types.TargetStats {
 	return res
 }
 
-// auditTargets is the list of enabled audit loggers
-// Must be immutable at all times.
-// Can be swapped to another while holding swapMu
-var (
-	auditTargets = []Target{}
-)
-
 // AddSystemTarget adds a new logger target to the
 // list of enabled loggers
 func AddSystemTarget(ctx context.Context, t Target) error {
@@ -130,23 +128,6 @@ func AddSystemTarget(ctx context.Context, t Target) error {
 	systemTargets = updated
 
 	return nil
-}
-
-func initSystemTargets(ctx context.Context, cfgMap map[string]http.Config) ([]Target, []error) {
-	tgts := []Target{}
-	errs := []error{}
-	for _, l := range cfgMap {
-		if l.Enabled {
-			t := http.New(l)
-			tgts = append(tgts, t)
-
-			e := t.Init(ctx)
-			if e != nil {
-				errs = append(errs, e)
-			}
-		}
-	}
-	return tgts, errs
 }
 
 func initKafkaTargets(ctx context.Context, cfgMap map[string]kafka.Config) ([]Target, []error) {
@@ -183,36 +164,73 @@ func splitTargets(targets []Target, t types.TargetType) (group1 []Target, group2
 
 func cancelTargets(targets []Target) {
 	for _, target := range targets {
-		target.Cancel()
+		go target.Cancel()
 	}
 }
 
-// UpdateSystemTargets swaps targets with newly loaded ones from the cfg
-func UpdateSystemTargets(ctx context.Context, cfg Config) []error {
-	newTgts, errs := initSystemTargets(ctx, cfg.HTTP)
-
-	swapSystemMuRW.Lock()
-	consoleTargets, otherTargets := splitTargets(systemTargets, types.TargetConsole)
-	newTgts = append(newTgts, consoleTargets...)
-	systemTargets = newTgts
-	swapSystemMuRW.Unlock()
-
-	cancelTargets(otherTargets) // cancel running targets
-	return errs
+// UpdateHTTPWebhooks swaps system webhook targets with newly loaded ones from the cfg
+func UpdateHTTPWebhooks(ctx context.Context, cfgs map[string]http.Config) (errs []error) {
+	return updateHTTPTargets(ctx, cfgs, &systemTargets)
 }
 
-// UpdateAuditWebhookTargets swaps audit webhook targets with newly loaded ones from the cfg
-func UpdateAuditWebhookTargets(ctx context.Context, cfg Config) []error {
-	newWebhookTgts, errs := initSystemTargets(ctx, cfg.AuditWebhook)
+// UpdateAuditWebhooks swaps audit webhook targets with newly loaded ones from the cfg
+func UpdateAuditWebhooks(ctx context.Context, cfgs map[string]http.Config) (errs []error) {
+	return updateHTTPTargets(ctx, cfgs, &auditTargets)
+}
+
+func updateHTTPTargets(ctx context.Context, cfgs map[string]http.Config, targetList *[]Target) (errs []error) {
+	tgts := make([]*http.Target, 0)
+	newWebhooks := make([]Target, 0)
+	for _, cfg := range cfgs {
+		if cfg.Enabled {
+			t, err := http.New(cfg)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			tgts = append(tgts, t)
+			newWebhooks = append(newWebhooks, t)
+		}
+	}
+
+	oldTargets := make([]Target, len(*targetList))
+	copy(oldTargets, *targetList)
+
+	for i := range oldTargets {
+		currentTgt, ok := oldTargets[i].(*http.Target)
+		if !ok {
+			continue
+		}
+		var newTgt *http.Target
+
+		for ii := range tgts {
+			if currentTgt.Name() == tgts[ii].Name() {
+				newTgt = tgts[ii]
+				http.CreateOrAdjustGlobalBuffer(currentTgt, newTgt)
+				break
+			}
+		}
+	}
+
+	for _, t := range tgts {
+		err := t.Init(ctx)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
 
 	swapAuditMuRW.Lock()
-	// Retain kafka targets
-	oldWebhookTgts, otherTgts := splitTargets(auditTargets, types.TargetHTTP)
-	newWebhookTgts = append(newWebhookTgts, otherTgts...)
-	auditTargets = newWebhookTgts
+	for i := range newWebhooks {
+		fmt.Printf(
+			"NEW TARGETS: %s %p\n",
+			newWebhooks[i].String(),
+			newWebhooks[i],
+		)
+	}
+	*targetList = newWebhooks
 	swapAuditMuRW.Unlock()
 
-	cancelTargets(oldWebhookTgts) // cancel running targets
+	cancelTargets(oldTargets)
+
 	return errs
 }
 

--- a/internal/logger/targets.go
+++ b/internal/logger/targets.go
@@ -219,13 +219,6 @@ func updateHTTPTargets(ctx context.Context, cfgs map[string]http.Config, targetL
 	}
 
 	swapAuditMuRW.Lock()
-	for i := range newWebhooks {
-		fmt.Printf(
-			"NEW TARGETS: %s %p\n",
-			newWebhooks[i].String(),
-			newWebhooks[i],
-		)
-	}
 	*targetList = newWebhooks
 	swapAuditMuRW.Unlock()
 

--- a/internal/store/queuestore.go
+++ b/internal/store/queuestore.go
@@ -100,6 +100,7 @@ func (store *QueueStore[_]) Open() error {
 	return nil
 }
 
+// Delete - Remove the store directory from disk
 func (store *QueueStore[_]) Delete() error {
 	return os.Remove(store.directory)
 }

--- a/internal/store/queuestore.go
+++ b/internal/store/queuestore.go
@@ -122,7 +122,6 @@ func (store *QueueStore[I]) PutMultiple(item []I) error {
 
 // write - writes an item to the directory.
 func (store *QueueStore[I]) multiWrite(key string, item []I) error {
-	// Marshalls the item.
 
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)

--- a/internal/store/queuestore.go
+++ b/internal/store/queuestore.go
@@ -120,9 +120,8 @@ func (store *QueueStore[I]) PutMultiple(item []I) error {
 	return store.multiWrite(key.String(), item)
 }
 
-// write - writes an item to the directory.
+// multiWrite - writes an item to the directory.
 func (store *QueueStore[I]) multiWrite(key string, item []I) error {
-
 	buf := bytebufferpool.Get()
 	defer bytebufferpool.Put(buf)
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	xioutil "github.com/minio/minio/internal/ioutil"
-	xnet "github.com/minio/pkg/v2/net"
 )
 
 const (
@@ -46,12 +45,15 @@ type Target interface {
 // Store - Used to persist items.
 type Store[I any] interface {
 	Put(item I) error
+	PutMultiple(item []I) error
 	Get(key string) (I, error)
+	GetRaw(key string) ([]byte, error)
 	Len() int
 	List() ([]string, error)
 	Del(key string) error
 	DelList(key []string) error
 	Open() error
+	Delete() error
 	Extension() string
 }
 
@@ -110,15 +112,14 @@ func sendItems(target Target, keyCh <-chan Key, doneCh <-chan struct{}, logger l
 				break
 			}
 
-			if err != ErrNotConnected && !xnet.IsConnResetErr(err) {
-				logger(context.Background(),
-					fmt.Errorf("target.SendFromStore() failed with '%w'", err),
-					target.Name())
-			}
-
-			// Retrying after 3secs back-off
+			logger(
+				context.Background(),
+				fmt.Errorf("unable to send webhook log entry to '%s' err '%w'", target.Name(), err),
+				target.Name(),
+			)
 
 			select {
+			// Retrying after 3secs back-off
 			case <-retryTicker.C:
 			case <-doneCh:
 				return false
@@ -131,7 +132,6 @@ func sendItems(target Target, keyCh <-chan Key, doneCh <-chan struct{}, logger l
 		select {
 		case key, ok := <-keyCh:
 			if !ok {
-				// closed channel.
 				return
 			}
 
@@ -146,10 +146,6 @@ func sendItems(target Target, keyCh <-chan Key, doneCh <-chan struct{}, logger l
 
 // StreamItems reads the keys from the store and replays the corresponding item to the target.
 func StreamItems[I any](store Store[I], target Target, doneCh <-chan struct{}, logger logger) {
-	go func() {
-		// Replays the items from the store.
-		keyCh := replayItems(store, doneCh, logger, target.Name())
-		// Send items from the store.
-		sendItems(target, keyCh, doneCh, logger)
-	}()
+	keyCh := replayItems(store, doneCh, logger, target.Name())
+	sendItems(target, keyCh, doneCh, logger)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -146,6 +146,8 @@ func sendItems(target Target, keyCh <-chan Key, doneCh <-chan struct{}, logger l
 
 // StreamItems reads the keys from the store and replays the corresponding item to the target.
 func StreamItems[I any](store Store[I], target Target, doneCh <-chan struct{}, logger logger) {
-	keyCh := replayItems(store, doneCh, logger, target.Name())
-	sendItems(target, keyCh, doneCh, logger)
+	go func() {
+		keyCh := replayItems(store, doneCh, logger, target.Name())
+		sendItems(target, keyCh, doneCh, logger)
+	}()
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

# Webhook updates
This refactor updates the HTTP webhook logic to be more robust and not lose messages during config reload. <br>
It implements a global buffer which acts as a middle man between the old and the new webhook targets. <br>
This new code should be restistant to multiple reloads with broken configurations and resizing of the queue_size between config changes. Additionally we can now migrate from an in memory queue to a disk queue during a live reload of the config. <br>

# NOTES
The fmt print logs are still in the code, this will make it easier to read the logs below and understand where they relate to the code. Once the PR has been accapted I will do a final pass to remove the logs.

# Things that were fixed
 - old version was unable to retain messages during config reload
 - old version could not go from memory to disk during reload
 - new version can batche disk queue entries to single for to reduce I/O load
 - error logging has been improved, previous version would miss certain errors.
 - logic for spawning/despawning additional workers has been adjusted to trigger when half capacity is reached, instead of when the log queue becomes full.
 - old version would json mashral x2 and unmarshal 1x for every log item. Now we only do marshal x1 and then we GetRaw from the store and send it without having to re-marshal.

# Debug logs
NOTES ON LOGS:<br>
++TARGET == a new webhook endpoint is being created
--TARGET == webhook queue processor is exiting
++W == a new webhook queue sub processor is spawned due to queue pressure
--W == webhook queue sub processor is de-spawned
DRAIN == webhook queue processor is draining current buffers in to global buffer
GLOBAL DRAIN == global buffer needed to adjust to new queuesize + current queue len
MEM == debug print for the logCh when running in memory mode
DIS == debug print for the logCh when running in disk mode
NEW TARGETS == list of new targets to be deployed post config update (or on start)
 - global == global migration buffer (len/cap)
 - tmpBuf == current workers internal buffer for items that are in transit (len)
 - logCh == current log item queue (len/cap)

## Multiple reload with broken config + queue drain
```
UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc001c94480
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc001250448


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc0011e7b00
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc00108c7f8
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc001250448
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc001250448


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000d73680
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae490
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  || P:0xc00108c7f8
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 1 / 104000 ) ||  drained: (1) || P:0xc00108c7f8


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc03b76e000
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc0001f25c8
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae490
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 2 / 104000 ) ||  drained: (2) || P:0xc02c4ae490


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc03b76e180
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 3 ) ||  global ( 0 / 104000 ) ||  || P:0xc0001f25c8
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 3 ) ||  global ( 3 / 104000 ) ||  drained: (3) || P:0xc0001f25c8


### at this point we have reloaded 5x so we have 5 items in the tmpBuff
### now we start sending 30k requests while the authentication is broken.

API: SYSTEM()
Time: 14:35:56 UTC 03/19/2024
DeploymentID: bf643cbe-3d8e-4b1a-9dfa-1d5215f4b1ee
Error: unable to send webhook log entry to 'minio-http-audit-_' err 'https://172.17.0.3:8088/services/collector/raw returned '403 Forbidden', please check if your auth token is correctly set' (*fmt.wrapError)
       3: internal/logger/logonce.go:64:logger.(*logOnceType).logOnceConsoleIf()
       2: internal/logger/logonce.go:157:logger.LogOnceConsoleIf()
       1: internal/logger/target/http/http.go:456:http.(*Target).startQueueProcessor()
MEM || logCh ( 1906 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 5418 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 10001 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 10001 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 10001 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 10106 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 11847 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 13629 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 18086 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 20003 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 20003 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 21290 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 23388 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 25686 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 28754 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 30005 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
MEM || logCh ( 30005 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828

### we end up with the original 5 in the tmpBuffer and 30005 items in the log queue.
### NOTE: even if we moved 30k items there are overhead calls like ListBucket which also show up in the queue.

### finally we reload the config and fix the authentication, now all the buffers can be drained.
### All in all we send 29011 items from the global buffer and 1000 items from the tmpBuff
### for a total of 30011 items.


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc001220d80
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 30005 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
DRAIN || logCh ( 30005 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 0 / 104000 ) ||  || P:0xc02c4ae828
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 5 ) ||  global ( 29915 / 104000 ) ||  drained: (30010) || P:0xc02c4ae828
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 29011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 28011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 27011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 26011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 25011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 24011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 23011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 22011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 21011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 20011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 17011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 16011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 15011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 14011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 13011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 12011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 11011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 10011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 9011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 8011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 7011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 6011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 5011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 4011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 3011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 2011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 1011 / 104000 ) ||  || P:0xc03f9d8088
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 11 / 104000 ) ||  || P:0xc03f9d8088
```

## Multiple global temp buffer transfers + queue drain
```
UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000b27b00
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc000e021f0

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc0331c2300
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc000e021f0
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc000e021f0

API: SYSTEM()
Time: 14:37:27 UTC 03/19/2024
DeploymentID: bf643cbe-3d8e-4b1a-9dfa-1d5215f4b1ee
Error: unable to send webhook log entry to 'minio-http-audit-_' err 'https://172.17.0.3:8088/services/collector/raw returned '403 Forbidden', please check if your auth token is correctly set' (*fmt.wrapError)
       3: internal/logger/logonce.go:64:logger.(*logOnceType).logOnceConsoleIf()
       2: internal/logger/logonce.go:157:logger.LogOnceConsoleIf()
       1: internal/logger/target/http/http.go:456:http.(*Target).startQueueProcessor()
MEM || logCh ( 1770 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 4941 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 9632 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 10908 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 12886 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 15469 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 18586 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 20003 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
MEM || logCh ( 20003 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270


### at this point we have 20005 items in the queue and we reload the config

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000cae000
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc030f0b020
MEM || logCh ( 20003 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270
DRAIN || logCh ( 20003 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc001296270

### here we can see that 20005 total items were drained from the queue. 

--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 19934 / 104000 ) ||  drained: (20005) || P:0xc001296270

### the new target now has the 20005 items from the previous target plus the new item generated
### by the 'mc admin config set' command.

MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19006 / 104000 ) ||  || P:0xc030f0b020



UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW GLOBAL || name (minio-http-audit-_) gBuff ( 0 / 123006 ) ||  || new (0xc0331c2600)
GLOBAL DRAIN || name (audit-_) gBuff ( 19006 / 123006 ) ||  || cur. (0xc000cae000) new (0xc0331c2600)
NEW TARGETS: audit-_ 0xc0331c2600
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 19006 / 123006 ) ||  || P:0xc03634e748
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18007 / 123006 ) ||  || P:0xc03634e748
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  || P:0xc030f0b020
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18007 / 123006 ) ||  || P:0xc030f0b020
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19007 / 123006 ) ||  drained: (1000) || P:0xc030f0b020
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19007 / 123006 ) ||  || P:0xc03634e748



UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW GLOBAL || name (minio-http-audit-_) gBuff ( 0 / 123007 ) ||  || new (0xc000e92300)
GLOBAL DRAIN || name (audit-_) gBuff ( 19007 / 123007 ) ||  || cur. (0xc0331c2600) new (0xc000e92300)
NEW TARGETS: audit-_ 0xc000e92300
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 19007 / 123007 ) ||  || P:0xc035607540
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18008 / 123007 ) ||  || P:0xc035607540
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123006 ) ||  || P:0xc03634e748
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18008 / 123007 ) ||  || P:0xc03634e748
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19008 / 123007 ) ||  drained: (1000) || P:0xc03634e748
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19008 / 123007 ) ||  || P:0xc035607540



UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW GLOBAL || name (minio-http-audit-_) gBuff ( 0 / 123008 ) ||  || new (0xc000dbf080)
GLOBAL DRAIN || name (audit-_) gBuff ( 19008 / 123008 ) ||  || cur. (0xc000e92300) new (0xc000dbf080)
NEW TARGETS: audit-_ 0xc000dbf080
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 19008 / 123008 ) ||  || P:0xc03506d278
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18009 / 123008 ) ||  || P:0xc03506d278
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123007 ) ||  || P:0xc035607540
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18009 / 123008 ) ||  || P:0xc035607540
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19009 / 123008 ) ||  drained: (1000) || P:0xc035607540
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19009 / 123008 ) ||  || P:0xc03506d278
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19009 / 123008 ) ||  || P:0xc03506d278



UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW GLOBAL || name (minio-http-audit-_) gBuff ( 0 / 123009 ) ||  || new (0xc000b27b00)
GLOBAL DRAIN || name (audit-_) gBuff ( 19009 / 123009 ) ||  || cur. (0xc000dbf080) new (0xc000b27b00)
NEW TARGETS: audit-_ 0xc000b27b00
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 19009 / 123009 ) ||  || P:0xc030f0b238
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18010 / 123009 ) ||  || P:0xc030f0b238
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123008 ) ||  || P:0xc03506d278
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18010 / 123009 ) ||  || P:0xc03506d278
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19010 / 123009 ) ||  drained: (1000) || P:0xc03506d278
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 19010 / 123009 ) ||  || P:0xc030f0b238


### the target finally get updated with working authentication

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW GLOBAL || name (minio-http-audit-_) gBuff ( 0 / 123010 ) ||  || new (0xc001054600)
GLOBAL DRAIN || name (audit-_) gBuff ( 19010 / 123010 ) ||  || cur. (0xc000b27b00) new (0xc001054600)
NEW TARGETS: audit-_ 0xc001054600
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 19010 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 18011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 17011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 16011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 15011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 14011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 13011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 12011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 11011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 10011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 9011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 8011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 7011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 6011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 5011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 4011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 3011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 2011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 1011 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 11 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123009 ) ||  || P:0xc030f0b238
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc030f0b238
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 999 / 123010 ) ||  drained: (1000) || P:0xc030f0b238

### this is me sending some extra items to make sure everything is still operating normally

MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 11 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 12 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 576 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 597 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 561 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 849 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 581 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 838 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 523 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 541 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 535 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 549 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 770 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 920 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 982 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 935 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 806 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
MEM || logCh ( 3 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 123010 ) ||  || P:0xc03599d2c0
```

## Directory queue logs
```
UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000fb4480
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc001e06178

DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 563 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 551 ) ||  global ( 0 / 0 ) ||  store ( 1 /  100000 ) || P:0xc001e06178
DIS || logCh ( 8 / 100000 ) ||  tmpBuff ( 556 ) ||  global ( 0 / 0 ) ||  store ( 2 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 622 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 1 /  100000 ) || P:0xc001e06178
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 2 /  100000 ) || P:0xc001e06178
DIS || logCh ( 3 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 1 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 2 /  100000 ) || P:0xc001e06178
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 3 /  100000 ) || P:0xc001e06178
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 0 ) ||  store ( 4 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 709 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  store ( 0 /  100000 ) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  store ( 1 /  100000 ) || P:0xc001e06178

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc001e5db00
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc05467f318
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc001e06178
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc001e06178
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc05467f318

API: SYSTEM()
Time: 15:16:24 UTC 03/19/2024
DeploymentID: bf643cbe-3d8e-4b1a-9dfa-1d5215f4b1ee
Error: unable to send webhook log entry to 'minio-http-audit-_' err 'https://172.17.0.3:8088/services/collector/raw returned '403 Forbidden', please check if your auth token is correctly set' (*fmt.wrapError)
       5: internal/logger/logonce.go:64:logger.(*logOnceType).logOnceConsoleIf()
       4: internal/logger/logonce.go:157:logger.LogOnceConsoleIf()
       3: internal/store/store.go:114:store.sendItems.func1()
       2: internal/store/store.go:137:store.sendItems()
       1: internal/store/store.go:151:store.StreamItems[...]()
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc05467f318
DIS || logCh ( 9 / 100000 ) ||  tmpBuff ( 622 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc05467f318
DIS || logCh ( 9 / 100000 ) ||  tmpBuff ( 567 ) ||  global ( 0 / 104000 ) ||  store ( 3 /  100000 ) || P:0xc05467f318
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 564 ) ||  global ( 0 / 104000 ) ||  store ( 4 /  100000 ) || P:0xc05467f318
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 591 ) ||  global ( 0 / 104000 ) ||  store ( 5 /  100000 ) || P:0xc05467f318
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 6 /  100000 ) || P:0xc05467f318
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 7 /  100000 ) || P:0xc05467f318
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 8 /  100000 ) || P:0xc05467f318
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 9 /  100000 ) || P:0xc05467f318
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 10 /  100000 ) || P:0xc05467f318
DIS || logCh ( 6 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 11 /  100000 ) || P:0xc05467f318
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 12 /  100000 ) || P:0xc05467f318
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 657 ) ||  global ( 0 / 104000 ) ||  store ( 13 /  100000 ) || P:0xc05467f318

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc0010fb380
++TARGET || logCh ( 1 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc053faea40
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc05467f318
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc05467f318

DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 14 /  100000 ) || P:0xc053faea40
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 15 /  100000 ) || P:0xc053faea40
DIS || logCh ( 8 / 100000 ) ||  tmpBuff ( 657 ) ||  global ( 0 / 104000 ) ||  store ( 16 /  100000 ) || P:0xc053faea40
DIS || logCh ( 11 / 100000 ) ||  tmpBuff ( 891 ) ||  global ( 0 / 104000 ) ||  store ( 17 /  100000 ) || P:0xc053faea40
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 583 ) ||  global ( 0 / 104000 ) ||  store ( 18 /  100000 ) || P:0xc053faea40
DIS || logCh ( 10 / 100000 ) ||  tmpBuff ( 566 ) ||  global ( 0 / 104000 ) ||  store ( 19 /  100000 ) || P:0xc053faea40
DIS || logCh ( 3 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 20 /  100000 ) || P:0xc053faea40
DIS || logCh ( 6 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 21 /  100000 ) || P:0xc053faea40
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 22 /  100000 ) || P:0xc053faea40
DIS || logCh ( 7 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 23 /  100000 ) || P:0xc053faea40
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 24 /  100000 ) || P:0xc053faea40
DIS || logCh ( 7 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 25 /  100000 ) || P:0xc053faea40
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 26 /  100000 ) || P:0xc053faea40
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 304 ) ||  global ( 0 / 104000 ) ||  store ( 27 /  100000 ) || P:0xc053faea40

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000de2f00
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc04474a670
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc053faea40
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc053faea40

DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 492 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 1 / 100000 ) ||  tmpBuff ( 612 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc04474a670
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 654 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 710 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc04474a670
DIS || logCh ( 3 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc04474a670
DIS || logCh ( 7 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 3 /  100000 ) || P:0xc04474a670
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 7 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc04474a670
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc04474a670
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 533 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc04474a670
```

## Migrating from memory queue to directory queue
```
UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc0011b0180
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0

API: SYSTEM()
Time: 15:50:01 UTC 03/19/2024
DeploymentID: bf643cbe-3d8e-4b1a-9dfa-1d5215f4b1ee
Error: unable to send webhook log entry to 'minio-http-audit-_' err 'https://172.17.0.3:8088/services/collector/raw returned '403 Forbidden', please check if your auth token is correctly set' (*fmt.wrapError)
       3: internal/logger/logonce.go:64:logger.(*logOnceType).logOnceConsoleIf()
       2: internal/logger/logonce.go:157:logger.LogOnceConsoleIf()
       1: internal/logger/target/http/http.go:467:http.(*Target).startQueueProcessor()
MEM || logCh ( 1659 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 4910 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 9092 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0


UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000d9f200
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed8e8
MEM || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc0014222c0
DRAIN || logCh ( 10000 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  || P:0xc0014222c0
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 9002 / 104000 ) ||  drained: (10002) || P:0xc0014222c0


DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 9002 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 8002 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 7002 / 104000 ) ||  store ( 3 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 6002 / 104000 ) ||  store ( 4 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 5002 / 104000 ) ||  store ( 5 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 4002 / 104000 ) ||  store ( 6 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 3002 / 104000 ) ||  store ( 7 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 2002 / 104000 ) ||  store ( 8 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 1002 / 104000 ) ||  store ( 9 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 2 / 104000 ) ||  store ( 10 /  100000 ) || P:0xc0336ed8e8
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 104000 ) ||  store ( 11 /  100000 ) || P:0xc0336ed8e8

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc000dfcf00
++TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc0336ed928
DRAIN || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  || P:0xc0336ed8e8
--TARGET || logCh ( 0 / 100000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 104000 ) ||  drained: (0) || P:0xc0336ed8e8

DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 663 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 10 / 100000 ) ||  tmpBuff ( 613 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 8 / 100000 ) ||  tmpBuff ( 599 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 644 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 3 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 933 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 1 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 5 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 2 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 2 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 3 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 4 / 100000 ) ||  tmpBuff ( 1000 ) ||  global ( 0 / 104000 ) ||  store ( 4 /  100000 ) || P:0xc0336ed928
DIS || logCh ( 0 / 100000 ) ||  tmpBuff ( 549 ) ||  global ( 0 / 104000 ) ||  store ( 0 /  100000 ) || P:0xc0336ed928
```

### Spawning additional workers due to queue pressure
```

UPDATING AUDIT FOR SUBSYSTEM audit_webhook
NEW TARGETS: audit-_ 0xc0000c3080
++TARGET || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 244 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 542 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 788 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1059 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1292 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1540 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1892 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 2463 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 3089 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 3674 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 4179 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 4824 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 5457 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

### at this point the queue has reached more then half capacity so we start spawning extra workers

++W || logCh ( 5457 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 5457 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608

MEM || logCh ( 5977 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 5989 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 5989 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 5989 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48

MEM || logCh ( 6754 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 6761 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 6768 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 6768 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 6768 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908

MEM || logCh ( 7489 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 7505 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 7506 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 7506 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 7506 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
++TARGET || logCh ( 7506 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40

MEM || logCh ( 7308 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 7304 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 7303 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 7303 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 7301 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478

MEM || logCh ( 7301 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 7301 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 6908 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 6906 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 6897 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 6898 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 6899 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50

MEM || logCh ( 6898 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 6896 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 6890 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 6544 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 6538 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 6532 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 6519 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 6519 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 6519 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228

MEM || logCh ( 6528 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 6526 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 6526 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 6126 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 6109 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 6091 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 6091 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 6089 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 6089 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 6089 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
++TARGET || logCh ( 6089 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70

MEM || logCh ( 6074 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 6072 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 5605 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 5583 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 5564 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 5562 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 5556 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 5542 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 5538 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8

++W || logCh ( 5538 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
++TARGET || logCh ( 5538 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720

### we have now reached the required number of workers to handle this load
### no more workers will be spawned from here on.

MEM || logCh ( 5532 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 5532 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 4920 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 4884 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 4871 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 4857 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 4854 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 4862 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 4856 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 4850 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 4839 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 4833 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 4244 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 4228 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 4217 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 4199 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 4192 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 4192 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 4188 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 4183 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 4181 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 4167 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 3557 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 3549 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 3535 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 3526 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 3523 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 3522 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 3515 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 3514 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 3505 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 3496 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 3043 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 3036 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 3012 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 3007 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 3003 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 3008 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 3006 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 3004 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 2997 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 2996 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 2539 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 2528 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 2506 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 2487 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 2487 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 2482 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 2474 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 2464 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 2463 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 2463 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 2009 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 2004 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 1979 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 1975 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 1972 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 1970 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 1966 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1959 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 1953 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 1955 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 1484 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 1476 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 1463 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 1439 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 1438 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 1433 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 1429 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 1429 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 1427 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 1412 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 965 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 954 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 931 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 893 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 890 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 902 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 886 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 885 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 873 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 863 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 433 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 422 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 410 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 375 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 375 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 365 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 362 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 360 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 347 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 347 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 1 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 3 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 4 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 1 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 4 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 3 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 6 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 2 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 11 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 91 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 97 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 92 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 94 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 96 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 99 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 92 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 93 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 92 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 1 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 21 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 22 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 15 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 6 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 2 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 2 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 11 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 6 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 3 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 2 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 3 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 100 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 47 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478

### here I send a few more calls to trigger the sub processors to exit
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc03d0c9720
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc032264e40
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc033d37f50
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc039407f70
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc04452a608
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc04bf6d908
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc0376b7228
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc048136f48
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 1 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
--W || logCh ( 0 / 10000 ) ||  tmpBuff ( 0 ) ||  global ( 0 / 0 ) ||  || P:0xc03317f478
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 2 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
MEM || logCh ( 0 / 10000 ) ||  tmpBuff ( 7 ) ||  global ( 0 / 0 ) ||  || P:0xc000114aa8
```



