### PR TITLE
remove older deploymentID fix behavior to speed up startup

### DIFF
--- a/cmd/format-erasure_test.go
+++ b/cmd/format-erasure_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"os"
 	"reflect"
 	"testing"
@@ -428,62 +427,6 @@ func BenchmarkGetFormatErasureInQuorum(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_, _ = getFormatErasureInQuorum(formats)
-	}
-}
-
-// Tests formatErasureGetDeploymentID()
-func TestGetErasureID(t *testing.T) {
-	setCount := 2
-	setDriveCount := 8
-
-	format := newFormatErasureV3(setCount, setDriveCount)
-	format.Erasure.DistributionAlgo = formatErasureVersionV2DistributionAlgoV1
-	formats := make([]*formatErasureV3, 16)
-
-	for i := 0; i < setCount; i++ {
-		for j := 0; j < setDriveCount; j++ {
-			newFormat := format.Clone()
-			newFormat.Erasure.This = format.Erasure.Sets[i][j]
-			formats[i*setDriveCount+j] = newFormat
-		}
-	}
-
-	// Return a format from list of formats in quorum.
-	quorumFormat, err := getFormatErasureInQuorum(formats)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Check if the reference format and input formats are same.
-	var id string
-	if id, err = formatErasureGetDeploymentID(quorumFormat, formats); err != nil {
-		t.Fatal(err)
-	}
-
-	if id == "" {
-		t.Fatal("ID cannot be empty.")
-	}
-
-	formats[0] = nil
-	if id, err = formatErasureGetDeploymentID(quorumFormat, formats); err != nil {
-		t.Fatal(err)
-	}
-	if id == "" {
-		t.Fatal("ID cannot be empty.")
-	}
-
-	formats[1].Erasure.Sets[0][0] = "bad-uuid"
-	if id, err = formatErasureGetDeploymentID(quorumFormat, formats); err != nil {
-		t.Fatal(err)
-	}
-
-	if id == "" {
-		t.Fatal("ID cannot be empty.")
-	}
-
-	formats[2].ID = "bad-id"
-	if _, err = formatErasureGetDeploymentID(quorumFormat, formats); !errors.Is(err, errCorruptedFormat) {
-		t.Fatalf("Unexpected error %s", err)
 	}
 }
 

--- a/cmd/metacache-walk.go
+++ b/cmd/metacache-walk.go
@@ -414,7 +414,7 @@ func (p *xlStorageDiskIDCheck) WalkDir(ctx context.Context, opts WalkDirOptions,
 // On success a meta cache stream will be returned, that should be closed when done.
 func (client *storageRESTClient) WalkDir(ctx context.Context, opts WalkDirOptions, wr io.Writer) error {
 	// Ensure remote has the same disk ID.
-	opts.DiskID = client.diskID
+	opts.DiskID = *client.diskID.Load()
 	b, err := opts.MarshalMsg(grid.GetByteBuffer()[:0])
 	if err != nil {
 		return toStorageErr(err)

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -106,10 +106,6 @@ func (d *naughtyDisk) GetDiskID() (string, error) {
 	return d.disk.GetDiskID()
 }
 
-func (d *naughtyDisk) SetFormatData(b []byte) {
-	d.disk.SetFormatData(b)
-}
-
 func (d *naughtyDisk) SetDiskID(id string) {
 	d.disk.SetDiskID(id)
 }

--- a/cmd/prepare-storage.go
+++ b/cmd/prepare-storage.go
@@ -245,23 +245,11 @@ func connectLoadInitFormats(verboseLogging bool, firstDisk bool, endpoints Endpo
 	}
 
 	if format.ID == "" {
-		// Not a first disk, wait until first disk fixes deploymentID
-		if !firstDisk {
-			return nil, nil, errNotFirstDisk
-		}
-		if err = formatErasureFixDeploymentID(endpoints, storageDisks, format, formatConfigs); err != nil {
-			storageLogIf(GlobalContext, err)
-			return nil, nil, err
-		}
+		internalLogIf(GlobalContext, errors.New("unexpected error deployment ID is missing, refusing to continue"))
+		return nil, nil, errInvalidArgument
 	}
 
 	globalDeploymentIDPtr.Store(&format.ID)
-
-	if err = formatErasureFixLocalDeploymentID(endpoints, storageDisks, format); err != nil {
-		storageLogIf(GlobalContext, err)
-		return nil, nil, err
-	}
-
 	return storageDisks, format, nil
 }
 

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -108,5 +108,4 @@ type StorageAPI interface {
 	// Read all.
 	ReadAll(ctx context.Context, volume string, path string) (buf []byte, err error)
 	GetDiskLoc() (poolIdx, setIdx, diskIdx int) // Retrieve location indexes.
-	SetFormatData(b []byte)                     // Set formatData cached value
 }


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
remove older deploymentID fix behavior to speed up startup

## Motivation and Context
since mid-2018, we have not had any deployments
without deployment-id, it is time to put this
code to rest, this PR removes this old code as
it's no longer valuable.

on setups with 1000's drives, these are all
quite expensive operations.

## How to test this PR?
CI/CD would cover it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
