### PR TITLE
Validates PostgreSQL table name

### DIFF
--- a/internal/event/target/postgresql_test.go
+++ b/internal/event/target/postgresql_test.go
@@ -38,8 +38,8 @@ func TestPostgreSQLRegistration(t *testing.T) {
 }
 
 func TestPsqlTableNameValidation(t *testing.T) {
-	validTables := []string{"table", "\"Table name\"", "\"✅✅\"", "table$one", "\"táblë\""}
-	invalidTables := []string{"table name", "table \"name\"", "✅✅", "$table$", "táblë"}
+	validTables := []string{"táblë", "table", "TableName", "\"Table name\"", "\"✅✅\"", "table$one", "\"táblë\""}
+	invalidTables := []string{"table name", "table \"name\"", "✅✅", "$table$"}
 
 	for _, name := range validTables {
 		if err := validatePsqlTableName(name); err != nil {

--- a/internal/event/target/postgresql_test.go
+++ b/internal/event/target/postgresql_test.go
@@ -36,3 +36,19 @@ func TestPostgreSQLRegistration(t *testing.T) {
 		t.Fatal("postgres driver not registered")
 	}
 }
+
+func TestPsqlTableNameValidation(t *testing.T) {
+	validTables := []string{"table", "\"Table name\"", "\"✅✅\"", "table$one", "\"táblë\""}
+	invalidTables := []string{"table name", "table \"name\"", "✅✅", "$table$", "táblë"}
+
+	for _, name := range validTables {
+		if err := validatePsqlTableName(name); err != nil {
+			t.Errorf("Should be valid: %s - %s", name, err)
+		}
+	}
+	for _, name := range invalidTables {
+		if err := validatePsqlTableName(name); err != errInvalidPsqlTablename {
+			t.Errorf("Should be invalid: %s - %s", name, err)
+		}
+	}
+}


### PR DESCRIPTION
The PostgreSQL store can be for submitting events to a table. This table can be configured, but it is inserted using `Sprintf(...)` to generate `INSERT`, `UPDATE`, `DELETE` statements. Despite it being a configuration value (and not originating from user input) it is still a good idea to validate or sanitize the value.

This PR checks the table name and only allows the use of valid PSQL identifiers. Note that [PostgreSQL identifier rules](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS) also allow diacritics as valid identifier names, but they are only accepted here when used with quotes. Creating a regular expression that accepts diacritics is hard and probably not used often.