### PR TITLE
list: Fix rare listing continuation freeze

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -573,6 +573,7 @@ func (er *erasureObjects) streamMetadataParts(ctx context.Context, o listPathOpt
 					continue
 				case InsufficientReadQuorum:
 					retries++
+					loadedPart = -1
 					time.Sleep(retryDelay250)
 					continue
 				default:


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Reading the list metacache is not protected by a lock, the code retries when it fails to read the metacache object, however it forgot to re-read the metacache object from the drives, which is necessary, especially if the metacache objcet is inlined.

This commit will ensure that we always re-read the metacache object from the drives when it is retrying.

## Motivation and Context
Fix listing freeze

## How to test this PR?
Create a bucket with many objects and then do a recursive listing in a loop and wait until the listing stucks

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
