### PR TITLE
bring back minor DNS cache for k8s setups

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -590,8 +590,6 @@ func hostResolveToLocalhost(endpoint Endpoint) bool {
 
 // UpdateIsLocal - resolves the host and discovers the local host.
 func (endpoints Endpoints) UpdateIsLocal() error {
-	orchestrated := IsDocker() || IsKubernetes()
-
 	var epsResolved int
 	var foundLocal bool
 	resolvedList := make([]bool, len(endpoints))
@@ -775,8 +773,6 @@ type PoolEndpointList []Endpoints
 
 // UpdateIsLocal - resolves all hosts and discovers which are local
 func (p PoolEndpointList) UpdateIsLocal() error {
-	orchestrated := IsDocker() || IsKubernetes()
-
 	var epsResolved int
 	var epCount int
 
@@ -1034,7 +1030,6 @@ func CreatePoolEndpoints(serverAddr string, poolsLayout ...poolDisksLayout) ([]E
 			}
 		}
 
-		orchestrated := IsKubernetes() || IsDocker()
 		reverseProxy := (env.Get("_MINIO_REVERSE_PROXY", "") != "") && ((env.Get("MINIO_CI_CD", "") != "") || (env.Get("CI", "") != ""))
 		// If not orchestrated
 		// and not setup in reverse proxy

--- a/cmd/grid.go
+++ b/cmd/grid.go
@@ -35,13 +35,9 @@ var globalGrid atomic.Pointer[grid.Manager]
 var globalGridStart = make(chan struct{})
 
 func initGlobalGrid(ctx context.Context, eps EndpointServerPools) error {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
 	hosts, local := eps.GridHosts()
 	g, err := grid.NewManager(ctx, grid.ManagerOptions{
-		Dialer:       grid.ContextDialer(xhttp.DialContextWithLookupHost(lookupHost, xhttp.NewInternodeDialContext(rest.DefaultTimeout, globalTCPOptions))),
+		Dialer:       grid.ContextDialer(xhttp.DialContextWithLookupHost(globalDNSCache.LookupHost, xhttp.NewInternodeDialContext(rest.DefaultTimeout, globalTCPOptions))),
 		Local:        local,
 		Hosts:        hosts,
 		AddAuth:      newCachedAuthToken(),

--- a/cmd/net.go
+++ b/cmd/net.go
@@ -98,12 +98,7 @@ func mustGetLocalIP6() (ipList set.StringSet) {
 
 // getHostIP returns IP address of given host.
 func getHostIP(host string) (ipList set.StringSet, err error) {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = net.DefaultResolver.LookupHost
-	}
-
-	addrs, err := lookupHost(GlobalContext, host)
+	addrs, err := globalDNSCache.LookupHost(GlobalContext, host)
 	if err != nil {
 		return ipList, err
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -572,13 +572,8 @@ func ToS3ETag(etag string) string {
 
 // GetDefaultConnSettings returns default HTTP connection settings.
 func GetDefaultConnSettings() xhttp.ConnSettings {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	return xhttp.ConnSettings{
-		LookupHost:  lookupHost,
+		LookupHost:  globalDNSCache.LookupHost,
 		DialTimeout: rest.DefaultTimeout,
 		RootCAs:     globalRootCAs,
 		TCPOptions:  globalTCPOptions,
@@ -588,13 +583,8 @@ func GetDefaultConnSettings() xhttp.ConnSettings {
 // NewInternodeHTTPTransport returns a transport for internode MinIO
 // connections.
 func NewInternodeHTTPTransport(maxIdleConnsPerHost int) func() http.RoundTripper {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	return xhttp.ConnSettings{
-		LookupHost:       lookupHost,
+		LookupHost:       globalDNSCache.LookupHost,
 		DialTimeout:      rest.DefaultTimeout,
 		RootCAs:          globalRootCAs,
 		CipherSuites:     fips.TLSCiphers(),
@@ -607,13 +597,8 @@ func NewInternodeHTTPTransport(maxIdleConnsPerHost int) func() http.RoundTripper
 // NewCustomHTTPProxyTransport is used only for proxied requests, specifically
 // only supports HTTP/1.1
 func NewCustomHTTPProxyTransport() func() *http.Transport {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	return xhttp.ConnSettings{
-		LookupHost:       lookupHost,
+		LookupHost:       globalDNSCache.LookupHost,
 		DialTimeout:      rest.DefaultTimeout,
 		RootCAs:          globalRootCAs,
 		CipherSuites:     fips.TLSCiphers(),
@@ -626,13 +611,8 @@ func NewCustomHTTPProxyTransport() func() *http.Transport {
 // NewHTTPTransportWithClientCerts returns a new http configuration
 // used while communicating with the cloud backends.
 func NewHTTPTransportWithClientCerts(clientCert, clientKey string) *http.Transport {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	s := xhttp.ConnSettings{
-		LookupHost:  lookupHost,
+		LookupHost:  globalDNSCache.LookupHost,
 		DialTimeout: defaultDialTimeout,
 		RootCAs:     globalRootCAs,
 		TCPOptions:  globalTCPOptions,
@@ -663,14 +643,9 @@ const defaultDialTimeout = 5 * time.Second
 
 // NewHTTPTransportWithTimeout allows setting a timeout.
 func NewHTTPTransportWithTimeout(timeout time.Duration) *http.Transport {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	return xhttp.ConnSettings{
 		DialContext: newCustomDialContext(),
-		LookupHost:  lookupHost,
+		LookupHost:  globalDNSCache.LookupHost,
 		DialTimeout: defaultDialTimeout,
 		RootCAs:     globalRootCAs,
 		TCPOptions:  globalTCPOptions,
@@ -702,14 +677,9 @@ func newCustomDialContext() xhttp.DialContext {
 // NewRemoteTargetHTTPTransport returns a new http configuration
 // used while communicating with the remote replication targets.
 func NewRemoteTargetHTTPTransport(insecure bool) func() *http.Transport {
-	lookupHost := globalDNSCache.LookupHost
-	if IsKubernetes() || IsDocker() {
-		lookupHost = nil
-	}
-
 	return xhttp.ConnSettings{
 		DialContext: newCustomDialContext(),
-		LookupHost:  lookupHost,
+		LookupHost:  globalDNSCache.LookupHost,
 		RootCAs:     globalRootCAs,
 		TCPOptions:  globalTCPOptions,
 		EnableHTTP2: false,


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
bring back minor DNS cache for k8s setups

## Motivation and Context
k8s as it stands is flaky in DNS lookups,
bring this change back such that we can
cache DNS atleast for 30secs TTL.

## How to test this PR?
Node local DNS is not installed by most
k8s deployments, having a minor DNS cache
It wouldn't hurt. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
