### PR TITLE
fix: Filter out cust. AssumeRole `Token` for audit

### DIFF
--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -929,7 +929,9 @@ func (sts *stsAPIHandlers) AssumeRoleWithCustomToken(w http.ResponseWriter, r *h
 	ctx := newContext(r, w, "AssumeRoleWithCustomToken")
 
 	claims := make(map[string]interface{})
-	defer logger.AuditLog(ctx, w, r, claims)
+
+	auditLogFilterKeys := []string{stsToken}
+	defer logger.AuditLog(ctx, w, r, claims, auditLogFilterKeys...)
 
 	if !globalIAMSys.Initialized() {
 		writeSTSErrorResponse(ctx, w, ErrSTSIAMNotInitialized, errIAMNotInitialized)

--- a/docs/auditlog/auditlog-echo.go
+++ b/docs/auditlog/auditlog-echo.go
@@ -1,0 +1,62 @@
+//go:build ignore
+// +build ignore
+
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+var port int
+
+func init() {
+	flag.IntVar(&port, "port", 8080, "Port to listen on")
+}
+
+func mainHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		log.Printf("Error reading request body: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	log.Printf(">>> %s %s\n", r.Method, r.URL.Path)
+	var out bytes.Buffer
+	json.Indent(&out, body, "", "    ")
+	log.Printf("%s\n", out.String())
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func main() {
+	flag.Parse()
+	http.HandleFunc("/", mainHandler)
+
+	log.Printf("Listening on :%d\n", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+}

--- a/docs/auditlog/auditlog-echo.md
+++ b/docs/auditlog/auditlog-echo.md
@@ -1,0 +1,17 @@
+# `auditlog-echo`: A tool to view MinIO Audit logs on the console
+
+1. Run the tool with:
+
+```
+go run docs/auditlog/auditlog-echo.go
+```
+
+The listen port has a default value (8080), but can be set with the `-port` flag.
+
+2. Configure audit logging in MinIO with for example:
+
+```
+mc admin config set myminio audit_webhook enable=on endpoint=http://localhost:8080
+```
+
+3. Make any requests to MinIO and see audit logs printed to the tool's console.

--- a/docs/iam/identity-manager-plugin.go
+++ b/docs/iam/identity-manager-plugin.go
@@ -81,6 +81,6 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/", mainHandler)
 
-	log.Print("Listing on :8081")
+	log.Print("Listening on :8081")
 	log.Fatal(http.ListenAndServe(":8081", nil))
 }


### PR DESCRIPTION

## Description


The `Token` parameter is a sensitive value that should not be output in the Audit log for STS AssumeRoleWithCustomToken API.

Bonus: Add a simple tool that echoes audit logs to the console.

## Motivation and Context

Do not output credentials stored in MinIO server.

## How to test this PR?

Use the auditlog-echo program added in the PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
