### PR TITLE
Handle zero versions qualified for expiration

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -233,6 +233,10 @@ func (es *expiryState) enqueueByDays(oi ObjectInfo, event lifecycle.Event, src l
 // enqueueByNewerNoncurrent enqueues object versions expired by
 // NewerNoncurrentVersions limit for expiry.
 func (es *expiryState) enqueueByNewerNoncurrent(bucket string, versions []ObjectToDelete, lcEvent lifecycle.Event) {
+	if len(versions) == 0 {
+		return
+	}
+
 	task := newerNoncurrentTask{bucket: bucket, versions: versions, event: lcEvent}
 	wrkr := es.getWorkerCh(task.OpHash())
 	if wrkr == nil {

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1051,7 +1051,9 @@ func (i *scannerItem) applyNewerNoncurrentVersionLimit(ctx context.Context, _ Ob
 		})
 	}
 
-	expState.enqueueByNewerNoncurrent(i.bucket, toDel, event)
+	if len(toDel) > 0 {
+		expState.enqueueByNewerNoncurrent(i.bucket, toDel, event)
+	}
 	return objectInfos, nil
 }
 


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
When objects have more versions than their ILM policy expects to retain via NewerNoncurrentVersions but they don't qualify for expiry due to NoncurrentDays configured in that rule. In this case, applyNewerNoncurrentVersionsLimit method was enqueuing empty tasks which lead to a panic (panic: runtime error: index out of range [0] with length 0) in newerNoncurrentTask.OpHash method, which assumes the task to contain at least one version to expire.

## How to test this PR?
1. Create a bucket and enable versioning
2. Upload 10 versions for an object
3. Configure the following ilm policy
e.g
`mc ilm rule add --noncurrent-expire-newer 5 --noncurrent-expire-days 10 myminio/bucket`

4. Observe scanner and ILM activity (optional)
`mc admin trace --call ilm --call scanner myminio`

5. Increase scanner speed to speed up the test (optional)
`mc admin config set myminio scanner speed=fastest`

You should observe a panic backtrace without this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
