### PR TITLE
Fix few wrongly defined metric types

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -907,7 +907,7 @@ func getRepFailedBytesTotalMD(namespace MetricNamespace) MetricDescription {
 		Subsystem: replicationSubsystem,
 		Name:      totalFailedBytes,
 		Help:      "Total number of bytes failed at least once to replicate since server start",
-		Type:      gaugeMetric,
+		Type:      counterMetric,
 	}
 }
 
@@ -917,7 +917,7 @@ func getRepFailedOperationsTotalMD(namespace MetricNamespace) MetricDescription 
 		Subsystem: replicationSubsystem,
 		Name:      totalFailedCount,
 		Help:      "Total number of objects which failed replication since server start",
-		Type:      gaugeMetric,
+		Type:      counterMetric,
 	}
 }
 
@@ -927,7 +927,7 @@ func getRepSentBytesMD(namespace MetricNamespace) MetricDescription {
 		Subsystem: replicationSubsystem,
 		Name:      sentBytes,
 		Help:      "Total number of bytes replicated to the target",
-		Type:      gaugeMetric,
+		Type:      counterMetric,
 	}
 }
 
@@ -951,7 +951,7 @@ func getRepReceivedBytesMD(namespace MetricNamespace) MetricDescription {
 		Subsystem: replicationSubsystem,
 		Name:      receivedBytes,
 		Help:      helpText,
-		Type:      gaugeMetric,
+		Type:      counterMetric,
 	}
 }
 
@@ -3900,7 +3900,7 @@ func getWebhookMetrics() *MetricsGroupV2 {
 					Subsystem: webhookSubsystem,
 					Name:      webhookQueueLength,
 					Help:      "Webhook queue length",
-					Type:      counterMetric,
+					Type:      gaugeMetric,
 				},
 				VariableLabels: labels,
 				Value:          float64(t.Stats().QueueLength),


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

`minio_cluster_webhook_queue_length` was wrongly defined as `counter` whereas it should be `gauge`

Following were wrongly defined as `gauge` when they should actually be `counter`:

- minio_bucket_replication_sent_bytes
- minio_bucket_replication_received_bytes
- minio_bucket_replication_total_failed_bytes
- minio_bucket_replication_total_failed_count

## Motivation and Context

Bugfix

## How to test this PR?

`mc admin prometheus metrics <alias>`

should return correct metric type for the above mentioned metrics.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
