### PR TITLE
Suppress metrics with zero values

### DIFF
--- a/cmd/metrics-v3-types.go
+++ b/cmd/metrics-v3-types.go
@@ -232,10 +232,13 @@ func (m *MetricValues) Set(name MetricName, value float64, labels ...string) {
 	if !ok {
 		v = make([]metricValue, 0, 1)
 	}
-	m.values[name] = append(v, metricValue{
-		Labels: labelMap,
-		Value:  value,
-	})
+	// If valid non zero value set the metrics
+	if value > 0 {
+		m.values[name] = append(v, metricValue{
+			Labels: labelMap,
+			Value:  value,
+		})
+	}
 }
 
 // SetHistogram - sets values for the given MetricName using the provided
@@ -274,7 +277,10 @@ func (m *MetricValues) SetHistogram(name MetricName, hist *prometheus.HistogramV
 			}
 		}
 		labels = append(labels, extraLabels...)
-		m.Set(name, metric.Value, labels...)
+		// If valid non zero value set the metrics
+		if metric.Value > 0 {
+			m.Set(name, metric.Value, labels...)
+		}
 	}
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This would reduce the size of data in response of metrics listing. While graphing we can default these metrics with a zero value if not found.

## Motivation and Context
A huge amount of data gets responded as part of metrics listing with zero values. This imposes issues for huge clusters and zero value metrics being reported. This way we can reduce the size of data and while graphing we can default the values of such metrics to a zero value.

## How to test this PR?
`curl -XGET -H 'Authorization: Bearer <TOKEN>' http://localhost:9000/minio/metrics/v3/cluster/health`
See that no metrics with zero values get listed (e.g. `minio_cluster_health_nodes_offline_count` in a healthy cluster). Without the PR the metrics with zero values also would get listed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
