### PR TITLE
Remove empty replication stats

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -543,9 +543,13 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 				}
 
 				wg.Wait()
+				// Flatten for upstream, but save full state.
 				var root dataUsageEntry
 				if r := cache.root(); r != nil {
 					root = cache.flatten(*r)
+					if root.ReplicationStats.empty() {
+						root.ReplicationStats = nil
+					}
 				}
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
When sending final stats upstream also trim empty ReplicationStats.


## How to test this PR?

Regular ops. Observe memory usage on scan leader.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
