### PR TITLE
update() inlineBlock settings properly in storageClass config

### DIFF
--- a/internal/config/storageclass/storage-class.go
+++ b/internal/config/storageclass/storage-class.go
@@ -319,6 +319,7 @@ func (sCfg *Config) Update(newCfg Config) {
 	sCfg.RRS = newCfg.RRS
 	sCfg.Standard = newCfg.Standard
 	sCfg.Optimize = newCfg.Optimize
+	sCfg.inlineBlock = newCfg.inlineBlock
 	sCfg.initialized = true
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
update() inlineBlock settings properly in storageClass config

## Motivation and Context
upon a config KV set make sure to apply the inlineBlock value
from the new config.

This was a commit that went missing in #19336 due to a force-push 

## How to test this PR?
You need to extract `xl-meta` to look for `x-minio-inline-data` metadata field
not present for the relevant block and above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
