### PR TITLE
set max versions to be IntMax to avoid premature failures

### DIFF
--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"math"
 	"net/http"
 	"os"
 	"runtime"
@@ -55,7 +56,7 @@ type apiConfig struct {
 	gzipObjects                 bool
 	rootAccess                  bool
 	syncEvents                  bool
-	objectMaxVersions           int
+	objectMaxVersions           int64
 }
 
 const (
@@ -393,13 +394,13 @@ func (t *apiConfig) isSyncEventsEnabled() bool {
 	return t.syncEvents
 }
 
-func (t *apiConfig) getObjectMaxVersions() int {
+func (t *apiConfig) getObjectMaxVersions() int64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	if t.objectMaxVersions <= 0 {
-		// defaults to 'maxObjectVersions' when unset.
-		return maxObjectVersions
+		// defaults to 'IntMax' when unset.
+		return math.MaxInt64
 	}
 
 	return t.objectMaxVersions

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -40,9 +40,6 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// Reject creating new versions when a single object is cross maxObjectVersions
-var maxObjectVersions = 10000
-
 var (
 	// XL header specifies the format
 	xlHeader = [4]byte{'X', 'L', '2', ' '}
@@ -1091,8 +1088,8 @@ func (x *xlMetaV2) addVersion(ver xlMetaV2Version) error {
 		return err
 	}
 
-	// returns error if we have exceeded maxObjectVersions
-	if len(x.versions)+1 > globalAPIConfig.getObjectMaxVersions() {
+	// returns error if we have exceeded configured object max versions
+	if int64(len(x.versions)+1) > globalAPIConfig.getObjectMaxVersions() {
 		return errMaxVersionsExceeded
 	}
 


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
set max versions to IntMax to avoid premature failures

## Motivation and Context
let users/customers set relevant values, making the default 
value non-applicable.

## How to test this PR?
The default value of 10000 is removed; now, it's unlimited by default.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
