### PR TITLE
fix: list operations resuming when hitting different node

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1121,7 +1121,7 @@ func (sys *NotificationSys) restClientFromHash(s string) (client *peerRESTClient
 	if len(sys.peerClients) == 0 {
 		return nil
 	}
-	peerClients := sys.getOnlinePeers()
+	peerClients := sys.allPeerClients
 	if len(peerClients) == 0 {
 		return nil
 	}

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1104,17 +1104,6 @@ func (sys *NotificationSys) ServerInfo(metrics bool) []madmin.ServerProperties {
 	return reply
 }
 
-// returns all the peers that are currently online.
-func (sys *NotificationSys) getOnlinePeers() []*peerRESTClient {
-	var peerClients []*peerRESTClient
-	for _, peerClient := range sys.allPeerClients {
-		if peerClient != nil && peerClient.IsOnline() {
-			peerClients = append(peerClients, peerClient)
-		}
-	}
-	return peerClients
-}
-
 // restClientFromHash will return a deterministic peerRESTClient based on s.
 // Will return nil if client is local.
 func (sys *NotificationSys) restClientFromHash(s string) (client *peerRESTClient) {


### PR DESCRIPTION
## Description

Rest peer clients were not consistent across nodes. So metacache requests would not go to the same server if a continuation happens on a different node.

This would cause listings to needlessly be aborted and restart.

## How to test this PR?

Start a distributed cluster. Test listing behind a load balancer that spreads requests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
