### PR TITLE
turn-off Nlink readdir() optimization for NFS/CIFS

### DIFF
--- a/cmd/is-dir-empty_linux.go
+++ b/cmd/is-dir-empty_linux.go
@@ -25,22 +25,19 @@ import (
 )
 
 // Returns true if no error and there is no object or prefix inside this directory
-func isDirEmpty(dirname string) bool {
-	var stat syscall.Stat_t
-	if err := syscall.Stat(dirname, &stat); err != nil {
-		return false
-	}
-	if stat.Mode&syscall.S_IFMT == syscall.S_IFDIR && stat.Nlink == 2 {
-		return true
-	}
-	// On filesystems such as btrfs, nfs this is not true, so fallback
-	// to performing readdir() instead.
-	if stat.Mode&syscall.S_IFMT == syscall.S_IFDIR && stat.Nlink < 2 {
+func isDirEmpty(dirname string, legacy bool) bool {
+	if legacy {
+		// On filesystems such as btrfs, nfs this is not true, so fallback
+		// to performing readdir() instead.
 		entries, err := readDirN(dirname, 1)
 		if err != nil {
 			return false
 		}
 		return len(entries) == 0
 	}
-	return false
+	var stat syscall.Stat_t
+	if err := syscall.Stat(dirname, &stat); err != nil {
+		return false
+	}
+	return stat.Mode&syscall.S_IFMT == syscall.S_IFDIR && stat.Nlink == 2
 }

--- a/cmd/is-dir-empty_other.go
+++ b/cmd/is-dir-empty_other.go
@@ -21,7 +21,7 @@
 package cmd
 
 // isDirEmpty - returns true if there is no error and no object and prefix inside this directory
-func isDirEmpty(dirname string) bool {
+func isDirEmpty(dirname string, _ bool) bool {
 	entries, err := readDirN(dirname, 1)
 	if err != nil {
 		return false

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -117,6 +117,7 @@ type xlStorage struct {
 
 	nrRequests   uint64
 	major, minor uint32
+	fsType       string
 
 	immediatePurge chan string
 
@@ -254,6 +255,7 @@ func newXLStorage(ep Endpoint, cleanUp bool) (s *xlStorage, err error) {
 	}
 	s.major = info.Major
 	s.minor = info.Minor
+	s.fsType = info.FSType
 
 	if !globalIsCICD && !globalIsErasureSD {
 		var rootDrive bool

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -190,7 +190,7 @@ func TestXLStorageIsDirEmpty(t *testing.T) {
 
 	// Should give false on non-existent directory.
 	dir1 := slashpath.Join(tmp, "non-existent-directory")
-	if isDirEmpty(dir1) {
+	if isDirEmpty(dir1, true) {
 		t.Error("expected false for non-existent directory, got true")
 	}
 
@@ -201,7 +201,7 @@ func TestXLStorageIsDirEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if isDirEmpty(dir2) {
+	if isDirEmpty(dir2, true) {
 		t.Error("expected false for a file, got true")
 	}
 
@@ -212,7 +212,7 @@ func TestXLStorageIsDirEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !isDirEmpty(dir3) {
+	if !isDirEmpty(dir3, true) {
 		t.Error("expected true for empty dir, got false")
 	}
 }


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
turn-off Nlink readdir() optimization for NFS/CIFS

## Motivation and Context
fixes #19418
fixes #19416

## How to test this PR?
Not all FS have this behavior, so turn it off on
FS, we still need to qualify.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
