### PR TITLE
avoid data race for testing

### DIFF
--- a/internal/grid/grid_test.go
+++ b/internal/grid/grid_test.go
@@ -1100,19 +1100,3 @@ func (i State) String() string {
 	}
 	return stateName[stateIndex[i]:stateIndex[i+1]]
 }
-
-func TestDataRace(t *testing.T) {
-	t.Run("TestDataRace", func(t *testing.T) {
-		go func() {
-			defer func() {
-				if e := recover(); e != nil {
-					// if we replace it with `t.Log`. It will have a data race
-					// go test -race --count 10000 -run=TestDataRace
-					fmt.Println(e)
-				}
-			}()
-			panic(errors.New("Do a panic!"))
-		}()
-	})
-	return
-}

--- a/internal/grid/grid_test.go
+++ b/internal/grid/grid_test.go
@@ -470,7 +470,7 @@ func testStreamCancel(t *testing.T, local, remote *Manager) {
 			Handle: func(ctx context.Context, payload []byte, request <-chan []byte, resp chan<- []byte) *RemoteErr {
 				<-ctx.Done()
 				serverCanceled <- struct{}{}
-				t.Log(GetCaller(ctx).Name, "Server Context canceled")
+				fmt.Println(GetCaller(ctx).Name, "Server Context canceled")
 				return nil
 			},
 			OutCapacity: 1,
@@ -480,7 +480,7 @@ func testStreamCancel(t *testing.T, local, remote *Manager) {
 			Handle: func(ctx context.Context, payload []byte, request <-chan []byte, resp chan<- []byte) *RemoteErr {
 				<-ctx.Done()
 				serverCanceled <- struct{}{}
-				t.Log(GetCaller(ctx).Name, "Server Context canceled")
+				fmt.Println(GetCaller(ctx).Name, "Server Context canceled")
 				return nil
 			},
 			OutCapacity: 1,
@@ -1099,4 +1099,20 @@ func (i State) String() string {
 		return "State(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return stateName[stateIndex[i]:stateIndex[i+1]]
+}
+
+func TestDataRace(t *testing.T) {
+	t.Run("TestDataRace", func(t *testing.T) {
+		go func() {
+			defer func() {
+				if e := recover(); e != nil {
+					// if we replace it with `t.Log`. It will have a data race
+					// go test -race --count 10000 -run=TestDataRace
+					fmt.Println(e)
+				}
+			}()
+			panic(errors.New("Do a panic!"))
+		}()
+	})
+	return
 }


### PR DESCRIPTION
aviod data race for testing

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

avoid data race for testing

## Motivation and Context


## How to test this PR?

```
func TestDataRace(t *testing.T) {
	t.Run("TestDataRace", func(t *testing.T) {
		ctx, cancel := context.WithCancel(context.Background())
		defer cancel()
		go func() {
			defer func() {
				if e := recover(); e != nil {
					t.Log(ctx, t, e)
				}
			}()
			panic(errors.New("Do a panic!"))
		}()
	})
	return
}
```
```
go test -race --count 10000 -run=TestDataRace
```

## Types of changes
- [x] Bug fix https://github.com/minio/minio/issues/19295
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
