### PR TITLE
fix: ldap: avoid unnecessary import errors

### DIFF
--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -829,11 +829,17 @@ func TestIAMImportAssetWithLDAP(t *testing.T) {
 }
 `,
 		userPolicyMappingsFile: `{}`,
+		// Contains duplicate mapping with same policy, we should not error out.
 		groupPolicyMappingsFile: `{
     "cn=project.c,ou=groups,ou=swengg,DC=min,dc=io": {
         "version": 0,
         "policy": "consoleAdmin",
         "updatedAt": "2024-04-17T23:54:28.442998301Z"
+    },
+    "cn=project.c,ou=groups,OU=swengg,DC=min,DC=io": {
+        "version": 0,
+        "policy": "consoleAdmin",
+        "updatedAt": "2024-04-17T20:54:28.442998301Z"
     }
 }
 `,


### PR DESCRIPTION

## Description
Follow up for #19528

If there are multiple existing DN mappings for the same normalized DN, if they all have the same policy mapping value, we pick one of them of them instead of returning an import error.



## Motivation and Context


## How to test this PR?

Test updated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
