### PR TITLE
allow configuring inline shard size value

### DIFF
--- a/internal/config/storageclass/help.go
+++ b/internal/config/storageclass/help.go
@@ -39,8 +39,8 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
-			Key:         ClassOptimize,
-			Description: `optimize parity calculation for standard storage class, set 'capacity' for capacity optimized (no additional parity)` + defaultHelpPostfix(ClassOptimize),
+			Key:         Optimize,
+			Description: `optimize parity calculation for standard storage class, set 'capacity' for capacity optimized (no additional parity)` + defaultHelpPostfix(Optimize),
 			Optional:    true,
 			Type:        "string",
 		},


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow configuring inline shard size value

## Motivation and Context
performance of inline v/s non-inline seems to be 2x 
difference - allow configuring this in some
situations when a bigger stripe for 1MiB object size
would fall under the inline category.

## How to test this PR?
We need to do performance numbers to see the difference
allow this to be configurable for now. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
