### PR TITLE
Always return slice with cap

### DIFF
--- a/internal/grid/grid.go
+++ b/internal/grid/grid.go
@@ -87,12 +87,19 @@ var GetByteBuffer = func() []byte {
 
 // GetByteBufferCap returns a length 0 byte buffer with at least the given capacity.
 func GetByteBufferCap(wantSz int) []byte {
-	switch {
-	case wantSz <= defaultBufferSize:
-		return GetByteBuffer()[:0]
-	case wantSz <= maxBufferSize:
+	if wantSz < defaultBufferSize {
+		b := GetByteBuffer()[:0]
+		if cap(b) >= wantSz {
+			return b
+		}
+		PutByteBuffer(b)
+	}
+	if wantSz <= maxBufferSize {
 		b := *internal32KByteBuffer.Get().(*[]byte)
-		return b[:0]
+		if cap(b) >= wantSz {
+			return b[:0]
+		}
+		internal32KByteBuffer.Put(&b)
 	}
 	return make([]byte, 0, wantSz)
 }


### PR DESCRIPTION
## Description

Method documentation promised this - so we should do it as well. Try to get a buffer and stash if it isn't big enough.

## How to test this PR?

Only really internal stuff.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
