### PR TITLE
fix: ignore signaturev2 for policy header check

### DIFF
--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -610,7 +610,6 @@ func newPostRequestV2(endPoint, bucketName, objectName string, accessKey, secret
 		"key":                         objectName + "/${filename}",
 		"policy":                      encodedPolicy,
 		"signature":                   signature,
-		"X-Amz-Ignore-signature":      "",
 		"X-Amz-Ignore-AWSAccessKeyId": "",
 	}
 

--- a/cmd/postpolicyform.go
+++ b/cmd/postpolicyform.go
@@ -347,8 +347,8 @@ func checkPostPolicy(formValues http.Header, postPolicyForm PostPolicyForm) erro
 		}
 		delete(checkHeader, formCanonicalName)
 	}
-	// For SignV2 - Signature field will be ignore
-	// Policy is generated from Signature with others fields, so it should be ignored
+	// For SignV2 - Signature field will be ignored
+	// Policy is generated from Signature with other fields, so it should be ignored
 	if _, ok := formValues[xhttp.AmzSignatureV2]; ok {
 		delete(checkHeader, xhttp.AmzSignatureV2)
 	}

--- a/cmd/postpolicyform.go
+++ b/cmd/postpolicyform.go
@@ -347,6 +347,11 @@ func checkPostPolicy(formValues http.Header, postPolicyForm PostPolicyForm) erro
 		}
 		delete(checkHeader, formCanonicalName)
 	}
+	// For SignV2 - Signature field will be ignore
+	// Policy is generated from Signature with others fields, so it should be ignored
+	if _, ok := formValues[xhttp.AmzSignatureV2]; ok {
+		delete(checkHeader, xhttp.AmzSignatureV2)
+	}
 
 	if len(checkHeader) != 0 {
 		logKeys := make([]string, 0, len(checkHeader))

--- a/cmd/signature-v4.go
+++ b/cmd/signature-v4.go
@@ -154,7 +154,7 @@ func getSignature(signingKey []byte, stringToSign string) string {
 // Check to see if Policy is signed correctly.
 func doesPolicySignatureMatch(formValues http.Header) (auth.Credentials, APIErrorCode) {
 	// For SignV2 - Signature field will be valid
-	if _, ok := formValues["Signature"]; ok {
+	if _, ok := formValues[xhttp.AmzSignatureV2]; ok {
 		return doesPolicySignatureV2Match(formValues)
 	}
 	return doesPolicySignatureV4Match(formValues)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix https://github.com/minio/minio/issues/19520
 ignore signaturev2 for policy header check
Because this field work fine with `formData: X-Amz-Ignore-signature:""`  or `"policy.conditions":["$start-with" "signature" ""]` only.

## Motivation and Context


## How to test this PR?

UT should cover this.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
