### PR TITLE
fix: a crash in RemoveReplication target

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -735,7 +735,7 @@ func (a adminAPIHandlers) ImportBucketMetadataHandler(w http.ResponseWriter, r *
 				rpt.SetStatus(bucket, fileName, fmt.Errorf("An Object Lock configuration is present on this bucket, so the versioning state cannot be suspended."))
 				continue
 			}
-			if _, err := getReplicationConfig(ctx, bucket); err == nil && v.Suspended() {
+			if rcfg, _ := getReplicationConfig(ctx, bucket); rcfg != nil && v.Suspended() {
 				rpt.SetStatus(bucket, fileName, fmt.Errorf("A replication configuration is present on this bucket, so the versioning state cannot be suspended."))
 				continue
 			}

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -998,7 +998,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 	object := ri.Name
 
 	cfg, err := getReplicationConfig(ctx, bucket)
-	if err != nil {
+	if err != nil || cfg == nil {
 		replLogOnceIf(ctx, err, "get-replication-config-"+bucket)
 		sendEvent(eventArgs{
 			EventName:  event.ObjectReplicationNotTracked,

--- a/cmd/bucket-targets.go
+++ b/cmd/bucket-targets.go
@@ -428,7 +428,7 @@ func (sys *BucketTargetSys) RemoveTarget(ctx context.Context, bucket, arnStr str
 	if arn.Type == madmin.ReplicationService {
 		// reject removal of remote target if replication configuration is present
 		rcfg, err := getReplicationConfig(ctx, bucket)
-		if err == nil {
+		if err == nil && rcfg != nil {
 			for _, tgtArn := range rcfg.FilterTargetArns(replication.ObjectOpts{OpType: replication.AllReplicationType}) {
 				if err == nil && (tgtArn == arnStr || rcfg.RoleArn == arnStr) {
 					sys.RLock()

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -958,7 +958,7 @@ func (i *scannerItem) applyLifecycle(ctx context.Context, o ObjectLayer, oi Obje
 	var vc *versioning.Versioning
 	var lr objectlock.Retention
 	var rcfg *replication.Config
-	if i.bucket != minioMetaBucket {
+	if !isMinioMetaBucketName(i.bucket) {
 		vc, err = globalBucketVersioningSys.Get(i.bucket)
 		if err != nil {
 			scannerLogOnceIf(ctx, err, i.bucket)

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -5781,7 +5781,7 @@ func (c *SiteReplicationSys) startResync(ctx context.Context, objAPI ObjectLayer
 
 	for _, bi := range buckets {
 		bucket := bi.Name
-		if _, err := getReplicationConfig(ctx, bucket); err != nil {
+		if _, _, err := globalBucketMetadataSys.GetReplicationConfig(ctx, bucket); err != nil {
 			res.Buckets = append(res.Buckets, madmin.ResyncBucketStatus{
 				ErrDetail: err.Error(),
 				Bucket:    bucket,


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: a crash in RemoveReplication target

## Motivation and Context
calling a remote target to remove with a perfectly
A well-constructed ARN can lead to a crash for a bucket 
with no replication configured.

This PR fixes and adds a crash check for ImportMetadata as well.

## How to test this PR?
You need to run console UI integration tests, which has
a specific case where this is added as a test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression yes from #19563 
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
