### PR TITLE
allow protection from invalid config values

### DIFF
--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -566,6 +566,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 		return errServerNotInitialized
 	}
 
+	var errs []error
 	setDriveCounts := objAPI.SetDriveCounts()
 	switch subSys {
 	case config.APISubSys:
@@ -588,26 +589,29 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 	case config.HealSubSys:
 		healCfg, err := heal.LookupConfig(s[config.HealSubSys][config.Default])
 		if err != nil {
-			return fmt.Errorf("Unable to apply heal config: %w", err)
+			errs = append(errs, fmt.Errorf("Unable to apply heal config: %w", err))
+		} else {
+			globalHealConfig.Update(healCfg)
 		}
-		globalHealConfig.Update(healCfg)
 	case config.BatchSubSys:
 		batchCfg, err := batch.LookupConfig(s[config.BatchSubSys][config.Default])
 		if err != nil {
-			return fmt.Errorf("Unable to apply batch config: %w", err)
+			errs = append(errs, fmt.Errorf("Unable to apply batch config: %w", err))
+		} else {
+			globalBatchConfig.Update(batchCfg)
 		}
-		globalBatchConfig.Update(batchCfg)
 	case config.ScannerSubSys:
 		scannerCfg, err := scanner.LookupConfig(s[config.ScannerSubSys][config.Default])
 		if err != nil {
-			return fmt.Errorf("Unable to apply scanner config: %w", err)
+			errs = append(errs, fmt.Errorf("Unable to apply scanner config: %w", err))
+		} else {
+			// update dynamic scanner values.
+			scannerIdleMode.Store(scannerCfg.IdleMode)
+			scannerCycle.Store(scannerCfg.Cycle)
+			scannerExcessObjectVersions.Store(scannerCfg.ExcessVersions)
+			scannerExcessFolders.Store(scannerCfg.ExcessFolders)
+			configLogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 		}
-		// update dynamic scanner values.
-		scannerIdleMode.Store(scannerCfg.IdleMode)
-		scannerCycle.Store(scannerCfg.Cycle)
-		scannerExcessObjectVersions.Store(scannerCfg.ExcessVersions)
-		scannerExcessFolders.Store(scannerCfg.ExcessFolders)
-		configLogIf(ctx, scannerSleeper.Update(scannerCfg.Delay, scannerCfg.MaxWait))
 	case config.LoggerWebhookSubSys:
 		loggerCfg, err := logger.LookupConfigForSubSys(ctx, s, config.LoggerWebhookSubSys)
 		if err != nil {
@@ -693,11 +697,11 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			}
 		}
 	case config.DriveSubSys:
-		if driveConfig, err := drive.LookupConfig(s[config.DriveSubSys][config.Default]); err != nil {
+		driveConfig, err := drive.LookupConfig(s[config.DriveSubSys][config.Default])
+		if err != nil {
 			configLogIf(ctx, fmt.Errorf("Unable to load drive config: %w", err))
 		} else {
-			err := globalDriveConfig.Update(driveConfig)
-			if err != nil {
+			if err = globalDriveConfig.Update(driveConfig); err != nil {
 				configLogIf(ctx, fmt.Errorf("Unable to update drive config: %v", err))
 			}
 		}
@@ -711,26 +715,31 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 	case config.BrowserSubSys:
 		browserCfg, err := browser.LookupConfig(s[config.BrowserSubSys][config.Default])
 		if err != nil {
-			return fmt.Errorf("Unable to apply browser config: %w", err)
+			errs = append(errs, fmt.Errorf("Unable to apply browser config: %w", err))
+		} else {
+			globalBrowserConfig.Update(browserCfg)
 		}
-		globalBrowserConfig.Update(browserCfg)
 	case config.ILMSubSys:
 		ilmCfg, err := ilm.LookupConfig(s[config.ILMSubSys][config.Default])
 		if err != nil {
-			return fmt.Errorf("Unable to apply ilm config: %w", err)
+			errs = append(errs, fmt.Errorf("Unable to apply ilm config: %w", err))
+		} else {
+			if globalTransitionState != nil {
+				globalTransitionState.UpdateWorkers(ilmCfg.TransitionWorkers)
+			}
+			if globalExpiryState != nil {
+				globalExpiryState.ResizeWorkers(ilmCfg.ExpirationWorkers)
+			}
+			globalILMConfig.update(ilmCfg)
 		}
-		if globalTransitionState != nil {
-			globalTransitionState.UpdateWorkers(ilmCfg.TransitionWorkers)
-		}
-		if globalExpiryState != nil {
-			globalExpiryState.ResizeWorkers(ilmCfg.ExpirationWorkers)
-		}
-		globalILMConfig.update(ilmCfg)
 	}
 	globalServerConfigMu.Lock()
 	defer globalServerConfigMu.Unlock()
 	if globalServerConfig != nil {
 		globalServerConfig[subSys] = s[subSys]
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 	return nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -626,6 +626,10 @@ func NewHTTPTransportWithClientCerts(clientCert, clientKey string) *http.Transpo
 		if err != nil {
 			internalLogIf(ctx, fmt.Errorf("Unable to load client key and cert, please check your client certificate configuration: %w", err))
 		}
+		if transport == nil {
+			// Client certs are not readable return default transport.
+			return s.NewHTTPTransportWithTimeout(1 * time.Minute)
+		}
 		return transport
 	}
 

--- a/internal/config/drive/drive.go
+++ b/internal/config/drive/drive.go
@@ -33,30 +33,35 @@ var DefaultKVS = config.KVS{
 	},
 }
 
+var configLk sync.RWMutex
+
 // Config represents the subnet related configuration
 type Config struct {
 	// MaxTimeout - maximum timeout for a drive operation
 	MaxTimeout time.Duration `json:"maxTimeout"`
-	mutex      sync.RWMutex
 }
 
 // Update - updates the config with latest values
-func (c *Config) Update(new *Config) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+func (c *Config) Update(new Config) error {
+	configLk.Lock()
+	defer configLk.Unlock()
 	c.MaxTimeout = getMaxTimeout(new.MaxTimeout)
 	return nil
 }
 
 // GetMaxTimeout - returns the max timeout value.
 func (c *Config) GetMaxTimeout() time.Duration {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
+	configLk.RLock()
+	defer configLk.RUnlock()
+
 	return getMaxTimeout(c.MaxTimeout)
 }
 
 // LookupConfig - lookup config and override with valid environment settings if any.
-func LookupConfig(kvs config.KVS) (cfg *Config, err error) {
+func LookupConfig(kvs config.KVS) (cfg Config, err error) {
+	cfg = Config{
+		MaxTimeout: 30 * time.Second,
+	}
 	if err = config.CheckValidKeys(config.DriveSubSys, kvs, DefaultKVS); err != nil {
 		return cfg, err
 	}
@@ -68,9 +73,7 @@ func LookupConfig(kvs config.KVS) (cfg *Config, err error) {
 			d = env.Get("_MINIO_DISK_MAX_TIMEOUT", "")
 		}
 	}
-	cfg = &Config{
-		mutex: sync.RWMutex{},
-	}
+
 	dur, _ := time.ParseDuration(d)
 	if dur < time.Second {
 		cfg.MaxTimeout = 30 * time.Second

--- a/internal/config/heal/heal.go
+++ b/internal/config/heal/heal.go
@@ -157,11 +157,14 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	if err = config.CheckValidKeys(config.HealSubSys, kvs, DefaultKVS); err != nil {
 		return cfg, err
 	}
-	cfg.Bitrot = env.Get(EnvBitrot, kvs.GetWithDefault(Bitrot, DefaultKVS))
-	_, err = parseBitrotConfig(cfg.Bitrot)
-	if err != nil {
+
+	bitrot := env.Get(EnvBitrot, kvs.GetWithDefault(Bitrot, DefaultKVS))
+	if _, err = parseBitrotConfig(bitrot); err != nil {
 		return cfg, fmt.Errorf("'heal:bitrotscan' value invalid: %w", err)
 	}
+
+	cfg.Bitrot = bitrot
+
 	cfg.Sleep, err = time.ParseDuration(env.Get(EnvSleep, kvs.GetWithDefault(Sleep, DefaultKVS)))
 	if err != nil {
 		return cfg, fmt.Errorf("'heal:max_sleep' value invalid: %w", err)

--- a/internal/config/ilm/ilm.go
+++ b/internal/config/ilm/ilm.go
@@ -44,6 +44,15 @@ type Config struct {
 
 // LookupConfig - lookup ilm config and override with valid environment settings if any.
 func LookupConfig(kvs config.KVS) (cfg Config, err error) {
+	cfg = Config{
+		TransitionWorkers: 100,
+		ExpirationWorkers: 100,
+	}
+
+	if err = config.CheckValidKeys(config.ILMSubSys, kvs, DefaultKVS); err != nil {
+		return cfg, err
+	}
+
 	tw, err := strconv.Atoi(env.Get(EnvILMTransitionWorkers, kvs.GetWithDefault(transitionWorkers, DefaultKVS)))
 	if err != nil {
 		return cfg, err

--- a/internal/config/scanner/scanner.go
+++ b/internal/config/scanner/scanner.go
@@ -114,15 +114,44 @@ var DefaultKVS = config.KVS{
 
 // LookupConfig - lookup config and override with valid environment settings if any.
 func LookupConfig(kvs config.KVS) (cfg Config, err error) {
+	cfg = Config{
+		ExcessVersions: 100,
+		ExcessFolders:  50000,
+		IdleMode:       0, // Default is on
+	}
+
 	if err = config.CheckValidKeys(config.ScannerSubSys, kvs, DefaultKVS); err != nil {
 		return cfg, err
+	}
+
+	excessVersions, err := strconv.ParseInt(env.Get(EnvExcessVersions, kvs.GetWithDefault(ExcessVersions, DefaultKVS)), 10, 64)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.ExcessVersions = excessVersions
+
+	excessFolders, err := strconv.ParseInt(env.Get(EnvExcessFolders, kvs.GetWithDefault(ExcessFolders, DefaultKVS)), 10, 64)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.ExcessFolders = excessFolders
+
+	switch idleSpeed := env.Get(EnvIdleSpeed, kvs.GetWithDefault(IdleSpeed, DefaultKVS)); idleSpeed {
+	case "", config.EnableOn:
+		cfg.IdleMode = 0
+	case config.EnableOff:
+		cfg.IdleMode = 1
+	default:
+		return cfg, fmt.Errorf("unknown value: '%s'", idleSpeed)
 	}
 
 	// Stick to loading deprecated config/env if they are already set, and the Speed value
 	// has not been changed from its "default" value, if it has been changed honor new settings.
 	if kvs.GetWithDefault(Speed, DefaultKVS) == "default" {
 		if kvs.Get(Delay) != "" && kvs.Get(MaxWait) != "" {
-			return lookupDeprecatedScannerConfig(kvs)
+			if err = lookupDeprecatedScannerConfig(kvs, &cfg); err != nil {
+				return cfg, err
+			}
 		}
 	}
 
@@ -141,38 +170,17 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 		return cfg, fmt.Errorf("unknown '%s' value", speed)
 	}
 
-	switch idleSpeed := env.Get(EnvIdleSpeed, kvs.GetWithDefault(IdleSpeed, DefaultKVS)); idleSpeed {
-	case "", config.EnableOn:
-		cfg.IdleMode = 0
-	case config.EnableOff:
-		cfg.IdleMode = 1
-	default:
-		return cfg, fmt.Errorf("unknown value: '%s'", idleSpeed)
-	}
-
-	excessVersions, err := strconv.ParseInt(env.Get(EnvExcessVersions, kvs.GetWithDefault(ExcessVersions, DefaultKVS)), 10, 64)
-	if err != nil {
-		return cfg, err
-	}
-	cfg.ExcessVersions = excessVersions
-
-	excessFolders, err := strconv.ParseInt(env.Get(EnvExcessFolders, kvs.GetWithDefault(ExcessFolders, DefaultKVS)), 10, 64)
-	if err != nil {
-		return cfg, err
-	}
-	cfg.ExcessFolders = excessFolders
-
 	return cfg, nil
 }
 
-func lookupDeprecatedScannerConfig(kvs config.KVS) (cfg Config, err error) {
+func lookupDeprecatedScannerConfig(kvs config.KVS, cfg *Config) (err error) {
 	delay := env.Get(EnvDelayLegacy, "")
 	if delay == "" {
 		delay = env.Get(EnvDelay, kvs.GetWithDefault(Delay, DefaultKVS))
 	}
 	cfg.Delay, err = strconv.ParseFloat(delay, 64)
 	if err != nil {
-		return cfg, err
+		return err
 	}
 	maxWait := env.Get(EnvMaxWaitLegacy, "")
 	if maxWait == "" {
@@ -180,7 +188,7 @@ func lookupDeprecatedScannerConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 	cfg.MaxWait, err = time.ParseDuration(maxWait)
 	if err != nil {
-		return cfg, err
+		return err
 	}
 	cycle := env.Get(EnvCycle, kvs.GetWithDefault(Cycle, DefaultKVS))
 	if cycle == "" {
@@ -188,7 +196,7 @@ func lookupDeprecatedScannerConfig(kvs config.KVS) (cfg Config, err error) {
 	}
 	cfg.Cycle, err = time.ParseDuration(cycle)
 	if err != nil {
-		return cfg, err
+		return err
 	}
-	return cfg, nil
+	return nil
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow protection from invalid config values

## Motivation and Context
we have had numerous reports on some config
values not having default values, causing
features misbehaving and not having default
values set properly. 

This PR tries to address all these concerns
once and for all. 

Each new sub-system that gets added

- must check for invalid keys
- must have default values set
- must not "return err" when being saved into
  a global state() instead collate as part of
  other subsystem errors allow other sub-systems
  to independently initialize.

## How to test this PR?
Introduce buggy values into config and see
that rest of the subsystems initialize with
their own set of proper default values.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
