### PR TITLE
Remove leading zero strings in return value of (*xlMetaV2)getDataDirs()

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1245,7 +1245,7 @@ func (x *xlMetaV2) setIdx(idx int, ver xlMetaV2Version) (err error) {
 // getDataDirs will return all data directories in the metadata
 // as well as all version ids used for inline data.
 func (x *xlMetaV2) getDataDirs() ([]string, error) {
-	dds := make([]string, len(x.versions)*2)
+	dds := make([]string, 0, len(x.versions)*2)
 	for i, ver := range x.versions {
 		if ver.header.Type == DeleteType {
 			continue


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Just a trivial fix of minor mistake.
Variable `dds` is initialized as slice with length `len(x.versions)*2`. But probably it want to mean capacity rather than length. It results leading zero values.
This remove leading zero strings (`""`) in return value of `(*xlMetaV2).getDataDirs()`.

## Motivation and Context
It should improve performance (extremely slightly).

Adding context, I'm developing a static checker and testing it with real-world codes. I'm sorry but I'm not familiar with minio.

## How to test this PR?
Need your help.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] ~Fixes a regression (If yes, please add `commit-id` or `PR #` here)~
- [ ] Unit tests added/updated
- [ ] ~Internal documentation updated~
- [ ] ~Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)~
