### PR TITLE
heal/list: Fix rare incomplete listing with flaky internode connections

### DIFF
--- a/cmd/metacache-set.go
+++ b/cmd/metacache-set.go
@@ -1095,8 +1095,7 @@ func listPathRaw(ctx context.Context, opts listPathRawOptions) (err error) {
 				switch err.Error() {
 				case errFileNotFound.Error(),
 					errVolumeNotFound.Error(),
-					errUnformattedDisk.Error(),
-					errDiskNotFound.Error():
+					errUnformattedDisk.Error():
 					atEOF++
 					fnf++
 					// This is a special case, to handle bucket does


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
listPathRaw() counts errDiskNotFound as a valid error to indicate 
a listing stream end. However, storage.WalkDir() is allowed to
 return errDiskNotFound anytime since grid.ErrDisconnected
 is converted to errDiskNotFound.

This affects fresh disk healing and should affect S3 listing as well.

## Motivation and Context
Fix early new disk healing abort

## How to test this PR?
Hard to reproduce, but it was observed that r.peek() in listPathRaw()
returning errDiskNotFound by simulating a flakky connection.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
