### PR TITLE
use `GenerateKey` as more reliable KMS health-check

### DIFF
--- a/cmd/healthcheck-handler.go
+++ b/cmd/healthcheck-handler.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	xhttp "github.com/minio/minio/internal/http"
+	"github.com/minio/minio/internal/kms"
 )
 
 const unavailable = "offline"
@@ -134,7 +135,7 @@ func ReadinessCheckHandler(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), time.Minute)
 		defer cancel()
 
-		if _, err := GlobalKMS.Stat(ctx); err != nil {
+		if _, err := GlobalKMS.GenerateKey(ctx, "", kms.Context{"healthcheck": ""}); err != nil {
 			switch r.Method {
 			case http.MethodHead:
 				apiErr := toAPIError(r.Context(), err)


### PR DESCRIPTION
## Description
This commit replaces the `KMS.Stat` API call with a `KMS.GenerateKey` call. This approach is more reliable since data key generation works also when the KMS backend is not available (temp. offline) but KES has cached the key. Ref: KES offline caching.

With this change, its less likely that MinIO readiness checks fail in cases where the KMS backend is offline.

## Motivation and Context
KMS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
