### PR TITLE
Use pkg helper to allow default MINIO_KMS_KEY_CACHE_INTERVAL as a time.Duration

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -958,8 +958,7 @@ func handleKMSConfig() {
 			}
 		}
 
-		kmsLogger := Logger{}
-		KMS, err := kms.NewWithConfig(kmsConf, kmsLogger)
+		KMS, err := kms.NewWithConfig(kmsConf, KMSLogger{})
 		if err != nil {
 			logger.Fatal(err, "Unable to initialize a connection to KES as specified by the shell environment")
 		}

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -198,11 +198,11 @@ func kmsLogIf(ctx context.Context, err error, errKind ...interface{}) {
 type KMSLogger struct{}
 
 // LogOnceIf is the implementation of LogOnceIf, accessible using the Logger interface
-func (kmsLogger KMSLogger) LogOnceIf(ctx context.Context, err error, id string, errKind ...interface{}) {
+func (l KMSLogger) LogOnceIf(ctx context.Context, err error, id string, errKind ...interface{}) {
 	logger.LogOnceIf(ctx, "kms", err, id, errKind...)
 }
 
 // LogIf is the implementation of LogIf, accessible using the Logger interface
-func (kmsLogger KMSLogger) LogIf(ctx context.Context, err error, errKind ...interface{}) {
+func (l KMSLogger) LogIf(ctx context.Context, err error, errKind ...interface{}) {
 	logger.LogIf(ctx, "kms", err, errKind...)
 }

--- a/cmd/logging.go
+++ b/cmd/logging.go
@@ -194,10 +194,15 @@ func kmsLogIf(ctx context.Context, err error, errKind ...interface{}) {
 	logger.LogIf(ctx, "kms", err, errKind...)
 }
 
-// Logger permits access to module specific logging
-type Logger struct{}
+// KMSLogger permits access to kms module specific logging
+type KMSLogger struct{}
 
 // LogOnceIf is the implementation of LogOnceIf, accessible using the Logger interface
-func (l Logger) LogOnceIf(ctx context.Context, subsystem string, err error, id string, errKind ...interface{}) {
-	logger.LogOnceIf(ctx, subsystem, err, id, errKind...)
+func (kmsLogger KMSLogger) LogOnceIf(ctx context.Context, err error, id string, errKind ...interface{}) {
+	logger.LogOnceIf(ctx, "kms", err, id, errKind...)
+}
+
+// LogIf is the implementation of LogIf, accessible using the Logger interface
+func (kmsLogger KMSLogger) LogIf(ctx context.Context, err error, errKind ...interface{}) {
+	logger.LogIf(ctx, "kms", err, errKind...)
 }

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/minio/madmin-go/v3 v3.0.50
 	github.com/minio/minio-go/v7 v7.0.69
 	github.com/minio/mux v1.9.0
-	github.com/minio/pkg/v2 v2.0.16
+	github.com/minio/pkg/v2 v2.0.17
 	github.com/minio/selfupdate v0.6.0
 	github.com/minio/sha256-simd v1.0.1
 	github.com/minio/simdjson-go v0.4.5

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,8 @@ github.com/minio/minio-go/v7 v7.0.69 h1:l8AnsQFyY1xiwa/DaQskY4NXSLA2yrGsW5iD9nRP
 github.com/minio/minio-go/v7 v7.0.69/go.mod h1:XAvOPJQ5Xlzk5o3o/ArO2NMbhSGkimC+bpW/ngRKDmQ=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/mux v1.9.0/go.mod h1:1pAare17ZRL5GpmNL+9YmqHoWnLmMZF9C/ioUCfy0BQ=
-github.com/minio/pkg/v2 v2.0.16 h1:qBw2D08JE7fu4UORIxx0O4L09NM0wtMrw9sJRU5R1u0=
-github.com/minio/pkg/v2 v2.0.16/go.mod h1:V+OP/fKRD/qhJMQpdXXrCXcLYjGMpHKEE26zslthm5k=
+github.com/minio/pkg/v2 v2.0.17 h1:ndmGlitUj/eCVRPmfsAw3KlbtVNxqk0lQIvDXlcTHiQ=
+github.com/minio/pkg/v2 v2.0.17/go.mod h1:V+OP/fKRD/qhJMQpdXXrCXcLYjGMpHKEE26zslthm5k=
 github.com/minio/selfupdate v0.6.0 h1:i76PgT0K5xO9+hjzKcacQtO7+MjJ4JKA8Ak8XQ9DDwU=
 github.com/minio/selfupdate v0.6.0/go.mod h1:bO02GTIPCMQFTEvE5h4DjYB58bCoZ35XLeBf0buTDdM=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=

--- a/internal/kms/kes.go
+++ b/internal/kms/kes.go
@@ -72,7 +72,7 @@ type Config struct {
 
 // NewWithConfig returns a new KMS using the given
 // configuration.
-func NewWithConfig(config Config, kmsLogger KMSLogger) (KMS, error) {
+func NewWithConfig(config Config, logger Logger) (KMS, error) {
 	if len(config.Endpoints) == 0 {
 		return nil, errors.New("kms: no server endpoints")
 	}
@@ -141,23 +141,26 @@ func NewWithConfig(config Config, kmsLogger KMSLogger) (KMS, error) {
 		}
 	}()
 
-	go c.refreshKMSMasterKeyCache(kmsLogger)
+	go c.refreshKMSMasterKeyCache(logger)
 	return c, nil
 }
 
 // Request KES keep an up-to-date copy of the KMS master key to allow minio to start up even if KMS is down. The
 // cached key may still be evicted if the period of this function is longer than that of KES .cache.expiry.unused
-func (c *kesClient) refreshKMSMasterKeyCache(kmsLogger KMSLogger) {
+func (c *kesClient) refreshKMSMasterKeyCache(logger Logger) {
 	ctx := context.Background()
 
-	defaultCacheDuration := time.Duration(10)
+	defaultCacheDuration := 10 * time.Second
 	cacheDuration, err := env.GetDuration(EnvKESKeyCacheInterval, defaultCacheDuration)
 	if err != nil {
-		kmsLogger.LogOnceIf(ctx, err, "refresh-kms-master-key")
+		logger.LogOnceIf(ctx, fmt.Errorf("%s, using default of 10s", err.Error()), "refresh-kms-master-key")
 		cacheDuration = defaultCacheDuration
 	}
-
-	timer := time.NewTimer(cacheDuration * time.Second)
+	if cacheDuration < time.Second {
+		logger.LogOnceIf(ctx, errors.New("cache duration is less than 1s, using default of 10s"), "refresh-kms-master-key")
+		cacheDuration = defaultCacheDuration
+	}
+	timer := time.NewTimer(cacheDuration)
 	defer timer.Stop()
 
 	for {
@@ -165,10 +168,10 @@ func (c *kesClient) refreshKMSMasterKeyCache(kmsLogger KMSLogger) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			c.RefreshKey(ctx, kmsLogger)
+			c.RefreshKey(ctx, logger)
 
 			// Reset for the next interval
-			timer.Reset(cacheDuration * time.Second)
+			timer.Reset(cacheDuration)
 		}
 	}
 }
@@ -483,14 +486,14 @@ func (c *kesClient) Verify(ctx context.Context) []VerifyResult {
 	return results
 }
 
-// KMSLogger interface permits access to module specific logging, in this case, for KMS
-type KMSLogger interface {
+// Logger interface permits access to module specific logging, in this case, for KMS
+type Logger interface {
 	LogOnceIf(ctx context.Context, err error, id string, errKind ...interface{})
 	LogIf(ctx context.Context, err error, errKind ...interface{})
 }
 
 // RefreshKey checks the validity of the KMS Master Key
-func (c *kesClient) RefreshKey(ctx context.Context, kmsLogger KMSLogger) bool {
+func (c *kesClient) RefreshKey(ctx context.Context, logger Logger) bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
@@ -505,13 +508,13 @@ func (c *kesClient) RefreshKey(ctx context.Context, kmsLogger KMSLogger) bool {
 		// 1. Generate a new key using the KMS.
 		kmsCtx, err := kmsContext.MarshalText()
 		if err != nil {
-			kmsLogger.LogOnceIf(ctx, err, "refresh-kms-master-key")
+			logger.LogOnceIf(ctx, err, "refresh-kms-master-key")
 			validKey = false
 			break
 		}
 		_, err = client.GenerateKey(ctx, env.Get(EnvKESKeyName, ""), kmsCtx)
 		if err != nil {
-			kmsLogger.LogOnceIf(ctx, err, "refresh-kms-master-key")
+			logger.LogOnceIf(ctx, err, "refresh-kms-master-key")
 			validKey = false
 			break
 		}


### PR DESCRIPTION
Use pkg helper to allow default MINIO_KMS_KEY_CACHE_INTERVAL as a time.Duration
Specify default duration when invalid input or input < 1s is given

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Follow up to https://github.com/minio/minio/pull/19492

## Motivation and Context
Define a MINIO_KMS_KEY_CACHE_INTERVAL as a time.Duration. Log appropriate errors.

## How to test this PR?
Run example minio start command
This assumes minio, kes and a kms have been setup. e.g. in https://github.com/minio/minio/pull/19492
```
MINIO_KMS_KEY_CACHE_INTERVAL=25s \
MINIO_KMS_KES_ENDPOINT=https://10.214.226.181:9073 \
MINIO_KMS_KES_KEY_NAME=minio-key \
MINIO_KMS_KES_CAPATH=public.crt \
MINIO_KMS_KES_CERT_FILE=client.crt \
MINIO_KMS_KES_KEY_FILE=client.key \
CI=on \
~/github/minio/minio server /tmp/data --certs-dir ~/.minio/certs --address :9000 --console-address :9090
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
