### PR TITLE
Disable trailing header support for MinIO tiers

### DIFF
--- a/cmd/warm-backend-minio.go
+++ b/cmd/warm-backend-minio.go
@@ -113,10 +113,9 @@ func newWarmBackendMinIO(conf madmin.TierMinIO, tier string) (*warmBackendMinIO,
 		getRemoteTierTargetInstanceTransport = NewHTTPTransportWithTimeout(10 * time.Minute)
 	})
 	opts := &minio.Options{
-		Creds:           creds,
-		Secure:          u.Scheme == "https",
-		Transport:       getRemoteTierTargetInstanceTransport,
-		TrailingHeaders: true,
+		Creds:     creds,
+		Secure:    u.Scheme == "https",
+		Transport: getRemoteTierTargetInstanceTransport,
 	}
 	client, err := minio.New(u.Host, opts)
 	if err != nil {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
AWS S3 trailing header support was recently enabled on the warm tier client connection to MinIO type remote tiers. With this enabled, we are seeing the following error message at http transport layer.

> Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n400 Bad Request"; err=<nil>

This is an interim fix until we identify the root cause for this behaviour in the minio-go client package.

## Motivation and Context
To avoid the error message being printed on stdout.

## How to test this PR?
1. Add a remote tier of MinIO type.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
