### PR TITLE
fix: Fix crash when logging events and anonymous is enabled

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -364,7 +364,9 @@ func buildLogEntry(ctx context.Context, message string, trace []string, errKind 
 		entry.API.Args.Bucket = HashString(entry.API.Args.Bucket)
 		entry.API.Args.Object = HashString(entry.API.Args.Object)
 		entry.RemoteHost = HashString(entry.RemoteHost)
-		entry.Trace.Variables = make(map[string]interface{})
+		if entry.Trace != nil {
+			entry.Trace.Variables = make(map[string]interface{})
+		}
 	}
 
 	return entry


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Events log does not have a stacktrace. So Trace is nil. 
Fix a crash in this case when an event is printed while anonymous logging is enabled.

## Motivation and Context
Fixes https://github.com/minio/minio/issues/19312

## How to test this PR?
Trigger a healing disk operation while anonymous flag is enabled

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
