### PR TITLE
add metrics ioerror counter for alerts on I/O errors

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -541,6 +541,16 @@ func getNodeDriveTimeoutErrorsMD() MetricDescription {
 	}
 }
 
+func getNodeDriveIOErrorsMD() MetricDescription {
+	return MetricDescription{
+		Namespace: nodeMetricNamespace,
+		Subsystem: driveSubsystem,
+		Name:      "errors_ioerror",
+		Help:      "Total number of drive I/O errors since server start",
+		Type:      counterMetric,
+	}
+}
+
 func getNodeDriveAvailabilityErrorsMD() MetricDescription {
 	return MetricDescription{
 		Namespace: nodeMetricNamespace,
@@ -3518,6 +3528,12 @@ func getLocalStorageMetrics(opts MetricsGroupOpts) *MetricsGroupV2 {
 				metrics = append(metrics, MetricV2{
 					Description:    getNodeDriveTimeoutErrorsMD(),
 					Value:          float64(disk.Metrics.TotalErrorsTimeout),
+					VariableLabels: map[string]string{"drive": disk.DrivePath},
+				})
+
+				metrics = append(metrics, MetricV2{
+					Description:    getNodeDriveIOErrorsMD(),
+					Value:          float64(disk.Metrics.TotalErrorsAvailability - disk.Metrics.TotalErrorsTimeout),
 					VariableLabels: map[string]string{"drive": disk.DrivePath},
 				})
 

--- a/cmd/metrics-v3-system-drive.go
+++ b/cmd/metrics-v3-system-drive.go
@@ -47,6 +47,7 @@ const (
 	driveFreeInodes              = "free_inodes"
 	driveTotalInodes             = "total_inodes"
 	driveTimeoutErrorsTotal      = "timeout_errors_total"
+	driveIOErrorsTotal           = "io_errors_total"
 	driveAvailabilityErrorsTotal = "availability_errors_total"
 	driveWaitingIO               = "waiting_io"
 	driveAPILatencyMicros        = "api_latency_micros"
@@ -82,6 +83,8 @@ var (
 		"Total inodes available on a drive", allDriveLabels...)
 	driveTimeoutErrorsMD = NewCounterMD(driveTimeoutErrorsTotal,
 		"Total timeout errors on a drive", allDriveLabels...)
+	driveIOErrorsMD = NewCounterMD(driveIOErrorsTotal,
+		"Total I/O errors on a drive", allDriveLabels...)
 	driveAvailabilityErrorsMD = NewCounterMD(driveAvailabilityErrorsTotal,
 		"Total availability errors (I/O errors, timeouts) on a drive",
 		allDriveLabels...)
@@ -167,6 +170,7 @@ func (m *MetricValues) setDriveAPIMetrics(disk madmin.Disk, labels []string) {
 	}
 
 	m.Set(driveTimeoutErrorsTotal, float64(disk.Metrics.TotalErrorsTimeout), labels...)
+	m.Set(driveIOErrorsTotal, float64(disk.Metrics.TotalErrorsAvailability-disk.Metrics.TotalErrorsTimeout), labels...)
 	m.Set(driveAvailabilityErrorsTotal, float64(disk.Metrics.TotalErrorsAvailability), labels...)
 	m.Set(driveWaitingIO, float64(disk.Metrics.TotalWaiting), labels...)
 

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -153,6 +153,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			driveFreeInodesMD,
 			driveTotalInodesMD,
 			driveTimeoutErrorsMD,
+			driveIOErrorsMD,
 			driveAvailabilityErrorsMD,
 			driveWaitingIOMD,
 			driveAPILatencyMD,

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -194,19 +194,20 @@ For deployments with [bucket](https://min.io/docs/minio/linux/administration/buc
 
 ## Drive Metrics
 
-| Name                                   | Description                                                                         |
-|:---------------------------------------|:------------------------------------------------------------------------------------|
-| `minio_node_drive_free_bytes`          | Total storage available on a drive.                                                 |
-| `minio_node_drive_free_inodes`         | Total free inodes.                                                                  |
-| `minio_node_drive_latency_us`          | Average last minute latency in µs for drive API storage operations.                 |
-| `minio_node_drive_offline_total`       | Total drives offline in this node.                                                  |
-| `minio_node_drive_online_total`        | Total drives online in this node.                                                   |
-| `minio_node_drive_total`               | Total drives in this node.                                                          |
-| `minio_node_drive_total_bytes`         | Total storage on a drive.                                                           |
-| `minio_node_drive_used_bytes`          | Total storage used on a drive.                                                      |
-| `minio_node_drive_errors_timeout`      | Total number of drive timeout errors since server start                             |
-| `minio_node_drive_errors_availability` | Total number of drive I/O errors, permission denied and timeouts since server start |
-| `minio_node_drive_io_waiting`          | Total number I/O operations waiting on drive                                        |
+| Name                                   | Description                                                         |
+|:---------------------------------------|:--------------------------------------------------------------------|
+| `minio_node_drive_free_bytes`          | Total storage available on a drive.                                 |
+| `minio_node_drive_free_inodes`         | Total free inodes.                                                  |
+| `minio_node_drive_latency_us`          | Average last minute latency in µs for drive API storage operations. |
+| `minio_node_drive_offline_total`       | Total drives offline in this node.                                  |
+| `minio_node_drive_online_total`        | Total drives online in this node.                                   |
+| `minio_node_drive_total`               | Total drives in this node.                                          |
+| `minio_node_drive_total_bytes`         | Total storage on a drive.                                           |
+| `minio_node_drive_used_bytes`          | Total storage used on a drive.                                      |
+| `minio_node_drive_errors_timeout`      | Total number of drive timeout errors since server start             |
+| `minio_node_drive_errors_ioerror`      | Total number of drive I/O errors since server start                 |
+| `minio_node_drive_errors_availability` | Total number of drive I/O errors, timeouts since server start       |
+| `minio_node_drive_io_waiting`          | Total number I/O operations waiting on drive                        |
 
 ## Identity and Access Management (IAM) Metrics
 

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -110,6 +110,7 @@ The standard metrics groups for ProcessCollector and GoCollector are not shown b
 | `minio_system_drive_free_inodes`               | `gauge`   | Total free inodes on a drive                                       | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_total_inodes`              | `gauge`   | Total inodes available on a drive                                  | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_timeout_errors_total`      | `counter` | Total timeout errors on a drive                                    | `drive,set_index,drive_index,pool_index,server`     |
+| `minio_system_drive_io_errors_total`           | `counter` | Total I/O errors on a drive                                        | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_availability_errors_total` | `counter` | Total availability errors (I/O errors, timeouts) on a drive        | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_waiting_io`                | `gauge`   | Total waiting I/O operations on a drive                            | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_api_latency_micros`        | `gauge`   | Average last minute latency in µs for drive API storage operations | `drive,api,set_index,drive_index,pool_index,server` |


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add metrics ioerror counter for alerts on I/O errors

## Motivation and Context
adds some more granularity to alerts

## How to test this PR?
Simulating I/O error is hard, but this should work
as advertised. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
