### PR TITLE
support preserving renameData() on inlined content during overwrites

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2760,11 +2760,9 @@ func (s *xlStorage) RenameData(ctx context.Context, srcVolume, srcPath string, f
 		}
 	}
 
-	// When we are not inlined and there is no oldDataDir present
-	// we backup existing xl.meta -> xl.meta.bkp - this is done to
-	// ensure for some reason we didn't get enough quorum we can
-	// revert this back to original xl.meta and preserve the older dataDir.
-	if notInline && res.OldDataDir != "" {
+	// If we have oldDataDir then we must preserve current xl.meta
+	// as backup, in-case needing renames().
+	if res.OldDataDir != "" {
 		// preserve current xl.meta inside the oldDataDir.
 		if err = s.writeAll(ctx, dstVolume, pathJoin(dstPath, res.OldDataDir, xlStorageFormatFileBackup), dstBuf, true, skipParent); err != nil {
 			if legacyPreserved {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
support preserving renameData() on inlined content during overwrites

## Motivation and Context
extending #19548 to inlined-data as well.

## How to test this PR?
```
minio server /tmp/xl{1...12} &
mc mb myminio/testbucket/
mc cp /etc/hosts myminio/testbucket/

chown -R root. /tmp/xl{1..5}

mc cp /etc/hosts myminio/testbucket/
chown -R harsha. /tmp/xl{1..5}

## this would fail with master
mc cat myminio/testbucket/hosts
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
