### PR TITLE
re-use transport and set stronger backwards compatible Ciphers

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -2376,7 +2376,7 @@ func getKubernetesInfo(dctx context.Context) madmin.KubernetesInfo {
 	}
 
 	client := &http.Client{
-		Transport: globalHealthChkTransport,
+		Transport: globalRemoteTargetTransport,
 		Timeout:   10 * time.Second,
 	}
 

--- a/cmd/config-current.go
+++ b/cmd/config-current.go
@@ -678,7 +678,7 @@ func applyDynamicConfigForSubSys(ctx context.Context, objAPI ObjectLayer, s conf
 			}
 		}
 	case config.SubnetSubSys:
-		subnetConfig, err := subnet.LookupConfig(s[config.SubnetSubSys][config.Default], globalProxyTransport)
+		subnetConfig, err := subnet.LookupConfig(s[config.SubnetSubSys][config.Default], globalRemoteTargetTransport)
 		if err != nil {
 			configLogIf(ctx, fmt.Errorf("Unable to parse subnet configuration: %w", err))
 		} else {

--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -1205,7 +1205,7 @@ func GetProxyEndpoints(endpointServerPools EndpointServerPools) []ProxyEndpoint 
 
 			proxyEps = append(proxyEps, ProxyEndpoint{
 				Endpoint:  endpoint,
-				Transport: globalProxyTransport,
+				Transport: globalRemoteTargetTransport,
 			})
 		}
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -398,11 +398,7 @@ var (
 
 	globalInternodeTransport http.RoundTripper
 
-	globalProxyTransport http.RoundTripper
-
 	globalRemoteTargetTransport http.RoundTripper
-
-	globalHealthChkTransport http.RoundTripper
 
 	globalDNSCache = &dnscache.Resolver{
 		Timeout: 5 * time.Second,

--- a/cmd/warm-backend-minio.go
+++ b/cmd/warm-backend-minio.go
@@ -25,7 +25,6 @@ import (
 	"math"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/minio/madmin-go/v3"
 	minio "github.com/minio/minio-go/v7"
@@ -108,14 +107,11 @@ func newWarmBackendMinIO(conf madmin.TierMinIO, tier string) (*warmBackendMinIO,
 	}
 
 	creds := credentials.NewStaticV4(conf.AccessKey, conf.SecretKey, "")
-
-	getRemoteTierTargetInstanceTransportOnce.Do(func() {
-		getRemoteTierTargetInstanceTransport = NewHTTPTransportWithTimeout(10 * time.Minute)
-	})
 	opts := &minio.Options{
-		Creds:     creds,
-		Secure:    u.Scheme == "https",
-		Transport: getRemoteTierTargetInstanceTransport,
+		Creds:           creds,
+		Secure:          u.Scheme == "https",
+		Transport:       globalRemoteTargetTransport,
+		TrailingHeaders: true,
 	}
 	client, err := minio.New(u.Host, opts)
 	if err != nil {

--- a/cmd/warm-backend-s3.go
+++ b/cmd/warm-backend-s3.go
@@ -25,18 +25,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-)
-
-// getRemoteTierTargetInstanceTransport contains a singleton roundtripper.
-var (
-	getRemoteTierTargetInstanceTransport     http.RoundTripper
-	getRemoteTierTargetInstanceTransportOnce sync.Once
 )
 
 type warmBackendS3 struct {
@@ -162,13 +154,10 @@ func newWarmBackendS3(conf madmin.TierS3, tier string) (*warmBackendS3, error) {
 	default:
 		return nil, errors.New("insufficient parameters for S3 backend authentication")
 	}
-	getRemoteTierTargetInstanceTransportOnce.Do(func() {
-		getRemoteTierTargetInstanceTransport = NewHTTPTransportWithTimeout(10 * time.Minute)
-	})
 	opts := &minio.Options{
 		Creds:     creds,
 		Secure:    u.Scheme == "https",
-		Transport: getRemoteTierTargetInstanceTransport,
+		Transport: globalRemoteTargetTransport,
 	}
 	client, err := minio.New(u.Host, opts)
 	if err != nil {

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -18,11 +18,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/minio/madmin-go/v3"
 	xhttp "github.com/minio/minio/internal/http"
@@ -48,8 +48,7 @@ const probeObject = "probeobject"
 // checkWarmBackend checks if tier config credentials have sufficient privileges
 // to perform all operations defined in the WarmBackend interface.
 func checkWarmBackend(ctx context.Context, w WarmBackend) error {
-	var empty bytes.Reader
-	remoteVersionID, err := w.Put(ctx, probeObject, &empty, 0)
+	remoteVersionID, err := w.Put(ctx, probeObject, strings.NewReader("MinIO"), 5)
 	if err != nil {
 		if _, ok := err.(BackendDown); ok {
 			return err


### PR DESCRIPTION



## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
re-use transport and set stronger backwards compatible Ciphers

## Motivation and Context
This PR fixes a few things

- FIPS support for missing remote transports, causing 
  MinIO could end up using non-FIPS Ciphers in FIPS mode

- Avoids too many transports; they all do the same thing 
  to make connection pooling work properly and reuse them.

- globalTCPOptions must be set before transporting to 
  ensure the client's conn deadlines are appropriately honored.

- GCS warm tier must re-use our transport

- Re-enable trailing headers support.

## How to test this PR?
CI/CD would test things already

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
