### PR TITLE
ilm: Handle DeleteAllVersions action differently for DEL markers

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -993,7 +993,7 @@ func (i *scannerItem) applyLifecycle(ctx context.Context, o ObjectLayer, oi Obje
 	// This can happen when,
 	// - ExpireObjectAllVersions flag is enabled
 	// - NoncurrentVersionExpiration is applicable
-	case lifecycle.DeleteVersionAction, lifecycle.DeleteAllVersionsAction:
+	case lifecycle.DeleteVersionAction, lifecycle.DeleteAllVersionsAction, lifecycle.DelMarkerDeleteAllVersionsAction:
 		size = 0
 	case lifecycle.DeleteAction:
 		// On a non-versioned bucket, DeleteObject removes the only version permanently.
@@ -1162,7 +1162,7 @@ func (i *scannerItem) applyActions(ctx context.Context, o ObjectLayer, oi Object
 
 	// Note: objDeleted is true if and only if action ==
 	// lifecycle.DeleteAllVersionsAction
-	if action == lifecycle.DeleteAllVersionsAction {
+	if action.DeleteAll() {
 		return true, 0
 	}
 
@@ -1292,7 +1292,7 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 
 		if lcEvent.Action != lifecycle.NoneAction {
 			numVersions := uint64(1)
-			if lcEvent.Action == lifecycle.DeleteAllVersionsAction {
+			if lcEvent.Action.DeleteAll() {
 				numVersions = uint64(obj.NumVersions)
 			}
 			globalScannerMetrics.timeILM(lcEvent.Action)(numVersions)
@@ -1320,8 +1320,11 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 	if obj.DeleteMarker {
 		eventName = event.ObjectRemovedDeleteMarkerCreated
 	}
-	if lcEvent.Action.DeleteAll() {
+	switch lcEvent.Action {
+	case lifecycle.DeleteAllVersionsAction:
 		eventName = event.ObjectRemovedDeleteAllVersions
+	case lifecycle.DelMarkerDeleteAllVersionsAction:
+		eventName = event.ILMDelMarkerExpirationDelete
 	}
 	// Notify object deleted event.
 	sendEvent(eventArgs{
@@ -1346,7 +1349,7 @@ func applyLifecycleAction(event lifecycle.Event, src lcEventSrc, obj ObjectInfo)
 	switch action := event.Action; action {
 	case lifecycle.DeleteVersionAction, lifecycle.DeleteAction,
 		lifecycle.DeleteRestoredAction, lifecycle.DeleteRestoredVersionAction,
-		lifecycle.DeleteAllVersionsAction:
+		lifecycle.DeleteAllVersionsAction, lifecycle.DelMarkerDeleteAllVersionsAction:
 		success = applyExpiryRule(event, src, obj)
 	case lifecycle.TransitionAction, lifecycle.TransitionVersionAction:
 		success = applyTransitionRule(event, src, obj)

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1886,12 +1886,13 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 			// based on the latest objectInfo and see if the object still
 			// qualifies for deletion.
 			if gerr == nil {
-				evt := evalActionFromLifecycle(ctx, *lc, rcfg, replcfg, goi)
 				var isErr bool
+				evt := evalActionFromLifecycle(ctx, *lc, rcfg, replcfg, goi)
 				switch evt.Action {
-				case lifecycle.NoneAction:
-					isErr = true
-				case lifecycle.TransitionAction, lifecycle.TransitionVersionAction:
+				case lifecycle.DeleteAllVersionsAction, lifecycle.DelMarkerDeleteAllVersionsAction:
+					// opts.DeletePrefix is used only in the above lifecycle Expiration actions.
+				default:
+					// object has been modified since lifecycle action was previously evaluated
 					isErr = true
 				}
 				if isErr {

--- a/internal/bucket/lifecycle/action_string.go
+++ b/internal/bucket/lifecycle/action_string.go
@@ -16,12 +16,13 @@ func _() {
 	_ = x[DeleteRestoredAction-5]
 	_ = x[DeleteRestoredVersionAction-6]
 	_ = x[DeleteAllVersionsAction-7]
-	_ = x[ActionCount-8]
+	_ = x[DelMarkerDeleteAllVersionsAction-8]
+	_ = x[ActionCount-9]
 }
 
-const _Action_name = "NoneActionDeleteActionDeleteVersionActionTransitionActionTransitionVersionActionDeleteRestoredActionDeleteRestoredVersionActionDeleteAllVersionsActionActionCount"
+const _Action_name = "NoneActionDeleteActionDeleteVersionActionTransitionActionTransitionVersionActionDeleteRestoredActionDeleteRestoredVersionActionDeleteAllVersionsActionDelMarkerDeleteAllVersionsActionActionCount"
 
-var _Action_index = [...]uint8{0, 10, 22, 41, 57, 80, 100, 127, 150, 161}
+var _Action_index = [...]uint8{0, 10, 22, 41, 57, 80, 100, 127, 150, 182, 193}
 
 func (i Action) String() string {
 	if i < 0 || i >= Action(len(_Action_index)-1) {

--- a/internal/bucket/lifecycle/delmarker-expiration.go
+++ b/internal/bucket/lifecycle/delmarker-expiration.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lifecycle
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+var errInvalidDaysDelMarkerExpiration = Errorf("Days must be a positive integer with DelMarkerExpiration")
+
+// DelMarkerExpiration used to xml encode/decode ILM action by the same name
+type DelMarkerExpiration struct {
+	XMLName xml.Name `xml:"DelMarkerExpiration"`
+	Days    int      `xml:"Days,omitempty"`
+}
+
+// Empty returns if a DelMarkerExpiration XML element is empty.
+// Used to detect if lifecycle.Rule contained a DelMarkerExpiration element.
+func (de DelMarkerExpiration) Empty() bool {
+	return de.Days == 0
+}
+
+// UnmarshalXML decodes a single XML element into a DelMarkerExpiration value
+func (de *DelMarkerExpiration) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	type delMarkerExpiration DelMarkerExpiration
+	var dexp delMarkerExpiration
+	err := dec.DecodeElement(&dexp, &start)
+	if err != nil {
+		return err
+	}
+
+	if dexp.Days <= 0 {
+		return errInvalidDaysDelMarkerExpiration
+	}
+
+	*de = DelMarkerExpiration(dexp)
+	return nil
+}
+
+// MarshalXML encodes a DelMarkerExpiration value into an XML element
+func (de DelMarkerExpiration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	if de.Empty() {
+		return nil
+	}
+
+	type delMarkerExpiration DelMarkerExpiration
+	return enc.EncodeElement(delMarkerExpiration(de), start)
+}
+
+// NextDue returns upcoming DelMarkerExpiration date for obj if
+// applicable, returns false otherwise.
+func (de DelMarkerExpiration) NextDue(obj ObjectOpts) (time.Time, bool) {
+	if !obj.IsLatest || !obj.DeleteMarker {
+		return time.Time{}, false
+	}
+
+	return ExpectedExpiryTime(obj.ModTime, de.Days), true
+}

--- a/internal/bucket/lifecycle/delmarker-expiration_test.go
+++ b/internal/bucket/lifecycle/delmarker-expiration_test.go
@@ -1,0 +1,46 @@
+package lifecycle
+
+import (
+	"encoding/xml"
+	"fmt"
+	"testing"
+)
+
+func TestDelMarkerExpParseAndValidate(t *testing.T) {
+	tests := []struct {
+		xml string
+		err error
+	}{
+		{
+			xml: `<DelMarkerExpiration> <Days> 1 </Days> </DelMarkerExpiration>`,
+			err: nil,
+		},
+		{
+			xml: `<DelMarkerExpiration> <Days> -1 </Days> </DelMarkerExpiration>`,
+			err: errInvalidDaysDelMarkerExpiration,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("TestDelMarker-%d", i), func(t *testing.T) {
+			var dexp DelMarkerExpiration
+			var fail bool
+			err := xml.Unmarshal([]byte(test.xml), &dexp)
+			if test.err == nil {
+				if err != nil {
+					fail = true
+				}
+			} else {
+				if err == nil {
+					fail = true
+				}
+				if test.err.Error() != err.Error() {
+					fail = true
+				}
+			}
+			if fail {
+				t.Fatalf("Expected %v but got %v", test.err, err)
+			}
+		})
+	}
+}

--- a/internal/bucket/lifecycle/delmarker-expiration_test.go
+++ b/internal/bucket/lifecycle/delmarker-expiration_test.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package lifecycle
 
 import (

--- a/internal/bucket/lifecycle/rule.go
+++ b/internal/bucket/lifecycle/rule.go
@@ -33,22 +33,24 @@ const (
 
 // Rule - a rule for lifecycle configuration.
 type Rule struct {
-	XMLName    xml.Name   `xml:"Rule"`
-	ID         string     `xml:"ID,omitempty"`
-	Status     Status     `xml:"Status"`
-	Filter     Filter     `xml:"Filter,omitempty"`
-	Prefix     Prefix     `xml:"Prefix,omitempty"`
-	Expiration Expiration `xml:"Expiration,omitempty"`
-	Transition Transition `xml:"Transition,omitempty"`
+	XMLName             xml.Name            `xml:"Rule"`
+	ID                  string              `xml:"ID,omitempty"`
+	Status              Status              `xml:"Status"`
+	Filter              Filter              `xml:"Filter,omitempty"`
+	Prefix              Prefix              `xml:"Prefix,omitempty"`
+	Expiration          Expiration          `xml:"Expiration,omitempty"`
+	Transition          Transition          `xml:"Transition,omitempty"`
+	DelMarkerExpiration DelMarkerExpiration `xml:"DelMarkerExpiration,omitempty"`
 	// FIXME: add a type to catch unsupported AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
 	NoncurrentVersionExpiration NoncurrentVersionExpiration `xml:"NoncurrentVersionExpiration,omitempty"`
 	NoncurrentVersionTransition NoncurrentVersionTransition `xml:"NoncurrentVersionTransition,omitempty"`
 }
 
 var (
-	errInvalidRuleID     = Errorf("ID length is limited to 255 characters")
-	errEmptyRuleStatus   = Errorf("Status should not be empty")
-	errInvalidRuleStatus = Errorf("Status must be set to either Enabled or Disabled")
+	errInvalidRuleID                  = Errorf("ID length is limited to 255 characters")
+	errEmptyRuleStatus                = Errorf("Status should not be empty")
+	errInvalidRuleStatus              = Errorf("Status must be set to either Enabled or Disabled")
+	errInvalidRuleDelMarkerExpiration = Errorf("Rule with DelMarkerExpiration cannot have tags based filtering")
 )
 
 // validateID - checks if ID is valid or not.
@@ -158,7 +160,10 @@ func (r Rule) Validate() error {
 	if err := r.validateNoncurrentTransition(); err != nil {
 		return err
 	}
-	if !r.Expiration.set && !r.Transition.set && !r.NoncurrentVersionExpiration.set && !r.NoncurrentVersionTransition.set {
+	if (!r.Filter.Tag.IsEmpty() || len(r.Filter.And.Tags) != 0) && !r.DelMarkerExpiration.Empty() {
+		return errInvalidRuleDelMarkerExpiration
+	}
+	if !r.Expiration.set && !r.Transition.set && !r.NoncurrentVersionExpiration.set && !r.NoncurrentVersionTransition.set && r.DelMarkerExpiration.Empty() {
 		return errXMLNotWellFormed
 	}
 	return nil

--- a/internal/bucket/lifecycle/rule_test.go
+++ b/internal/bucket/lifecycle/rule_test.go
@@ -105,6 +105,31 @@ func TestInvalidRules(t *testing.T) {
 	                    </Rule>`,
 			expectedErr: errXMLNotWellFormed,
 		},
+		{
+			inputXML: `<Rule>
+				<ID>Rule with a tag and DelMarkerExpiration</ID>
+				<Filter><Tag><Key>k1</Key><Value>v1</Value></Tag></Filter>
+				<DelMarkerExpiration>
+					<Days>365</Days>
+				</DelMarkerExpiration>
+                            <Status>Enabled</Status>
+	                    </Rule>`,
+			expectedErr: errInvalidRuleDelMarkerExpiration,
+		},
+		{
+			inputXML: `<Rule>
+				<ID>Rule with multiple tags and DelMarkerExpiration</ID>
+				<Filter><And>
+				<Tag><Key>k1</Key><Value>v1</Value></Tag>
+				<Tag><Key>k2</Key><Value>v2</Value></Tag>
+				</And></Filter>
+				<DelMarkerExpiration>
+					<Days>365</Days>
+				</DelMarkerExpiration>
+                            <Status>Enabled</Status>
+	                    </Rule>`,
+			expectedErr: errInvalidRuleDelMarkerExpiration,
+		},
 	}
 
 	for i, tc := range invalidTestCases {

--- a/internal/event/name.go
+++ b/internal/event/name.go
@@ -63,6 +63,7 @@ const (
 	ObjectManyVersions
 	ObjectLargeVersions
 	PrefixManyFolders
+	ILMDelMarkerExpirationDelete
 
 	objectSingleTypesEnd
 	// Start Compound types that require expansion:
@@ -199,6 +200,8 @@ func (name Name) String() string {
 		return "s3:ObjectRemoved:NoOP"
 	case ObjectRemovedDeleteAllVersions:
 		return "s3:ObjectRemoved:DeleteAllVersions"
+	case ILMDelMarkerExpirationDelete:
+		return "s3:LifecycleDelMarkerExpiration:Delete"
 	case ObjectReplicationAll:
 		return "s3:Replication:*"
 	case ObjectReplicationFailed:
@@ -324,6 +327,8 @@ func ParseName(s string) (Name, error) {
 		return ObjectRemovedNoOP, nil
 	case "s3:ObjectRemoved:DeleteAllVersions":
 		return ObjectRemovedDeleteAllVersions, nil
+	case "s3:LifecycleDelMarkerExpiration:Delete":
+		return ILMDelMarkerExpirationDelete, nil
 	case "s3:Replication:*":
 		return ObjectReplicationAll, nil
 	case "s3:Replication:OperationFailedReplication":

--- a/internal/event/name_test.go
+++ b/internal/event/name_test.go
@@ -68,6 +68,8 @@ func TestNameString(t *testing.T) {
 		{ObjectCreatedPut, "s3:ObjectCreated:Put"},
 		{ObjectRemovedAll, "s3:ObjectRemoved:*"},
 		{ObjectRemovedDelete, "s3:ObjectRemoved:Delete"},
+		{ObjectRemovedDeleteAllVersions, "s3:ObjectRemoved:DeleteAllVersions"},
+		{ILMDelMarkerExpirationDelete, "s3:LifecycleDelMarkerExpiration:Delete"},
 		{ObjectRemovedNoOP, "s3:ObjectRemoved:NoOP"},
 		{ObjectCreatedPutRetention, "s3:ObjectCreated:PutRetention"},
 		{ObjectCreatedPutLegalHold, "s3:ObjectCreated:PutLegalHold"},
@@ -219,6 +221,7 @@ func TestParseName(t *testing.T) {
 		{"s3:ObjectAccessed:*", ObjectAccessedAll, false},
 		{"s3:ObjectRemoved:Delete", ObjectRemovedDelete, false},
 		{"s3:ObjectRemoved:NoOP", ObjectRemovedNoOP, false},
+		{"s3:LifecycleDelMarkerExpiration:Delete", ILMDelMarkerExpirationDelete, false},
 		{"", blankName, true},
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR brings about two changes, one adds a new lifecycle action, `DelMarkerExpiration` and another modifies the behavior of an existing lifecycle configuration element, `ExpiredObjectDeleteAllVersions`.

## Companion PRs
- https://github.com/minio/minio-go/pull/1959
- https://github.com/minio/mc/pull/4913
### Addition of `DelMarkerExpiration`
This ILM action removes all versions of an object if its latest version is a DEL marker.
```xml
    <DelMarkerObjectExpiration>
        <Days> 10 </Days>
    </DelMarkerObjectExpiration>
```
1. Applies only to objects whose,

    - latest version is a DEL marker.
    - satisfies the number of days criteria

2. Deletes all versions of this object

3. Associated rule can't have tag-based filtering
 
### Modification to `ExpiredObjectDeleteAllVersions`
Will apply only to objects whose latest version is **not** a DEL marker.

## Motivation and Context

This is a breaking change to how ExpiredObejctDeleteAllVersions functions today. This is necessary to avoid the following highly probable footgun scenario in the future.

Scenario:
User uses tags based filtering to select the time to live(TTL) for an object. Application sometimes deletes objects too, making their latest version a DEL marker. Previous implementation skipped tag based filters if latest version was DEL marker, voiding the tag based TTL. User is surprised to find objects expired sooner than expected.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
