### PR TITLE
Reduce parallelReader allocs

### DIFF
--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -49,11 +49,11 @@ func newParallelReader(readers []io.ReaderAt, e Erasure, offset, totalLength int
 	}
 	bufs := make([][]byte, len(readers))
 	// Fill buffers
-	b := globalBytePoolCap.Get()
+	b := globalBytePoolCap.Load().Get()
 	shardSize := int(e.ShardSize())
 	if cap(b) < len(readers)*shardSize {
 		// We should always have enough capacity, but older objects may be bigger.
-		globalBytePoolCap.Put(b)
+		globalBytePoolCap.Load().Put(b)
 		b = nil
 	} else {
 		// Seed the buffers.
@@ -78,7 +78,7 @@ func newParallelReader(readers []io.ReaderAt, e Erasure, offset, totalLength int
 // Done will release any resources used by the parallelReader.
 func (p *parallelReader) Done() {
 	if p.stashBuffer != nil {
-		globalBytePoolCap.Put(p.stashBuffer)
+		globalBytePoolCap.Load().Put(p.stashBuffer)
 		p.stashBuffer = nil
 	}
 }

--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -38,6 +38,7 @@ type parallelReader struct {
 	shardFileSize int64
 	buf           [][]byte
 	readerToBuf   []int
+	stashBuffer   []byte
 }
 
 // newParallelReader returns parallelReader.
@@ -46,6 +47,21 @@ func newParallelReader(readers []io.ReaderAt, e Erasure, offset, totalLength int
 	for i := range r2b {
 		r2b[i] = i
 	}
+	bufs := make([][]byte, len(readers))
+	// Fill buffers
+	b := globalBytePoolCap.Get()
+	shardSize := int(e.ShardSize())
+	if cap(b) < len(readers)*shardSize {
+		// We should always have enough capacity, but older objects may be bigger.
+		globalBytePoolCap.Put(b)
+		b = nil
+	} else {
+		// Seed the buffers.
+		for i := range bufs {
+			bufs[i] = b[i*shardSize : (i+1)*shardSize]
+		}
+	}
+
 	return &parallelReader{
 		readers:       readers,
 		orgReaders:    readers,
@@ -55,6 +71,15 @@ func newParallelReader(readers []io.ReaderAt, e Erasure, offset, totalLength int
 		shardFileSize: e.ShardFileSize(totalLength),
 		buf:           make([][]byte, len(readers)),
 		readerToBuf:   r2b,
+		stashBuffer:   b,
+	}
+}
+
+// Done will release any resources used by the parallelReader.
+func (p *parallelReader) Done() {
+	if p.stashBuffer != nil {
+		globalBytePoolCap.Put(p.stashBuffer)
+		p.stashBuffer = nil
 	}
 }
 
@@ -224,6 +249,7 @@ func (e Erasure) Decode(ctx context.Context, writer io.Writer, readers []io.Read
 	if len(prefer) == len(readers) {
 		reader.preferReaders(prefer)
 	}
+	defer reader.Done()
 
 	startBlock := offset / e.blockSize
 	endBlock := (offset + length) / e.blockSize
@@ -294,6 +320,7 @@ func (e Erasure) Heal(ctx context.Context, writers []io.Writer, readers []io.Rea
 	if len(readers) == len(prefer) {
 		reader.preferReaders(prefer)
 	}
+	defer reader.Done()
 
 	startBlock := int64(0)
 	endBlock := totalLength / e.blockSize

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -103,8 +103,9 @@ func newErasureServerPools(ctx context.Context, endpointServerPools EndpointServ
 
 	// Initialize byte pool once for all sets, bpool size is set to
 	// setCount * setDriveCount with each memory upto blockSizeV2.
-	globalBytePoolCap = bpool.NewBytePoolCap(n, blockSizeV2, blockSizeV2*2)
-	globalBytePoolCap.Populate()
+	buffers := bpool.NewBytePoolCap(n, blockSizeV2, blockSizeV2*2)
+	buffers.Populate()
+	globalBytePoolCap.Store(buffers)
 
 	var localDrives []StorageAPI
 	local := endpointServerPools.FirstLocal()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -241,7 +241,7 @@ var (
 	globalBucketMonitor     *bandwidth.Monitor
 	globalPolicySys         *PolicySys
 	globalIAMSys            *IAMSys
-	globalBytePoolCap       *bpool.BytePoolCap
+	globalBytePoolCap       atomic.Pointer[bpool.BytePoolCap]
 
 	globalLifecycleSys       *LifecycleSys
 	globalBucketSSEConfigSys *BucketSSEConfigSys

--- a/internal/bpool/bpool.go
+++ b/internal/bpool/bpool.go
@@ -52,6 +52,9 @@ func (bp *BytePoolCap) Populate() {
 // Get gets a []byte from the BytePool, or creates a new one if none are
 // available in the pool.
 func (bp *BytePoolCap) Get() (b []byte) {
+	if bp == nil {
+		return nil
+	}
 	select {
 	case b = <-bp.c:
 		// reuse existing buffer
@@ -68,6 +71,9 @@ func (bp *BytePoolCap) Get() (b []byte) {
 
 // Put returns the given Buffer to the BytePool.
 func (bp *BytePoolCap) Put(b []byte) {
+	if bp == nil {
+		return
+	}
 	select {
 	case bp.c <- b:
 		// buffer went back into pool
@@ -78,10 +84,16 @@ func (bp *BytePoolCap) Put(b []byte) {
 
 // Width returns the width of the byte arrays in this pool.
 func (bp *BytePoolCap) Width() (n int) {
+	if bp == nil {
+		return 0
+	}
 	return bp.w
 }
 
 // WidthCap returns the cap width of the byte arrays in this pool.
 func (bp *BytePoolCap) WidthCap() (n int) {
+	if bp == nil {
+		return 0
+	}
 	return bp.wcap
 }


### PR DESCRIPTION
## Description

Use `globalBytePoolCap` for temporary buffers used by `parallelReader`.

Example `-alloc_space`:

![image](https://github.com/minio/minio/assets/5663952/469059e0-3421-4227-9f5b-afb14371fa1b)

## Motivation and Context

Faster operation

## How to test this PR?

Run reads on medium sized objects.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
