### PR TITLE
Add system memory metrics in v3

### DIFF
--- a/cmd/metrics-resource.go
+++ b/cmd/metrics-resource.go
@@ -50,15 +50,6 @@ const (
 	interfaceTxBytes  MetricName = "tx_bytes"
 	interfaceTxErrors MetricName = "tx_errors"
 
-	// memory stats
-	memUsed      MetricName = "used"
-	memUsedPerc  MetricName = "used_perc"
-	memFree      MetricName = "free"
-	memShared    MetricName = "shared"
-	memBuffers   MetricName = "buffers"
-	memCache     MetricName = "cache"
-	memAvailable MetricName = "available"
-
 	// cpu stats
 	cpuUser       MetricName = "user"
 	cpuSystem     MetricName = "system"

--- a/cmd/metrics-v3-system-memory.go
+++ b/cmd/metrics-v3-system-memory.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// # This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+)
+
+const (
+	memTotal     = "total"
+	memUsed      = "used"
+	memFree      = "free"
+	memBuffers   = "buffers"
+	memCache     = "cache"
+	memUsedPerc  = "used_perc"
+	memShared    = "shared"
+	memAvailable = "available"
+)
+
+var (
+	memTotalMD     = NewGaugeMD(memTotal, "Total memory on the node")
+	memUsedMD      = NewGaugeMD(memUsed, "Used memory on the node")
+	memUsedPercMD  = NewGaugeMD(memUsedPerc, "Used memory percentage on the node")
+	memFreeMD      = NewGaugeMD(memFree, "Free memory on the node")
+	memBuffersMD   = NewGaugeMD(memBuffers, "Buffers memory on the node")
+	memCacheMD     = NewGaugeMD(memCache, "Cache memory on the node")
+	memSharedMD    = NewGaugeMD(memShared, "Shared memory on the node")
+	memAvailableMD = NewGaugeMD(memAvailable, "Available memory on the node")
+)
+
+// loadMemoryMetrics - `MetricsLoaderFn` for node memory metrics.
+func loadMemoryMetrics(ctx context.Context, m MetricValues, c *metricsCache) error {
+	memMetrics, err := c.memoryMetrics.Get()
+	if err != nil {
+		metricsLogIf(ctx, err)
+		return err
+	}
+
+	m.Set(memTotal, float64(memMetrics.Total))
+	m.Set(memUsed, float64(memMetrics.Used))
+	usedPerc := float64(memMetrics.Used) * 100 / float64(memMetrics.Total)
+	m.Set(memUsedPerc, usedPerc)
+	m.Set(memFree, float64(memMetrics.Free))
+	m.Set(memBuffers, float64(memMetrics.Buffers))
+	m.Set(memCache, float64(memMetrics.Cache))
+	m.Set(memShared, float64(memMetrics.Shared))
+	m.Set(memAvailable, float64(memMetrics.Available))
+
+	return nil
+}

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -35,6 +35,7 @@ const (
 
 	systemNetworkInternodeCollectorPath collectorPath = "/system/network/internode"
 	systemDriveCollectorPath            collectorPath = "/system/drive"
+	systemMemoryCollectorPath           collectorPath = "/system/memory"
 	systemProcessCollectorPath          collectorPath = "/system/process"
 	systemGoCollectorPath               collectorPath = "/system/go"
 
@@ -110,6 +111,20 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			internodeRecvBytesTotalMD,
 		},
 		loadNetworkInternodeMetrics,
+	)
+
+	systemMemoryMG := NewMetricsGroup(systemMemoryCollectorPath,
+		[]MetricDescriptor{
+			memTotalMD,
+			memUsedMD,
+			memFreeMD,
+			memAvailableMD,
+			memBuffersMD,
+			memCacheMD,
+			memSharedMD,
+			memUsedPercMD,
+		},
+		loadMemoryMetrics,
 	)
 
 	systemDriveMG := NewMetricsGroup(systemDriveCollectorPath,
@@ -209,6 +224,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 
 		systemNetworkInternodeMG,
 		systemDriveMG,
+		systemMemoryMG,
 
 		clusterHealthMG,
 		clusterUsageObjectsMG,

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -42,6 +42,7 @@ These are metrics about the minio process and the node.
 | Path                        | Description                                       |
 |-----------------------------|---------------------------------------------------|
 | `/system/drive`             | Metrics about drives on the system                |
+| `/system/memory`            | Metrics about memory on the system                |
 | `/system/network/internode` | Metrics about internode requests made by the node |
 | `/system/process`           | Standard process metrics                          |
 | `/system/go`                | Standard Go lang metrics                          |
@@ -124,6 +125,20 @@ The standard metrics groups for ProcessCollector and GoCollector are not shown b
 | `minio_system_drive_writes_kb_per_sec`         | `gauge`   | Kilobytes written per second on a drive                            | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_writes_await`              | `gauge`   | Average time for write requests served on a drive                  | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_perc_util`                 | `gauge`   | Percentage of time the disk was busy                               | `drive,set_index,drive_index,pool_index,server`     |
+
+### `/system/memory`
+
+| Name                             | Type    | Help                               | Labels   |
+|----------------------------------|---------|------------------------------------|----------|
+| `minio_system_memory_used`       | `gauge` | Used memory on the node            | `server` |
+| `minio_system_memory_used_perc`  | `gauge` | Used memory percentage on the node | `server` |
+| `minio_system_memory_free`       | `gauge` | Free memory on the node            | `server` |
+| `minio_system_memory_total`      | `gauge` | Total memory on the node           | `server` |
+| `minio_system_memory_buffers`    | `gauge` | Buffers memory on the node         | `server` |
+| `minio_system_memory_cache`      | `gauge` | Cache memory on the node           | `server` |
+| `minio_system_memory_shared`     | `gauge` | Shared memory on the node          | `server` |
+| `minio_system_memory_available`  | `gauge` | Available memory on the node       | `server` |
+
 
 ### `/system/network/internode`
 


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Following memory metrics will be added under /system/memory

- available
- buffers
- cache
- free
- shared
- total
- used
- used_perc

## Motivation and Context

https://github.com/miniohq/engineering/issues/1510

## How to test this PR?

`mc admin prometheus metrics <alias> system`

should return the new memory related metrics
(will need some changes in mc to invoke the metrics-v3 api)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
