### PR TITLE
use bigger partSize per part for tiering to MinIO

### DIFF
--- a/cmd/warm-backend-minio.go
+++ b/cmd/warm-backend-minio.go
@@ -18,8 +18,11 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"math"
 	"net/url"
 	"strings"
 	"time"
@@ -34,6 +37,60 @@ type warmBackendMinIO struct {
 }
 
 var _ WarmBackend = (*warmBackendMinIO)(nil)
+
+const (
+	maxMultipartPutObjectSize = 1024 * 1024 * 1024 * 1024 * 5
+	maxPartsCount             = 10000
+	maxPartSize               = 1024 * 1024 * 1024 * 5
+	minPartSize               = 1024 * 1024 * 64 // chosen by us to be optimal for HDDs
+)
+
+// optimalPartInfo - calculate the optimal part info for a given
+// object size.
+//
+// NOTE: Assumption here is that for any object to be uploaded to any S3 compatible
+// object storage it will have the following parameters as constants.
+//
+//	maxPartsCount - 10000
+//	maxMultipartPutObjectSize - 5TiB
+func optimalPartSize(objectSize int64) (partSize int64, err error) {
+	// object size is '-1' set it to 5TiB.
+	if objectSize == -1 {
+		objectSize = maxMultipartPutObjectSize
+	}
+
+	// object size is larger than supported maximum.
+	if objectSize > maxMultipartPutObjectSize {
+		err = errors.New("entity too large")
+		return
+	}
+
+	configuredPartSize := minPartSize
+	// Use floats for part size for all calculations to avoid
+	// overflows during float64 to int64 conversions.
+	partSizeFlt := float64(objectSize / maxPartsCount)
+	partSizeFlt = math.Ceil(partSizeFlt/float64(configuredPartSize)) * float64(configuredPartSize)
+
+	// Part size.
+	partSize = int64(partSizeFlt)
+	if partSize == 0 {
+		return minPartSize, nil
+	}
+	return partSize, nil
+}
+
+func (m *warmBackendMinIO) Put(ctx context.Context, object string, r io.Reader, length int64) (remoteVersionID, error) {
+	partSize, err := optimalPartSize(length)
+	if err != nil {
+		return remoteVersionID(""), err
+	}
+	res, err := m.client.PutObject(ctx, m.Bucket, m.getDest(object), r, length, minio.PutObjectOptions{
+		StorageClass:         m.StorageClass,
+		PartSize:             uint64(partSize),
+		DisableContentSha256: true,
+	})
+	return remoteVersionID(res.VersionID), m.ToObjectError(err, object)
+}
 
 func newWarmBackendMinIO(conf madmin.TierMinIO, tier string) (*warmBackendMinIO, error) {
 	// Validation of credentials
@@ -56,9 +113,10 @@ func newWarmBackendMinIO(conf madmin.TierMinIO, tier string) (*warmBackendMinIO,
 		getRemoteTierTargetInstanceTransport = NewHTTPTransportWithTimeout(10 * time.Minute)
 	})
 	opts := &minio.Options{
-		Creds:     creds,
-		Secure:    u.Scheme == "https",
-		Transport: getRemoteTierTargetInstanceTransport,
+		Creds:           creds,
+		Secure:          u.Scheme == "https",
+		Transport:       getRemoteTierTargetInstanceTransport,
+		TrailingHeaders: true,
 	}
 	client, err := minio.New(u.Host, opts)
 	if err != nil {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
use bigger partSize per part for tiering to MinIO

## Motivation and Context
Bonus: Remove the persistent md5sum calculation and 
turn off sha256 as well. Instead, we always enable crc32c, 
which is enough for payload verification and 
supports trailing header checksum.

## How to test this PR?
Tiering must work as is CI/CD should help

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
