### PR TITLE
Inspect: Add error if no results

### DIFF
--- a/cmd/endpoint-ellipses.go
+++ b/cmd/endpoint-ellipses.go
@@ -477,7 +477,7 @@ func mergeDisksLayoutFromArgs(args []string, ctxt *serverCtxt) (err error) {
 		}
 		ctxt.Layout = disksLayout{
 			legacy: true,
-			pools:  []poolDisksLayout{{layout: setArgs}},
+			pools:  []poolDisksLayout{{layout: setArgs, cmdline: strings.Join(args, " ")}},
 		}
 		return
 	}

--- a/docs/debugging/inspect/decrypt-v1.go
+++ b/docs/debugging/inspect/decrypt-v1.go
@@ -27,7 +27,7 @@ import (
 	"github.com/secure-io/sio-go"
 )
 
-func extractInspectV1(keyHex string, r io.Reader, w io.Writer) error {
+func extractInspectV1(keyHex string, r io.Reader, w io.Writer, okMsg string) error {
 	id, err := hex.DecodeString(keyHex[:8])
 	if err != nil {
 		return err
@@ -51,5 +51,8 @@ func extractInspectV1(keyHex string, r io.Reader, w io.Writer) error {
 	nonce := make([]byte, stream.NonceSize())
 	encr := stream.DecryptReader(r, nonce, nil)
 	_, err = io.Copy(w, encr)
+	if err == nil {
+		fmt.Println(okMsg)
+	}
 	return err
 }

--- a/docs/debugging/inspect/decrypt-v2.go
+++ b/docs/debugging/inspect/decrypt-v2.go
@@ -26,7 +26,11 @@ import (
 	"github.com/minio/madmin-go/v3/estream"
 )
 
-func extractInspectV2(pk []byte, r io.Reader, w io.Writer) error {
+type keepFileErr struct {
+	error
+}
+
+func extractInspectV2(pk []byte, r io.Reader, w io.Writer, okMsg string) error {
 	privKey, err := bytesToPrivateKey(pk)
 	if err != nil {
 		return fmt.Errorf("decoding key returned: %w", err)
@@ -45,11 +49,14 @@ func extractInspectV2(pk []byte, r io.Reader, w io.Writer) error {
 		sr.SkipEncrypted(true)
 		return sr.DebugStream(os.Stdout)
 	}
-
+	extracted := false
 	for {
 		stream, err := sr.NextStream()
 		if err != nil {
 			if err == io.EOF {
+				if extracted {
+					return nil
+				}
 				return errors.New("no data found on stream")
 			}
 			if errors.Is(err, estream.ErrNoKey) {
@@ -61,14 +68,22 @@ func extractInspectV2(pk []byte, r io.Reader, w io.Writer) error {
 				}
 				continue
 			}
+			if extracted {
+				return keepFileErr{fmt.Errorf("next stream: %w", err)}
+			}
 			return fmt.Errorf("next stream: %w", err)
 		}
 		if stream.Name == "inspect.zip" {
+			if extracted {
+				return keepFileErr{errors.New("multiple inspect.zip streams found")}
+			}
 			_, err := io.Copy(w, stream)
 			if err != nil {
 				return fmt.Errorf("reading inspect stream: %w", err)
 			}
-			return nil
+			fmt.Println(okMsg)
+			extracted = true
+			continue
 		}
 		if err := stream.Skip(); err != nil {
 			return fmt.Errorf("stream skip: %w", err)


### PR DESCRIPTION
## Description

When no results match or another error occurs, add an error to the stream. Keep the "inspect-input.txt" as the only thing in the zip for reference.

Example:

```
λ mc support inspect --airgap myminio/testbucket/fjghfjh/**
mc: Using public key from C:\Users\klaus\mc\support_public.pem
File data successfully downloaded as inspect-data.enc

λ inspect inspect-data.enc
Using private key from support_private.pem
output written to inspect-data.zip
2024/04/11 14:10:51 next stream: GetRawData: No files matched the given pattern

λ unzip -l inspect-data.zip
Archive:  inspect-data.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      222  2024-04-11 14:10   inspect-input.txt
---------                     -------
      222                     1 file

λ
```

Modifies inspect to read until end of stream to report the error.

The error can be read without the decryption key.

Bonus: Add legacy commandline params

## How to test this PR?

See above.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
