### PR TITLE
fix: ListObjectVersions returning duplicates when resuming with null version id

### DIFF
--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -152,6 +152,15 @@ func (f *FileInfoVersions) findVersionIndex(v string) int {
 	if f == nil || v == "" {
 		return -1
 	}
+	if v == nullVersionID {
+		for i, ver := range f.Versions {
+			if ver.VersionID == "" {
+				return i
+			}
+		}
+		return -1
+	}
+
 	for i, ver := range f.Versions {
 		if ver.VersionID == v {
 			return i


### PR DESCRIPTION
## Description

When resuming a versioned listing where `version-id-marker=null` the full object would always be returned causing duplicate entries to be returned.

Fix check against empty version.

## How to test this PR?

A) Upload a large number (10K+) of objects to a bucket without versioning.
B) Enable versioning
C) Add second version of all objects

Perform listing to confirm there are no duplicates with same version ID.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
