### PR TITLE
fix: unknow contentType for ArchiveFileHandler

### DIFF
--- a/cmd/s3-zip-handlers.go
+++ b/cmd/s3-zip-handlers.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"mime"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -166,10 +168,11 @@ func (api objectAPIHandlers) getObjectInArchiveFileHandler(ctx context.Context, 
 
 	// New object info
 	fileObjInfo := ObjectInfo{
-		Bucket:  bucket,
-		Name:    object,
-		Size:    int64(file.UncompressedSize64),
-		ModTime: zipObjInfo.ModTime,
+		Bucket:      bucket,
+		Name:        object,
+		Size:        int64(file.UncompressedSize64),
+		ModTime:     zipObjInfo.ModTime,
+		ContentType: mime.TypeByExtension(filepath.Ext(object)),
 	}
 
 	var rc io.ReadCloser


### PR DESCRIPTION
fix: unknow contentType for ArchiveFileHandler

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix #19440

## Motivation and Context


## How to test this PR?

like the issue comment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
