### PR TITLE
ftp: Return current time for prefixes/directories

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -82,7 +82,10 @@ func (m *minioFileInfo) Mode() os.FileMode {
 }
 
 func (m *minioFileInfo) ModTime() time.Time {
-	return m.info.LastModified
+	if !m.info.LastModified.IsZero() {
+		return m.info.LastModified
+	}
+	return time.Now().UTC()
 }
 
 func (m *minioFileInfo) IsDir() bool {

--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -81,8 +81,13 @@ func (m *minioFileInfo) Mode() os.FileMode {
 	return os.ModePerm
 }
 
+var minFileDate = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC) // Workaround for Filezilla
+
 func (m *minioFileInfo) ModTime() time.Time {
-        return minFileDate;
+	if !m.info.LastModified.IsZero() {
+		return m.info.LastModified
+	}
+	return minFileDate
 }
 
 func (m *minioFileInfo) IsDir() bool {

--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -82,10 +82,7 @@ func (m *minioFileInfo) Mode() os.FileMode {
 }
 
 func (m *minioFileInfo) ModTime() time.Time {
-	if !m.info.LastModified.IsZero() {
-		return m.info.LastModified
-	}
-	return time.Now().UTC()
+        return minFileDate;
 }
 
 func (m *minioFileInfo) IsDir() bool {


### PR DESCRIPTION
## Description

Some clients (ok, Filezilla) doesn't like the zero date on directories and refuses to show entries without a date.

Prefixes do not have a time set. Return current time for these entries.

## How to test this PR?

Observe timestamps on prefixes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
