### PR TITLE
Add cluster config metrics in metrics-v3

### DIFF
--- a/cmd/metrics-v3-cluster-config.go
+++ b/cmd/metrics-v3-cluster-config.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import "context"
+
+const (
+	configWriteQuorum    = "write_quorum"
+	configRRSParity      = "rrs_parity"
+	configStandardParity = "standard_parity"
+)
+
+var (
+	configWriteQuorumMD = NewGaugeMD(configWriteQuorum,
+		"Maximum write quorum across all pools and sets")
+	configRRSParityMD = NewGaugeMD(configRRSParity,
+		"Reduced redundancy storage class parity")
+	configStandardParityMD = NewGaugeMD(configStandardParity,
+		"Standard storage class parity")
+)
+
+// loadClusterConfigMetrics - `MetricsLoaderFn` for cluster config
+// such as standard and RRS parity.
+func loadClusterConfigMetrics(ctx context.Context, m MetricValues, c *metricsCache) error {
+	clusterDriveMetrics, _ := c.clusterDriveMetrics.Get()
+	m.Set(configStandardParity, float64(clusterDriveMetrics.storageInfo.Backend.StandardSCParity))
+	m.Set(configRRSParity, float64(clusterDriveMetrics.storageInfo.Backend.RRSCParity))
+
+	objLayer := newObjectLayerFn()
+	result := objLayer.Health(ctx, HealthOptions{})
+	m.Set(configWriteQuorum, float64(result.WriteQuorum))
+
+	return nil
+}

--- a/cmd/metrics-v3-cluster-config.go
+++ b/cmd/metrics-v3-cluster-config.go
@@ -42,8 +42,10 @@ func loadClusterConfigMetrics(ctx context.Context, m MetricValues, c *metricsCac
 	m.Set(configRRSParity, float64(clusterDriveMetrics.storageInfo.Backend.RRSCParity))
 
 	objLayer := newObjectLayerFn()
-	result := objLayer.Health(ctx, HealthOptions{})
-	m.Set(configWriteQuorum, float64(result.WriteQuorum))
+	if objLayer != nil {
+		result := objLayer.Health(ctx, HealthOptions{})
+		m.Set(configWriteQuorum, float64(result.WriteQuorum))
+	}
 
 	return nil
 }

--- a/cmd/metrics-v3-cluster-config.go
+++ b/cmd/metrics-v3-cluster-config.go
@@ -42,10 +42,8 @@ func loadClusterConfigMetrics(ctx context.Context, m MetricValues, c *metricsCac
 	m.Set(configRRSParity, float64(clusterDriveMetrics.storageInfo.Backend.RRSCParity))
 
 	objLayer := newObjectLayerFn()
-	if objLayer != nil {
-		result := objLayer.Health(ctx, HealthOptions{})
-		m.Set(configWriteQuorum, float64(result.WriteQuorum))
-	}
+	result := objLayer.Health(ctx, HealthOptions{})
+	m.Set(configWriteQuorum, float64(result.WriteQuorum))
 
 	return nil
 }

--- a/cmd/metrics-v3-cluster-config.go
+++ b/cmd/metrics-v3-cluster-config.go
@@ -20,14 +20,11 @@ package cmd
 import "context"
 
 const (
-	configWriteQuorum    = "write_quorum"
 	configRRSParity      = "rrs_parity"
 	configStandardParity = "standard_parity"
 )
 
 var (
-	configWriteQuorumMD = NewGaugeMD(configWriteQuorum,
-		"Maximum write quorum across all pools and sets")
 	configRRSParityMD = NewGaugeMD(configRRSParity,
 		"Reduced redundancy storage class parity")
 	configStandardParityMD = NewGaugeMD(configStandardParity,

--- a/cmd/metrics-v3-cluster-config.go
+++ b/cmd/metrics-v3-cluster-config.go
@@ -37,14 +37,12 @@ var (
 // loadClusterConfigMetrics - `MetricsLoaderFn` for cluster config
 // such as standard and RRS parity.
 func loadClusterConfigMetrics(ctx context.Context, m MetricValues, c *metricsCache) error {
-	clusterDriveMetrics, _ := c.clusterDriveMetrics.Get()
-	m.Set(configStandardParity, float64(clusterDriveMetrics.storageInfo.Backend.StandardSCParity))
-	m.Set(configRRSParity, float64(clusterDriveMetrics.storageInfo.Backend.RRSCParity))
-
-	objLayer := newObjectLayerFn()
-	if objLayer != nil {
-		result := objLayer.Health(ctx, HealthOptions{})
-		m.Set(configWriteQuorum, float64(result.WriteQuorum))
+	clusterDriveMetrics, err := c.clusterDriveMetrics.Get()
+	if err != nil {
+		metricsLogIf(ctx, err)
+	} else {
+		m.Set(configStandardParity, float64(clusterDriveMetrics.storageInfo.Backend.StandardSCParity))
+		m.Set(configRRSParity, float64(clusterDriveMetrics.storageInfo.Backend.RRSCParity))
 	}
 
 	return nil

--- a/cmd/metrics-v3-types.go
+++ b/cmd/metrics-v3-types.go
@@ -430,7 +430,7 @@ func (mg *MetricsGroup) AddExtraLabels(labels ...string) {
 // requiresObjectLayer - use to add dependency on the global object layer API
 // when creating the metrics group
 // e.g. myMG := NewMetricsGroup(...).requiresObjectLayer()
-func (mg *MetricsGroup) requiresObjectLayer(labels ...string) *MetricsGroup {
+func (mg *MetricsGroup) requiresObjectLayer() *MetricsGroup {
 	mg.metricsGroupOpts.dependGlobalObjectAPI = true
 	return mg
 }

--- a/cmd/metrics-v3-types.go
+++ b/cmd/metrics-v3-types.go
@@ -374,6 +374,9 @@ type MetricsGroup struct {
 	// Collect() call. This is protected by the `bucketsLock`.
 	bucketsLock sync.Mutex
 	buckets     []string
+
+	// metricsGroupOpts - options for the metrics group.
+	metricsGroupOpts MetricsGroupOpts
 }
 
 // NewMetricsGroup creates a new MetricsGroup. To create a metrics group for
@@ -424,6 +427,14 @@ func (mg *MetricsGroup) AddExtraLabels(labels ...string) {
 	}
 }
 
+// requiresObjectLayer - use to add dependency on the global object layer API
+// when creating the metrics group
+// e.g. myMG := NewMetricsGroup(...).requiresObjectLayer()
+func (mg *MetricsGroup) requiresObjectLayer(labels ...string) *MetricsGroup {
+	mg.metricsGroupOpts.dependGlobalObjectAPI = true
+	return mg
+}
+
 // IsBucketMetricsGroup - returns true if the given MetricsGroup is a bucket
 // metrics group.
 func (mg *MetricsGroup) IsBucketMetricsGroup() bool {
@@ -437,6 +448,10 @@ func (mg *MetricsGroup) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
+func isObjectLayerInitialized() bool {
+	return newObjectLayerFn() != nil
+}
+
 // Collect - implements prometheus.Collector interface.
 func (mg *MetricsGroup) Collect(ch chan<- prometheus.Metric) {
 	metricValues := newMetricValues(mg.descriptorMap)
@@ -445,7 +460,13 @@ func (mg *MetricsGroup) Collect(ch chan<- prometheus.Metric) {
 	if mg.IsBucketMetricsGroup() {
 		err = mg.bucketLoader(GlobalContext, metricValues, mg.cache, mg.buckets)
 	} else {
-		err = mg.loader(GlobalContext, metricValues, mg.cache)
+		canLoad := true
+		if mg.metricsGroupOpts.dependGlobalObjectAPI && !isObjectLayerInitialized() {
+			canLoad = false
+		}
+		if canLoad {
+			err = mg.loader(GlobalContext, metricValues, mg.cache)
+		}
 	}
 
 	// There is no way to handle errors here, so we panic the current goroutine

--- a/cmd/metrics-v3-types.go
+++ b/cmd/metrics-v3-types.go
@@ -430,7 +430,7 @@ func (mg *MetricsGroup) AddExtraLabels(labels ...string) {
 // requiresObjectLayer - use to add dependency on the global object layer API
 // when creating the metrics group
 // e.g. myMG := NewMetricsGroup(...).requiresObjectLayer()
-func (mg *MetricsGroup) requiresObjectLayer() *MetricsGroup {
+func (mg *MetricsGroup) requiresObjectLayer(labels ...string) *MetricsGroup {
 	mg.metricsGroupOpts.dependGlobalObjectAPI = true
 	return mg
 }

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -345,7 +345,6 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 
 	clusterConfigMG := NewMetricsGroup(clusterConfigCollectorPath,
 		[]MetricDescriptor{
-			configWriteQuorumMD,
 			configRRSParityMD,
 			configStandardParityMD,
 		},

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -350,7 +350,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			configStandardParityMD,
 		},
 		loadClusterConfigMetrics,
-	)
+	).requiresObjectLayer()
 
 	loggerWebhookMG := NewMetricsGroup(loggerWebhookCollectorPath,
 		[]MetricDescriptor{

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -350,7 +350,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			configStandardParityMD,
 		},
 		loadClusterConfigMetrics,
-	).requiresObjectLayer()
+	)
 
 	loggerWebhookMG := NewMetricsGroup(loggerWebhookCollectorPath,
 		[]MetricDescriptor{

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -53,6 +53,7 @@ const (
 	clusterErasureSetCollectorPath   collectorPath = "/cluster/erasure-set"
 	clusterNotificationCollectorPath collectorPath = "/cluster/notification"
 	clusterIAMCollectorPath          collectorPath = "/cluster/iam"
+	clusterConfigCollectorPath       collectorPath = "/cluster/config"
 
 	auditCollectorPath         collectorPath = "/audit"
 	loggerWebhookCollectorPath collectorPath = "/logger/webhook"
@@ -342,6 +343,15 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 		loadClusterReplicationMetrics,
 	)
 
+	clusterConfigMG := NewMetricsGroup(clusterConfigCollectorPath,
+		[]MetricDescriptor{
+			configWriteQuorumMD,
+			configRRSParityMD,
+			configStandardParityMD,
+		},
+		loadClusterConfigMetrics,
+	)
+
 	loggerWebhookMG := NewMetricsGroup(loggerWebhookCollectorPath,
 		[]MetricDescriptor{
 			webhookFailedMessagesMD,
@@ -378,6 +388,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 		clusterNotificationMG,
 		clusterIAMMG,
 		clusterReplicationMG,
+		clusterConfigMG,
 
 		auditMG,
 		loggerWebhookMG,

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -253,6 +253,14 @@ The standard metrics group for GoCollector is not shown below.
 | `minio_cluster_health_capacity_usable_total_bytes` | `gauge` | Total cluster usable storage capacity in bytes |        |
 | `minio_cluster_health_capacity_usable_free_bytes`  | `gauge` | Total cluster usable storage free in bytes     |        |
 
+### `/cluster/config`
+
+| Name                                   | Type    | Help                                           | Labels |
+|----------------------------------------|---------|------------------------------------------------|--------|
+| `minio_cluster_config_rrs_parity`      | `gauge` | Reduced redundancy storage class parity        |        |
+| `minio_cluster_config_standard_parity` | `gauge` | Standard storage class parity                  |        |
+| `minio_cluster_config_write_quorum`    | `gauge` | Maximum write quorum across all pools and sets |        |
+
 ### `/cluster/usage/objects`
 
 | Name                                                     | Type    | Help                                                           | Labels  |

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -259,7 +259,6 @@ The standard metrics group for GoCollector is not shown below.
 |----------------------------------------|---------|------------------------------------------------|--------|
 | `minio_cluster_config_rrs_parity`      | `gauge` | Reduced redundancy storage class parity        |        |
 | `minio_cluster_config_standard_parity` | `gauge` | Standard storage class parity                  |        |
-| `minio_cluster_config_write_quorum`    | `gauge` | Maximum write quorum across all pools and sets |        |
 
 ### `/cluster/usage/objects`
 

--- a/internal/cachevalue/cache.go
+++ b/internal/cachevalue/cache.go
@@ -92,7 +92,7 @@ func (t *Cache[T]) InitOnce(ttl time.Duration, opts Opts, update func(ctx contex
 // GetWithCtx will return a cached value or fetch a new one.
 // passes a caller context, if caller context cancels nothing
 // is cached.
-// Tf the Update function returns an error the value is forwarded as is and not cached.
+// If the Update function returns an error the value is forwarded as is and not cached.
 func (t *Cache[T]) GetWithCtx(ctx context.Context) (T, error) {
 	v := t.val.Load()
 	ttl := t.ttl


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

endpoint: /minio/metrics/v3/cluster/config
metrics:
- rrs_parity
- standard_parity

## Motivation and Context

https://github.com/miniohq/engineering/issues/1510

## How to test this PR?

`mc admin prometheus metrics <alias> cluster`

should return the new cluster config related metrics
(will need some changes in mc to invoke the metrics-v3 api)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
