### PR TITLE
fix: IAM LDAP access key import bug

### DIFF
--- a/cmd/admin-handlers-idp-ldap.go
+++ b/cmd/admin-handlers-idp-ldap.go
@@ -222,9 +222,8 @@ func (a adminAPIHandlers) AddServiceAccountLDAP(w http.ResponseWriter, r *http.R
 		err          error
 	)
 
-	// If we are creating svc account for request sender, ensure
-	// that targetUser is a real user (i.e. not derived
-	// credentials).
+	// If we are creating svc account for request sender, ensure that targetUser
+	// is a real user (i.e. not derived credentials).
 	if isSvcAccForRequestor {
 		if requestorIsDerivedCredential {
 			if requestorParentUser == "" {

--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -1632,9 +1632,10 @@ func (a adminAPIHandlers) SetPolicyForUserOrGroup(w http.ResponseWriter, r *http
 		var err error
 		if isGroup {
 			var foundGroupDN string
-			if foundGroupDN, err = globalIAMSys.LDAPConfig.GetValidatedGroupDN(nil, entityName); err != nil {
+			var underBaseDN bool
+			if foundGroupDN, underBaseDN, err = globalIAMSys.LDAPConfig.GetValidatedGroupDN(nil, entityName); err != nil {
 				iamLogIf(ctx, err)
-			} else if foundGroupDN == "" {
+			} else if foundGroupDN == "" || !underBaseDN {
 				err = errNoSuchGroup
 			}
 			entityName = foundGroupDN

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1441,9 +1441,10 @@ func (c *SiteReplicationSys) PeerPolicyMappingHandler(ctx context.Context, mappi
 		var err error
 		if isGroup {
 			var foundGroupDN string
-			if foundGroupDN, err = globalIAMSys.LDAPConfig.GetValidatedGroupDN(nil, entityName); err != nil {
+			var underBaseDN bool
+			if foundGroupDN, underBaseDN, err = globalIAMSys.LDAPConfig.GetValidatedGroupDN(nil, entityName); err != nil {
 				iamLogIf(ctx, err)
-			} else if foundGroupDN == "" {
+			} else if foundGroupDN == "" || !underBaseDN {
 				err = errNoSuchGroup
 			}
 			entityName = foundGroupDN

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -829,12 +829,14 @@ func TestIAMImportAssetWithLDAP(t *testing.T) {
   }
 }
 `,
+		// The `cn=projecty,..` group below is not under a configured DN, but we
+		// should still import without an error.
 		allSvcAcctsFile: `{
     "u4ccRswj62HV3Ifwima7": {
         "parent": "uid=svc.algorithm,OU=swengg,DC=min,DC=io",
         "accessKey": "u4ccRswj62HV3Ifwima7",
         "secretKey": "ZoEoZdLlzVbOlT9rbhD7ZN7TLyiYXSAlB79uGEge",
-        "groups": ["cn=project.c,ou=groups,OU=swengg,DC=min,DC=io"],
+        "groups": ["cn=project.c,ou=groups,OU=swengg,DC=min,DC=io", "cn=projecty,ou=groups,ou=hwengg,dc=min,dc=io"],
         "claims": {
             "accessKey": "u4ccRswj62HV3Ifwima7",
             "ldapUser": "uid=svc.algorithm,ou=swengg,dc=min,dc=io",


### PR DESCRIPTION

## Description

When importing access keys (i.e. service accounts) for LDAP accounts, we are requiring groups to exist under one of the configured group base DNs. This is not correct. This change fixes this by only checking for existence and storing the normalized form of the group DN - we do not return an error if the group is not under a base DN.

Test is updated to illustrate an import failure that would happen without this change.


## Motivation and Context

This IAM data import bug was found while working with a customer.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
