### PR TITLE
support compression after rotation of logs

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -205,6 +205,12 @@ var ServerFlags = []cli.Flag{
 		EnvVar: "MINIO_LOG_SIZE",
 		Hidden: true,
 	},
+	cli.BoolFlag{
+		Name:   "log-compress",
+		Usage:  "specify if we want the rotated logs to be gzip compressed or not",
+		EnvVar: "MINIO_LOG_COMPRESS",
+		Hidden: true,
+	},
 }
 
 var serverCmd = cli.Command{
@@ -682,6 +688,7 @@ func initializeLogRotate(ctx *cli.Context) (io.WriteCloser, error) {
 	output, err := logger.NewDir(logger.Options{
 		Directory:       lgDirAbs,
 		MaximumFileSize: int64(lgSize),
+		Compress:        ctx.Bool("log-compress"),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
support compression after rotation of logs

## Motivation and Context
allow gzip compression of logs after
rotation continues on #19641

## How to test this PR?
```
~ minio server ~/test/ --log-dir /tmp/dir --log-size 1024 --log-compress
```

You shall see logs compressed after rotation beyond 1024 bytes per log.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
