### PR TITLE
reload from drive tier-config when in-memory cache is not found

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -721,9 +721,9 @@ func auditTierActions(ctx context.Context, tier string, bytes int64) func(err er
 
 // getTransitionedObjectReader returns a reader from the transitioned tier.
 func getTransitionedObjectReader(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, oi ObjectInfo, opts ObjectOptions) (gr *GetObjectReader, err error) {
-	tgtClient, err := globalTierConfigMgr.getDriver(oi.TransitionedObject.Tier)
+	tgtClient, err := globalTierConfigMgr.getDriver(ctx, oi.TransitionedObject.Tier)
 	if err != nil {
-		return nil, fmt.Errorf("transition storage class not configured")
+		return nil, fmt.Errorf("transition storage class not configured: %w", err)
 	}
 
 	fn, off, length, err := NewGetObjectReader(rs, oi, opts)

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -2270,7 +2270,7 @@ func (er erasureObjects) GetObjectTags(ctx context.Context, bucket, object strin
 
 // TransitionObject - transition object content to target tier.
 func (er erasureObjects) TransitionObject(ctx context.Context, bucket, object string, opts ObjectOptions) error {
-	tgtClient, err := globalTierConfigMgr.getDriver(opts.Transition.Tier)
+	tgtClient, err := globalTierConfigMgr.getDriver(ctx, opts.Transition.Tier)
 	if err != nil {
 		return err
 	}

--- a/cmd/tier-sweeper.go
+++ b/cmd/tier-sweeper.go
@@ -143,13 +143,9 @@ type jentry struct {
 }
 
 func deleteObjectFromRemoteTier(ctx context.Context, objName, rvID, tierName string) error {
-	w, err := globalTierConfigMgr.getDriver(tierName)
+	w, err := globalTierConfigMgr.getDriver(ctx, tierName)
 	if err != nil {
 		return err
 	}
-	err = w.Remove(ctx, objName, remoteVersionID(rvID))
-	if err != nil {
-		return err
-	}
-	return nil
+	return w.Remove(ctx, objName, remoteVersionID(rvID))
 }

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -218,7 +219,7 @@ func (config *TierConfigMgr) Add(ctx context.Context, tier madmin.TierConfig, ig
 		return errTierAlreadyExists
 	}
 
-	d, err := newWarmBackend(ctx, tier)
+	d, err := newWarmBackend(ctx, tier, true)
 	if err != nil {
 		return err
 	}
@@ -242,8 +243,11 @@ func (config *TierConfigMgr) Add(ctx context.Context, tier madmin.TierConfig, ig
 
 // Remove removes tier if it is empty.
 func (config *TierConfigMgr) Remove(ctx context.Context, tier string) error {
-	d, err := config.getDriver(tier)
+	d, err := config.getDriver(ctx, tier)
 	if err != nil {
+		if errors.Is(err, errTierNotFound) {
+			return nil
+		}
 		return err
 	}
 	if inuse, err := d.InUse(ctx); err != nil {
@@ -261,7 +265,7 @@ func (config *TierConfigMgr) Remove(ctx context.Context, tier string) error {
 // Verify verifies if tier's config is valid by performing all supported
 // operations on the corresponding warmbackend.
 func (config *TierConfigMgr) Verify(ctx context.Context, tier string) error {
-	d, err := config.getDriver(tier)
+	d, err := config.getDriver(ctx, tier)
 	if err != nil {
 		return err
 	}
@@ -358,7 +362,7 @@ func (config *TierConfigMgr) Edit(ctx context.Context, tierName string, creds ma
 		cfg.MinIO.SecretKey = creds.SecretKey
 	}
 
-	d, err := newWarmBackend(ctx, cfg)
+	d, err := newWarmBackend(ctx, cfg, true)
 	if err != nil {
 		return err
 	}
@@ -382,7 +386,7 @@ func (config *TierConfigMgr) Bytes() ([]byte, error) {
 }
 
 // getDriver returns a warmBackend interface object initialized with remote tier config matching tierName
-func (config *TierConfigMgr) getDriver(tierName string) (d WarmBackend, err error) {
+func (config *TierConfigMgr) getDriver(ctx context.Context, tierName string) (d WarmBackend, err error) {
 	config.Lock()
 	defer config.Unlock()
 
@@ -398,7 +402,7 @@ func (config *TierConfigMgr) getDriver(tierName string) (d WarmBackend, err erro
 	if !ok {
 		return nil, errTierNotFound
 	}
-	d, err = newWarmBackend(context.TODO(), t)
+	d, err = newWarmBackend(ctx, t, false)
 	if err != nil {
 		return nil, err
 	}
@@ -462,6 +466,10 @@ func (config *TierConfigMgr) configReader(ctx context.Context) (*PutObjReader, *
 // Reload updates config by reloading remote tier config from config store.
 func (config *TierConfigMgr) Reload(ctx context.Context, objAPI ObjectLayer) error {
 	newConfig, err := loadTierConfig(ctx, objAPI)
+
+	config.Lock()
+	defer config.Unlock()
+
 	switch err {
 	case nil:
 		break
@@ -474,8 +482,6 @@ func (config *TierConfigMgr) Reload(ctx context.Context, objAPI ObjectLayer) err
 		return err
 	}
 
-	config.Lock()
-	defer config.Unlock()
 	// Reset drivercache built using current config
 	for k := range config.drivercache {
 		delete(config.drivercache, k)

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -131,7 +131,7 @@ type remoteVersionID string
 
 // newWarmBackend instantiates the tier type specific WarmBackend, runs
 // checkWarmBackend on it.
-func newWarmBackend(ctx context.Context, tier madmin.TierConfig) (d WarmBackend, err error) {
+func newWarmBackend(ctx context.Context, tier madmin.TierConfig, probe bool) (d WarmBackend, err error) {
 	switch tier.Type {
 	case madmin.S3:
 		d, err = newWarmBackendS3(*tier.S3, tier.Name)
@@ -148,9 +148,11 @@ func newWarmBackend(ctx context.Context, tier madmin.TierConfig) (d WarmBackend,
 		return nil, errTierTypeUnsupported
 	}
 
-	err = checkWarmBackend(ctx, d)
-	if err != nil {
-		return nil, err
+	if probe {
+		if err = checkWarmBackend(ctx, d); err != nil {
+			return nil, err
+		}
 	}
+
 	return d, nil
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
reload from drive tier-config when in-memory cache is not found

## Motivation and Context
avoid stale() information from disk

Bonus: avoid probing backend tiers for every
periodic reload.

## How to test this PR?
It is very hard to test this situation

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
