### PR TITLE
iam reload policy mapping of STS users properly

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -1634,6 +1634,8 @@ func (store *IAMStoreSys) PolicyMappingNotificationHandler(ctx context.Context, 
 	switch {
 	case isGroup:
 		m = cache.iamGroupPolicyMap
+	case userType == stsUser:
+		m = cache.iamSTSPolicyMap
 	default:
 		m = cache.iamUserPolicyMap
 	}


### PR DESCRIPTION
Incorrect map was being used - leading to inconsistent policy mapping and enforcement of permissions

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes #18761

## Motivation and Context


## How to test this PR?
in distributed minio with LDAP , attach/detach LDAP policies on one node for a parent user and list entities or perform s3 operations on another node with LDAP sts creds for that user.

Operations should sporadically give inconsistent results, entities listed will also be duplicated/inconsistent

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)  
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
