### PR TITLE
make renameData() more defensive during overwrites

### DIFF
--- a/.github/workflows/multipart/migrate.sh
+++ b/.github/workflows/multipart/migrate.sh
@@ -24,10 +24,7 @@ if [ ! -f ./mc ]; then
 		chmod +x mc
 fi
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 export RELEASE=RELEASE.2023-08-29T23-07-35Z
 

--- a/buildscripts/rewrite-old-new.sh
+++ b/buildscripts/rewrite-old-new.sh
@@ -87,10 +87,7 @@ function verify_rewrite() {
 		exit 1
 	fi
 
-	(
-		cd ./docs/debugging/s3-check-md5
-		go install -v
-	)
+	go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 	if ! s3-check-md5 \
 		-debug \

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -530,16 +530,7 @@ func healObject(bucket, object, versionID string, scan madmin.HealScanMode) erro
 	// Get background heal sequence to send elements to heal
 	bgSeq, ok := globalBackgroundHealState.getHealSequenceByToken(bgHealingUUID)
 	if ok {
-		return bgSeq.queueHealTask(healSource{
-			bucket:    bucket,
-			object:    object,
-			versionID: versionID,
-			noWait:    true, // do not block callers.
-			opts: &madmin.HealOpts{
-				Remove:   healDeleteDangling, // if found dangling purge it.
-				ScanMode: scan,
-			},
-		}, madmin.HealItemObject)
+		return bgSeq.healObject(bucket, object, versionID, scan)
 	}
 	return nil
 }

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -201,9 +201,9 @@ func (d *naughtyDisk) AppendFile(ctx context.Context, volume string, path string
 	return d.disk.AppendFile(ctx, volume, path, buf)
 }
 
-func (d *naughtyDisk) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (uint64, error) {
+func (d *naughtyDisk) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (RenameDataResp, error) {
 	if err := d.calcError(); err != nil {
-		return 0, err
+		return RenameDataResp{}, err
 	}
 	return d.disk.RenameData(ctx, srcVolume, srcPath, fi, dstVolume, dstPath, opts)
 }

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -33,6 +33,8 @@ type DeleteOptions struct {
 	Recursive bool `msg:"r"`
 	Immediate bool `msg:"i"`
 	UndoWrite bool `msg:"u"`
+	// OldDataDir of the previous object
+	OldDataDir string `msg:"o,omitempty"` // old data dir used only when to revert a rename()
 }
 
 // BaseOptions represents common options for all Storage API calls
@@ -490,8 +492,14 @@ type WriteAllHandlerParams struct {
 }
 
 // RenameDataResp - RenameData()'s response.
+// Provides information about the final state of Rename()
+//   - on xl.meta (array of versions) on disk to check for version disparity
+//   - on rewrite dataDir on disk that must be additionally purged
+//     only after as a 2-phase call, allowing the older dataDir to
+//     hang-around in-case we need some form of recovery.
 type RenameDataResp struct {
-	Signature uint64 `msg:"sig"`
+	Sign       []byte
+	OldDataDir string // contains '<uuid>', it is designed to be passed as value to Delete(bucket, pathJoin(object, dataDir))
 }
 
 // LocalDiskIDs - GetLocalIDs response.

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -85,7 +85,7 @@ type StorageAPI interface {
 	UpdateMetadata(ctx context.Context, volume, path string, fi FileInfo, opts UpdateMetadataOpts) error
 	ReadVersion(ctx context.Context, origvolume, volume, path, versionID string, opts ReadOptions) (FileInfo, error)
 	ReadXL(ctx context.Context, volume, path string, readData bool) (RawFileInfo, error)
-	RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (uint64, error)
+	RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (RenameDataResp, error)
 
 	// File operations.
 	ListDir(ctx context.Context, origvolume, volume, dirPath string, count int) ([]string, error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -440,7 +440,9 @@ func (client *storageRESTClient) CheckParts(ctx context.Context, volume string, 
 }
 
 // RenameData - rename source path to destination path atomically, metadata and data file.
-func (client *storageRESTClient) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (sign uint64, err error) {
+func (client *storageRESTClient) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo,
+	dstVolume, dstPath string, opts RenameOptions,
+) (res RenameDataResp, err error) {
 	params := RenameDataHandlerParams{
 		DiskID:    *client.diskID.Load(),
 		SrcVolume: srcVolume,
@@ -457,11 +459,11 @@ func (client *storageRESTClient) RenameData(ctx context.Context, srcVolume, srcP
 		resp, err = storageRenameDataInlineRPC.Call(ctx, client.gridConn, &RenameDataInlineHandlerParams{params})
 	}
 	if err != nil {
-		return 0, toStorageErr(err)
+		return res, toStorageErr(err)
 	}
 
 	defer storageRenameDataRPC.PutResponse(resp)
-	return resp.Signature, nil
+	return *resp, nil
 }
 
 // where we keep old *Readers

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -67,7 +67,7 @@ var (
 	storageWriteAllRPC         = grid.NewSingleHandler[*WriteAllHandlerParams, grid.NoPayload](grid.HandlerWriteAll, func() *WriteAllHandlerParams { return &WriteAllHandlerParams{} }, grid.NewNoPayload)
 	storageReadVersionRPC      = grid.NewSingleHandler[*grid.MSS, *FileInfo](grid.HandlerReadVersion, grid.NewMSS, func() *FileInfo { return &FileInfo{} })
 	storageReadXLRPC           = grid.NewSingleHandler[*grid.MSS, *RawFileInfo](grid.HandlerReadXL, grid.NewMSS, func() *RawFileInfo { return &RawFileInfo{} })
-	storageRenameDataRPC       = grid.NewSingleHandler[*RenameDataHandlerParams, *RenameDataResp](grid.HandlerRenameData, func() *RenameDataHandlerParams { return &RenameDataHandlerParams{} }, func() *RenameDataResp { return &RenameDataResp{} })
+	storageRenameDataRPC       = grid.NewSingleHandler[*RenameDataHandlerParams, *RenameDataResp](grid.HandlerRenameData2, func() *RenameDataHandlerParams { return &RenameDataHandlerParams{} }, func() *RenameDataResp { return &RenameDataResp{} })
 	storageRenameDataInlineRPC = grid.NewSingleHandler[*RenameDataInlineHandlerParams, *RenameDataResp](grid.HandlerRenameDataInline, newRenameDataInlineHandlerParams, func() *RenameDataResp { return &RenameDataResp{} }).AllowCallRequestPool(false)
 	storageRenameFileRPC       = grid.NewSingleHandler[*RenameFileHandlerParams, grid.NoPayload](grid.HandlerRenameFile, func() *RenameFileHandlerParams { return &RenameFileHandlerParams{} }, grid.NewNoPayload).AllowCallRequestPool(true)
 	storageStatVolRPC          = grid.NewSingleHandler[*grid.MSS, *VolInfo](grid.HandlerStatVol, grid.NewMSS, func() *VolInfo { return &VolInfo{} })
@@ -695,10 +695,8 @@ func (s *storageRESTServer) RenameDataHandler(p *RenameDataHandlerParams) (*Rena
 		return nil, grid.NewRemoteErr(errDiskNotFound)
 	}
 
-	sign, err := s.getStorage().RenameData(context.Background(), p.SrcVolume, p.SrcPath, p.FI, p.DstVolume, p.DstPath, p.Opts)
-	return &RenameDataResp{
-		Signature: sign,
-	}, grid.NewRemoteErr(err)
+	resp, err := s.getStorage().RenameData(context.Background(), p.SrcVolume, p.SrcPath, p.FI, p.DstVolume, p.DstPath, p.Opts)
+	return &resp, grid.NewRemoteErr(err)
 }
 
 // RenameDataInlineHandler - renames a meta object and data dir to destination.

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -29,6 +29,7 @@ import (
 	pathutil "path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,7 +49,6 @@ import (
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
 	"github.com/pkg/xattr"
-	"github.com/zeebo/xxh3"
 )
 
 const (
@@ -65,6 +65,9 @@ const (
 
 	// XL metadata file carries per object metadata.
 	xlStorageFormatFile = "xl.meta"
+
+	// XL metadata file backup file carries previous per object metadata.
+	xlStorageFormatFileBackup = "xl.meta.bkp"
 )
 
 var alignedBuf []byte
@@ -1366,6 +1369,10 @@ func (s *xlStorage) DeleteVersion(ctx context.Context, volume, path string, fi F
 		return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
 	}
 
+	if opts.UndoWrite && opts.OldDataDir != "" {
+		return renameAll(pathJoin(filePath, opts.OldDataDir, xlStorageFormatFileBackup), pathJoin(filePath, xlStorageFormatFile), filePath)
+	}
+
 	return s.deleteFile(volumeDir, pathJoin(volumeDir, path, xlStorageFormatFile), true, false)
 }
 
@@ -1375,12 +1382,21 @@ func (s *xlStorage) UpdateMetadata(ctx context.Context, volume, path string, fi 
 		return errInvalidArgument
 	}
 
+	volumeDir, err := s.getVolDir(volume)
+	if err != nil {
+		return err
+	}
+
+	// Validate file path length, before reading.
+	filePath := pathJoin(volumeDir, path)
+	if err = checkPathLength(filePath); err != nil {
+		return err
+	}
+
 	buf, err := s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFile))
 	if err != nil {
-		if err == errFileNotFound {
-			if fi.VersionID != "" {
-				return errFileVersionNotFound
-			}
+		if err == errFileNotFound && fi.VersionID != "" {
+			return errFileVersionNotFound
 		}
 		return err
 	}
@@ -1405,7 +1421,7 @@ func (s *xlStorage) UpdateMetadata(ctx context.Context, volume, path string, fi 
 	}
 	defer metaDataPoolPut(wbuf)
 
-	return s.writeAll(ctx, volume, pathJoin(path, xlStorageFormatFile), wbuf, !opts.NoPersistence)
+	return s.writeAll(ctx, volume, pathJoin(path, xlStorageFormatFile), wbuf, !opts.NoPersistence, volumeDir)
 }
 
 // WriteMetadata - writes FileInfo metadata for path at `xl.meta`
@@ -1438,7 +1454,7 @@ func (s *xlStorage) WriteMetadata(ctx context.Context, origvolume, volume, path 
 		// this is currently used by
 		// - emphemeral objects such as objects created during listObjects() calls
 		// - newMultipartUpload() call..
-		return s.writeAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf, false)
+		return s.writeAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf, false, "")
 	}
 
 	buf, err := s.ReadAll(ctx, volume, pathJoin(path, xlStorageFormatFile))
@@ -1936,14 +1952,17 @@ func (s *xlStorage) openFileDirect(path string, mode int) (f *os.File, err error
 	return w, nil
 }
 
-func (s *xlStorage) openFileSync(filePath string, mode int) (f *os.File, err error) {
-	return s.openFile(filePath, mode|writeMode)
+func (s *xlStorage) openFileSync(filePath string, mode int, skipParent string) (f *os.File, err error) {
+	return s.openFile(filePath, mode|writeMode, skipParent)
 }
 
-func (s *xlStorage) openFile(filePath string, mode int) (f *os.File, err error) {
+func (s *xlStorage) openFile(filePath string, mode int, skipParent string) (f *os.File, err error) {
+	if skipParent == "" {
+		skipParent = s.drivePath
+	}
 	// Create top level directories if they don't exist.
 	// with mode 0777 mkdir honors system umask.
-	if err = mkdirAll(pathutil.Dir(filePath), 0o777, s.drivePath); err != nil {
+	if err = mkdirAll(pathutil.Dir(filePath), 0o777, skipParent); err != nil {
 		return nil, osErrToFileErr(err)
 	}
 
@@ -2095,18 +2114,22 @@ func (s *xlStorage) CreateFile(ctx context.Context, origvolume, volume, path str
 		}
 	}()
 
-	return s.writeAllDirect(ctx, filePath, fileSize, r, os.O_CREATE|os.O_WRONLY|os.O_EXCL)
+	return s.writeAllDirect(ctx, filePath, fileSize, r, os.O_CREATE|os.O_WRONLY|os.O_EXCL, volumeDir)
 }
 
-func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSize int64, r io.Reader, flags int) (err error) {
+func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSize int64, r io.Reader, flags int, skipParent string) (err error) {
 	if contextCanceled(ctx) {
 		return ctx.Err()
+	}
+
+	if skipParent == "" {
+		skipParent = s.drivePath
 	}
 
 	// Create top level directories if they don't exist.
 	// with mode 0777 mkdir honors system umask.
 	parentFilePath := pathutil.Dir(filePath)
-	if err = mkdirAll(parentFilePath, 0o777, s.drivePath); err != nil {
+	if err = mkdirAll(parentFilePath, 0o777, skipParent); err != nil {
 		return osErrToFileErr(err)
 	}
 
@@ -2168,7 +2191,7 @@ func (s *xlStorage) writeAllDirect(ctx context.Context, filePath string, fileSiz
 	return w.Close()
 }
 
-func (s *xlStorage) writeAll(ctx context.Context, volume string, path string, b []byte, sync bool) (err error) {
+func (s *xlStorage) writeAll(ctx context.Context, volume string, path string, b []byte, sync bool, skipParent string) (err error) {
 	if contextCanceled(ctx) {
 		return ctx.Err()
 	}
@@ -2194,11 +2217,11 @@ func (s *xlStorage) writeAll(ctx context.Context, volume string, path string, b 
 		// This is an optimization mainly to ensure faster I/O.
 		if len(b) > xioutil.DirectioAlignSize {
 			r := bytes.NewReader(b)
-			return s.writeAllDirect(ctx, filePath, r.Size(), r, flags)
+			return s.writeAllDirect(ctx, filePath, r.Size(), r, flags, skipParent)
 		}
-		w, err = s.openFileSync(filePath, flags)
+		w, err = s.openFileSync(filePath, flags, skipParent)
 	} else {
-		w, err = s.openFile(filePath, flags)
+		w, err = s.openFile(filePath, flags, skipParent)
 	}
 	if err != nil {
 		return err
@@ -2235,7 +2258,12 @@ func (s *xlStorage) WriteAll(ctx context.Context, volume string, path string, b 
 		s.Unlock()
 	}
 
-	return s.writeAll(ctx, volume, path, b, true)
+	volumeDir, err := s.getVolDir(volume)
+	if err != nil {
+		return err
+	}
+
+	return s.writeAll(ctx, volume, path, b, true, volumeDir)
 }
 
 // AppendFile - append a byte array at path, if file doesn't exist at
@@ -2261,7 +2289,7 @@ func (s *xlStorage) AppendFile(ctx context.Context, volume string, path string, 
 	var w *os.File
 	// Create file if not found. Not doing O_DIRECT here to avoid the code that does buffer aligned writes.
 	// AppendFile() is only used by healing code to heal objects written in old format.
-	w, err = s.openFileSync(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY)
+	w, err = s.openFileSync(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, volumeDir)
 	if err != nil {
 		return err
 	}
@@ -2425,7 +2453,7 @@ func skipAccessChecks(volume string) (ok bool) {
 }
 
 // RenameData - rename source path to destination path atomically, metadata and data directory.
-func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (sign uint64, err error) {
+func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, fi FileInfo, dstVolume, dstPath string, opts RenameOptions) (res RenameDataResp, err error) {
 	defer func() {
 		ignoredErrs := []error{
 			errFileNotFound,
@@ -2451,24 +2479,24 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 
 	srcVolumeDir, err := s.getVolDir(srcVolume)
 	if err != nil {
-		return 0, err
+		return res, err
 	}
 
 	dstVolumeDir, err := s.getVolDir(dstVolume)
 	if err != nil {
-		return 0, err
+		return res, err
 	}
 
 	if !skipAccessChecks(srcVolume) {
 		// Stat a volume entry.
 		if err = Access(srcVolumeDir); err != nil {
-			return 0, convertAccessError(err, errVolumeAccessDenied)
+			return res, convertAccessError(err, errVolumeAccessDenied)
 		}
 	}
 
 	if !skipAccessChecks(dstVolume) {
 		if err = Access(dstVolumeDir); err != nil {
-			return 0, convertAccessError(err, errVolumeAccessDenied)
+			return res, convertAccessError(err, errVolumeAccessDenied)
 		}
 	}
 
@@ -2490,12 +2518,16 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	}
 
 	if err = checkPathLength(srcFilePath); err != nil {
-		return 0, err
+		return res, err
 	}
 
 	if err = checkPathLength(dstFilePath); err != nil {
-		return 0, err
+		return res, err
 	}
+
+	s.RLock()
+	formatLegacy := s.formatLegacy
+	s.RUnlock()
 
 	dstBuf, err := xioutil.ReadFile(dstFilePath)
 	if err != nil {
@@ -2506,20 +2538,22 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		if isSysErrNotDir(err) && runtime.GOOS != globalWindowsOSName {
 			// NOTE: On windows the error happens at
 			// next line and returns appropriate error.
-			return 0, errFileAccessDenied
+			return res, errFileAccessDenied
 		}
 		if !osIsNotExist(err) {
-			return 0, osErrToFileErr(err)
+			return res, osErrToFileErr(err)
 		}
-		// errFileNotFound comes here.
-		err = s.renameLegacyMetadata(dstVolumeDir, dstPath)
-		if err != nil && err != errFileNotFound {
-			return 0, err
-		}
-		if err == nil {
-			dstBuf, err = xioutil.ReadFile(dstFilePath)
-			if err != nil && !osIsNotExist(err) {
-				return 0, osErrToFileErr(err)
+		if formatLegacy {
+			// errFileNotFound comes here.
+			err = s.renameLegacyMetadata(dstVolumeDir, dstPath)
+			if err != nil && err != errFileNotFound {
+				return res, err
+			}
+			if err == nil {
+				dstBuf, err = xioutil.ReadFile(dstFilePath)
+				if err != nil && !osIsNotExist(err) {
+					return res, osErrToFileErr(err)
+				}
 			}
 		}
 	}
@@ -2548,9 +2582,6 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 			}
 		}
 	} else {
-		s.RLock()
-		formatLegacy := s.formatLegacy
-		s.RUnlock()
 		// It is possible that some drives may not have `xl.meta` file
 		// in such scenarios verify if at least `part.1` files exist
 		// to verify for legacy version.
@@ -2562,7 +2593,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 			currentDataPath := pathJoin(dstVolumeDir, dstPath)
 			entries, err := readDirN(currentDataPath, 1)
 			if err != nil && err != errFileNotFound {
-				return 0, osErrToFileErr(err)
+				return res, osErrToFileErr(err)
 			}
 			for _, entry := range entries {
 				if entry == xlStorageFormatFile || strings.HasSuffix(entry, slashSeparator) {
@@ -2576,62 +2607,56 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		}
 	}
 
-	legacyDataPath := pathJoin(dstVolumeDir, dstPath, legacyDataDir)
-	if legacyPreserved {
-		// Preserve all the legacy data, could be slow, but at max there can be 10,000 parts.
-		currentDataPath := pathJoin(dstVolumeDir, dstPath)
-		entries, err := readDir(currentDataPath)
-		if err != nil {
-			return 0, osErrToFileErr(err)
-		}
-
-		// legacy data dir means its old content, honor system umask.
-		if err = mkdirAll(legacyDataPath, 0o777, dstVolumeDir); err != nil {
-			// any failed mkdir-calls delete them.
-			s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
-			return 0, osErrToFileErr(err)
-		}
-
-		for _, entry := range entries {
-			// Skip xl.meta renames further, also ignore any directories such as `legacyDataDir`
-			if entry == xlStorageFormatFile || strings.HasSuffix(entry, slashSeparator) {
-				continue
+	var legacyDataPath string
+	if formatLegacy {
+		legacyDataPath = pathJoin(dstVolumeDir, dstPath, legacyDataDir)
+		if legacyPreserved {
+			// Preserve all the legacy data, could be slow, but at max there can be 1res,000 parts.
+			currentDataPath := pathJoin(dstVolumeDir, dstPath)
+			entries, err := readDir(currentDataPath)
+			if err != nil {
+				return res, osErrToFileErr(err)
 			}
 
-			if err = Rename(pathJoin(currentDataPath, entry), pathJoin(legacyDataPath, entry)); err != nil {
-				// Any failed rename calls un-roll previous transaction.
+			// legacy data dir means its old content, honor system umask.
+			if err = mkdirAll(legacyDataPath, 0o777, dstVolumeDir); err != nil {
+				// any failed mkdir-calls delete them.
 				s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
+				return res, osErrToFileErr(err)
+			}
 
-				return 0, osErrToFileErr(err)
+			for _, entry := range entries {
+				// Skip xl.meta renames further, also ignore any directories such as `legacyDataDir`
+				if entry == xlStorageFormatFile || strings.HasSuffix(entry, slashSeparator) {
+					continue
+				}
+
+				if err = Rename(pathJoin(currentDataPath, entry), pathJoin(legacyDataPath, entry)); err != nil {
+					// Any failed rename calls un-roll previous transaction.
+					s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
+
+					return res, osErrToFileErr(err)
+				}
 			}
 		}
 	}
 
-	var oldDstDataPath, reqVID string
+	// Set skipParent to skip mkdirAll() calls for deeply nested objects
+	// - if its an overwrite
+	// - if its a versioned object
+	//
+	// This can potentiall reduce syscalls by strings.Split(path, "/")
+	// times relative to the object name.
+	skipParent := dstVolumeDir
+	if len(dstBuf) > 0 {
+		skipParent = pathutil.Dir(dstFilePath)
+	}
 
+	var reqVID string
 	if fi.VersionID == "" {
 		reqVID = nullVersionID
 	} else {
 		reqVID = fi.VersionID
-	}
-
-	// Replace the data of null version or any other existing version-id
-	_, ver, err := xlMeta.findVersionStr(reqVID)
-	if err == nil {
-		dataDir := ver.getDataDir()
-		if dataDir != "" && (xlMeta.SharedDataDirCountStr(reqVID, dataDir) == 0) {
-			// Purge the destination path as we are not preserving anything
-			// versioned object was not requested.
-			oldDstDataPath = pathJoin(dstVolumeDir, dstPath, dataDir)
-			// if old destination path is same as new destination path
-			// there is nothing to purge, this is true in case of healing
-			// avoid setting oldDstDataPath at that point.
-			if oldDstDataPath == dstDataPath {
-				oldDstDataPath = ""
-			} else {
-				xlMeta.data.remove(reqVID, dataDir)
-			}
-		}
 	}
 
 	// Empty fi.VersionID indicates that versioning is either
@@ -2651,74 +2676,115 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	}
 
 	// indicates if RenameData() is called by healing.
-	// healing doesn't preserve the dataDir as 'legacy'
-	healing := fi.XLV1 && fi.DataDir != legacyDataDir
+	healing := fi.Healing()
+
+	// Replace the data of null version or any other existing version-id
+	_, ver, err := xlMeta.findVersionStr(reqVID)
+	if err == nil {
+		dataDir := ver.getDataDir()
+		if dataDir != "" && (xlMeta.SharedDataDirCountStr(reqVID, dataDir) == 0) {
+			// Purge the destination path as we are not preserving anything
+			// versioned object was not requested.
+			res.OldDataDir = dataDir
+			if healing {
+				// if old destination path is same as new destination path
+				// there is nothing to purge, this is true in case of healing
+				// avoid setting OldDataDir at that point.
+				res.OldDataDir = ""
+			} else {
+				xlMeta.data.remove(reqVID, dataDir)
+			}
+		}
+	}
 
 	if err = xlMeta.AddVersion(fi); err != nil {
 		if legacyPreserved {
 			// Any failed rename calls un-roll previous transaction.
 			s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
 		}
-		return 0, err
+		return res, err
 	}
 
-	var sbuf bytes.Buffer
-	for _, ver := range xlMeta.versions {
-		sbuf.Write(ver.header.Signature[:])
+	if len(xlMeta.versions) <= 10 {
+		// any number of versions beyond this is excessive
+		// avoid healing such objects in this manner, let
+		// it heal during the regular scanner cycle.
+		dst := []byte{}
+		for _, ver := range xlMeta.versions {
+			dst = slices.Grow(dst, 16)
+			copy(dst[len(dst):], ver.header.VersionID[:])
+		}
+		res.Sign = dst
 	}
-	sign = xxh3.Hash(sbuf.Bytes())
 
-	dstBuf, err = xlMeta.AppendTo(metaDataPoolGet())
-	defer metaDataPoolPut(dstBuf)
+	newDstBuf, err := xlMeta.AppendTo(metaDataPoolGet())
+	defer metaDataPoolPut(newDstBuf)
 	if err != nil {
 		if legacyPreserved {
 			s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
 		}
-		return 0, errFileCorrupt
+		return res, errFileCorrupt
 	}
 
-	if err = s.WriteAll(ctx, srcVolume, pathJoin(srcPath, xlStorageFormatFile), dstBuf); err != nil {
+	if err = s.WriteAll(ctx, srcVolume, pathJoin(srcPath, xlStorageFormatFile), newDstBuf); err != nil {
 		if legacyPreserved {
 			s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
 		}
-		return 0, osErrToFileErr(err)
+		return res, osErrToFileErr(err)
 	}
 	diskHealthCheckOK(ctx, err)
 
-	if srcDataPath != "" && len(fi.Data) == 0 && fi.Size > 0 {
-		// renameAll only for objects that have xl.meta not saved inline.
-		s.moveToTrash(dstDataPath, true, false)
+	notInline := srcDataPath != "" && len(fi.Data) == 0 && fi.Size > 0
+	if notInline {
 		if healing {
+			// renameAll only for objects that have xl.meta not saved inline.
+			// this must be done in healing only, otherwise it is expected
+			// that for fresh PutObject() call dstDataPath can never exist.
+			// if its an overwrite then the caller deletes the DataDir
+			// in a separate RPC call.
+			s.moveToTrash(dstDataPath, true, false)
+
 			// If we are healing we should purge any legacyDataPath content,
 			// that was previously preserved during PutObject() call
 			// on a versioned bucket.
 			s.moveToTrash(legacyDataPath, true, false)
 		}
-		if err = renameAll(srcDataPath, dstDataPath, dstVolumeDir); err != nil {
+		if err = renameAll(srcDataPath, dstDataPath, skipParent); err != nil {
 			if legacyPreserved {
 				// Any failed rename calls un-roll previous transaction.
 				s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
 			}
+			// if its a partial rename() do not attempt to delete recursively.
 			s.deleteFile(dstVolumeDir, dstDataPath, false, false)
-			return 0, osErrToFileErr(err)
+			return res, osErrToFileErr(err)
 		}
 	}
 
+	// When we are not inlined and there is no oldDataDir present
+	// we backup existing xl.meta -> xl.meta.bkp - this is done to
+	// ensure for some reason we didn't get enough quorum we can
+	// revert this back to original xl.meta and preserve the older dataDir.
+	if notInline && res.OldDataDir != "" {
+		// preserve current xl.meta inside the oldDataDir.
+		if err = s.writeAll(ctx, dstVolume, pathJoin(dstPath, res.OldDataDir, xlStorageFormatFileBackup), dstBuf, true, skipParent); err != nil {
+			if legacyPreserved {
+				s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
+			}
+			return res, osErrToFileErr(err)
+		}
+		diskHealthCheckOK(ctx, err)
+	}
+
 	// Commit meta-file
-	if err = renameAll(srcFilePath, dstFilePath, dstVolumeDir); err != nil {
+	if err = renameAll(srcFilePath, dstFilePath, skipParent); err != nil {
 		if legacyPreserved {
 			// Any failed rename calls un-roll previous transaction.
 			s.deleteFile(dstVolumeDir, legacyDataPath, true, false)
 		}
+		// if its a partial rename() do not attempt to delete recursively.
+		// this can be healed since all parts are available.
 		s.deleteFile(dstVolumeDir, dstDataPath, false, false)
-		return 0, osErrToFileErr(err)
-	}
-
-	// additionally only purge older data at the end of the transaction of new data-dir
-	// movement, this is to ensure that previous data references can co-exist for
-	// any recoverability.
-	if oldDstDataPath != "" {
-		s.moveToTrash(oldDstDataPath, true, false)
+		return res, osErrToFileErr(err)
 	}
 
 	if srcVolume != minioMetaMultipartBucket {
@@ -2729,7 +2795,7 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 	} else {
 		s.deleteFile(srcVolumeDir, pathutil.Dir(srcFilePath), true, false)
 	}
-	return sign, nil
+	return res, nil
 }
 
 // RenameFile - rename source path to destination path atomically.
@@ -3047,8 +3113,11 @@ func (s *xlStorage) CleanAbandonedData(ctx context.Context, volume string, path 
 	// Do not abort on context errors.
 	for dir := range foundDirs {
 		toRemove := pathJoin(volumeDir, path, dir+SlashSeparator)
-		err := s.deleteFile(volumeDir, toRemove, true, true)
+		err = s.deleteFile(volumeDir, toRemove, true, true)
 		diskHealthCheckOK(ctx, err)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Do the same for inline data
@@ -3056,32 +3125,38 @@ func (s *xlStorage) CleanAbandonedData(ctx context.Context, volume string, path 
 	if err != nil {
 		return err
 	}
+
 	// Clear and repopulate
 	for k := range foundDirs {
 		delete(foundDirs, k)
 	}
+
 	// Populate into map
 	for _, k := range dirs {
 		foundDirs[k] = struct{}{}
 	}
+
 	// Delete all directories we expect to be there.
 	for _, dir := range wantDirs {
 		delete(foundDirs, dir)
 	}
 
+	// Nothing to delete
+	if len(foundDirs) == 0 {
+		return nil
+	}
+
 	// Delete excessive inline entries.
-	if len(foundDirs) > 0 {
-		// Convert to slice.
-		dirs = dirs[:0]
-		for dir := range foundDirs {
-			dirs = append(dirs, dir)
-		}
-		if xl.data.remove(dirs...) {
-			newBuf, err := xl.AppendTo(metaDataPoolGet())
-			if err == nil {
-				defer metaDataPoolPut(newBuf)
-				return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
-			}
+	// Convert to slice.
+	dirs = dirs[:0]
+	for dir := range foundDirs {
+		dirs = append(dirs, dir)
+	}
+	if xl.data.remove(dirs...) {
+		newBuf, err := xl.AppendTo(metaDataPoolGet())
+		if err == nil {
+			defer metaDataPoolPut(newBuf)
+			return s.WriteAll(ctx, volume, pathJoin(path, xlStorageFormatFile), buf)
 		}
 	}
 	return nil

--- a/docs/bucket/replication/setup_3site_replication.sh
+++ b/docs/bucket/replication/setup_3site_replication.sh
@@ -43,10 +43,7 @@ unset MINIO_KMS_KES_KEY_FILE
 unset MINIO_KMS_KES_ENDPOINT
 unset MINIO_KMS_KES_KEY_NAME
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 wget -q -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
 	chmod +x mc

--- a/docs/distributed/decom-compressed-sse-s3.sh
+++ b/docs/distributed/decom-compressed-sse-s3.sh
@@ -147,10 +147,7 @@ if [ $ret -ne 0 ]; then
 	exit 1
 fi
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 s3-check-md5 -versions -access-key minioadmin -secret-key minioadmin -endpoint http://127.0.0.1:9001/ -bucket versioned
 

--- a/docs/distributed/decom-encrypted-sse-s3.sh
+++ b/docs/distributed/decom-encrypted-sse-s3.sh
@@ -158,10 +158,7 @@ if [ $ret -ne 0 ]; then
 	exit 1
 fi
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 s3-check-md5 -versions -access-key minioadmin -secret-key minioadmin -endpoint http://127.0.0.1:9001/ -bucket versioned
 

--- a/docs/distributed/decom-encrypted.sh
+++ b/docs/distributed/decom-encrypted.sh
@@ -144,10 +144,7 @@ if [ "${expected_checksum}" != "${got_checksum}" ]; then
 	exit 1
 fi
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 s3-check-md5 -versions -access-key minioadmin -secret-key minioadmin -endpoint http://127.0.0.1:9001/ -bucket versioned
 

--- a/docs/distributed/decom.sh
+++ b/docs/distributed/decom.sh
@@ -210,10 +210,7 @@ if [ "${expected_checksum}" != "${got_checksum}" ]; then
 	exit 1
 fi
 
-(
-	cd ./docs/debugging/s3-check-md5
-	go install -v
-)
+go install -v github.com/minio/minio/docs/debugging/s3-check-md5@latest
 
 s3-check-md5 -versions -access-key minioadmin -secret-key minioadmin -endpoint http://127.0.0.1:9001/ -bucket bucket2
 s3-check-md5 -versions -access-key minioadmin -secret-key minioadmin -endpoint http://127.0.0.1:9001/ -bucket versioned

--- a/internal/grid/handlers.go
+++ b/internal/grid/handlers.go
@@ -111,6 +111,7 @@ const (
 	HandlerWriteAll
 	HandlerListBuckets
 	HandlerRenameDataInline
+	HandlerRenameData2
 
 	// Add more above here ^^^
 	// If all handlers are used, the type of Handler can be changed.
@@ -189,6 +190,8 @@ var handlerPrefixes = [handlerLast]string{
 	HandlerConsoleLog:                  peerPrefix,
 	HandlerListDir:                     storagePrefix,
 	HandlerListBuckets:                 peerPrefixS3,
+	HandlerRenameDataInline:            storagePrefix,
+	HandlerRenameData2:                 storagePrefix,
 }
 
 const (

--- a/internal/grid/handlers_string.go
+++ b/internal/grid/handlers_string.go
@@ -81,14 +81,15 @@ func _() {
 	_ = x[HandlerWriteAll-70]
 	_ = x[HandlerListBuckets-71]
 	_ = x[HandlerRenameDataInline-72]
-	_ = x[handlerTest-73]
-	_ = x[handlerTest2-74]
-	_ = x[handlerLast-75]
+	_ = x[HandlerRenameData2-73]
+	_ = x[handlerTest-74]
+	_ = x[handlerTest2-75]
+	_ = x[handlerLast-76]
 }
 
-const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenameDataRenameFileReadAllServerVerifyTraceListenDeleteBucketMetadataLoadBucketMetadataReloadSiteReplicationConfigReloadPoolMetaStopRebalanceLoadRebalanceMetaLoadTransitionTierConfigDeletePolicyLoadPolicyLoadPolicyMappingDeleteServiceAccountLoadServiceAccountDeleteUserLoadUserLoadGroupHealBucketMakeBucketHeadBucketDeleteBucketGetMetricsGetResourceMetricsGetMemInfoGetProcInfoGetOSInfoGetPartitionsGetNetInfoGetCPUsServerInfoGetSysConfigGetSysServicesGetSysErrorsGetAllBucketStatsGetBucketStatsGetSRMetricsGetPeerMetricsGetMetacacheListingUpdateMetacacheListingGetPeerBucketMetricsStorageInfoConsoleLogListDirGetLocksBackgroundHealStatusGetLastDayTierStatsSignalServiceGetBandwidthWriteAllListBucketsRenameDataInlinehandlerTesthandlerTest2handlerLast"
+const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenameDataRenameFileReadAllServerVerifyTraceListenDeleteBucketMetadataLoadBucketMetadataReloadSiteReplicationConfigReloadPoolMetaStopRebalanceLoadRebalanceMetaLoadTransitionTierConfigDeletePolicyLoadPolicyLoadPolicyMappingDeleteServiceAccountLoadServiceAccountDeleteUserLoadUserLoadGroupHealBucketMakeBucketHeadBucketDeleteBucketGetMetricsGetResourceMetricsGetMemInfoGetProcInfoGetOSInfoGetPartitionsGetNetInfoGetCPUsServerInfoGetSysConfigGetSysServicesGetSysErrorsGetAllBucketStatsGetBucketStatsGetSRMetricsGetPeerMetricsGetMetacacheListingUpdateMetacacheListingGetPeerBucketMetricsStorageInfoConsoleLogListDirGetLocksBackgroundHealStatusGetLastDayTierStatsSignalServiceGetBandwidthWriteAllListBucketsRenameDataInlineRenameData2handlerTesthandlerTest2handlerLast"
 
-var _HandlerID_index = [...]uint16{0, 14, 22, 31, 41, 52, 63, 78, 85, 92, 100, 109, 115, 126, 136, 149, 163, 176, 186, 196, 206, 213, 225, 230, 236, 256, 274, 301, 315, 328, 345, 369, 381, 391, 408, 428, 446, 456, 464, 473, 483, 493, 503, 515, 525, 543, 553, 564, 573, 586, 596, 603, 613, 625, 639, 651, 668, 682, 694, 708, 727, 749, 769, 780, 790, 797, 805, 825, 844, 857, 869, 877, 888, 904, 915, 927, 938}
+var _HandlerID_index = [...]uint16{0, 14, 22, 31, 41, 52, 63, 78, 85, 92, 100, 109, 115, 126, 136, 149, 163, 176, 186, 196, 206, 213, 225, 230, 236, 256, 274, 301, 315, 328, 345, 369, 381, 391, 408, 428, 446, 456, 464, 473, 483, 493, 503, 515, 525, 543, 553, 564, 573, 586, 596, 603, 613, 625, 639, 651, 668, 682, 694, 708, 727, 749, 769, 780, 790, 797, 805, 825, 844, 857, 869, 877, 888, 904, 915, 926, 938, 949}
 
 func (i HandlerID) String() string {
 	if i >= HandlerID(len(_HandlerID_index)-1) {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
make renameData() more defensive during overwrites

## Motivation and Context
instead upon any error in renameData(), we still
preserve the existing dataDir in some form for
recoverability in strange situations, such as out
of disk space type errors.

Bonus: avoid running list and heal() instead, allow 
versions disparity to return the actual versions,
UUID to heal. Currently, this can be limited to `0 
versions and fewer disparate objects.

An undo now reverts the `xl.meta` from `xl.meta.bkp` 
during overwrites on such flaky setups.

Bonus: Save N depth syscalls by skipping the parents 
upon overwrites and versioned updates.

Flaky setup examples are stretch clusters with regular 
packet drops, etc. We need to add some defensive code 
to avoid dangling objects.

## How to test this PR?
CI/CD should cover these already.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
