### PR TITLE
fix: use MINIO_BROWSER_REDIRECT_URL instead of MINIO_IDENTITY_OPENID_REDIRECT_URI

### DIFF
--- a/helm/minio/templates/deployment.yaml
+++ b/helm/minio/templates/deployment.yaml
@@ -143,8 +143,10 @@ spec:
               value: {{ .Values.oidc.scopes }}
             - name: MINIO_IDENTITY_OPENID_COMMENT
               value: {{ .Values.oidc.comment }}
-            - name: MINIO_IDENTITY_OPENID_REDIRECT_URI
+            {{- if .Values.oidc.redirectUri }}
+            - name: MINIO_BROWSER_REDIRECT_URL
               value: {{ .Values.oidc.redirectUri }}
+            {{- end }}
             - name: MINIO_IDENTITY_OPENID_DISPLAY_NAME
               value: {{ .Values.oidc.displayName }}
             {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -181,8 +181,10 @@ spec:
               value: {{ .Values.oidc.scopes }}
             - name: MINIO_IDENTITY_OPENID_COMMENT
               value: {{ .Values.oidc.comment }}
-            - name: MINIO_IDENTITY_OPENID_REDIRECT_URI
+            {{- if .Values.oidc.redirectUri }}
+            - name: MINIO_BROWSER_REDIRECT_URL
               value: {{ .Values.oidc.redirectUri }}
+            {{- end }}
             - name: MINIO_IDENTITY_OPENID_DISPLAY_NAME
               value: {{ .Values.oidc.displayName }}
             {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -496,7 +496,7 @@ oidc:
   existingClientSecretKey: ""
   claimName: "policy"
   scopes: "openid,profile,email"
-  redirectUri: "https://console-endpoint-url/oauth_callback"
+  redirectUri: ""
   # Can leave empty
   claimPrefix: ""
   comment: ""


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The MINIO_IDENTITY_OPENID_REDIRECT_URI environment was removed in `RELEASE.2023-02-27T18-10-45Z`. And, the `image.tag` in Chart is already `RELEASE.2024-03-03T17-50-39Z`.

## Motivation and Context
If MINIO_BROWSER_REDIRECT_URL is missing, redirection will not work properly when using a reverse proxy.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
