### PR TITLE
fix: a regression in IAM policy reload routine()

### DIFF
--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -399,6 +399,7 @@ var (
 	groupsListKey           = "groups/"
 	policiesListKey         = "policies/"
 	stsListKey              = "sts/"
+	policyDBPrefix          = "policydb/"
 	policyDBUsersListKey    = "policydb/users/"
 	policyDBSTSUsersListKey = "policydb/sts-users/"
 	policyDBGroupsListKey   = "policydb/groups/"
@@ -406,8 +407,13 @@ var (
 
 // splitPath splits a path into a top-level directory and a child item. The
 // parent directory retains the trailing slash.
-func splitPath(s string) (string, string) {
-	i := strings.Index(s, "/")
+func splitPath(s string, lastIndex bool) (string, string) {
+	var i int
+	if lastIndex {
+		i = strings.LastIndex(s, "/")
+	} else {
+		i = strings.Index(s, "/")
+	}
 	if i == -1 {
 		return s, ""
 	}
@@ -424,7 +430,8 @@ func (iamOS *IAMObjectStore) listAllIAMConfigItems(ctx context.Context) (map[str
 			return nil, item.Err
 		}
 
-		listKey, trimmedItem := splitPath(item.Item)
+		lastIndex := strings.HasPrefix(item.Item, policyDBPrefix)
+		listKey, trimmedItem := splitPath(item.Item, lastIndex)
 		if listKey == iamFormatFile {
 			continue
 		}

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1918,7 +1918,7 @@ func (sys *IAMSys) IsAllowedSTS(args policy.Args, parentUser string) bool {
 	default:
 		// Otherwise, inherit parent user's policy
 		var err error
-		policies, err = sys.store.PolicyDBGet(parentUser, args.Groups...)
+		policies, err = sys.PolicyDBGet(parentUser, args.Groups...)
 		if err != nil {
 			iamLogIf(GlobalContext, fmt.Errorf("error fetching policies on %s: %v", parentUser, err))
 			return false


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: a regression in IAM policy reload routine()

## Motivation and Context
all policy reloading has been broken since the last release since

48deccdc404a5cc147aa722dcc7fc0d6ae64292d

fixes #19417

## How to test this PR?
Added tests to cover this scenario

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression 48deccdc404a5cc147aa722dcc7fc0d6ae64292d
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
