### PR TITLE
Change endpoint format for per-bucket metrics

### DIFF
--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -29,9 +29,13 @@ import (
 //
 // These are paths under the top-level /minio/metrics/v3 metrics endpoint. Each
 // of these paths returns a set of V3 metrics.
+//
+// Per-bucket metrics endpoints always start with /bucket and the bucket name is
+// appended to the path. e.g. if the collector path is /bucket/api, the endpoint
+// for the bucket "mybucket" would be /minio/metrics/v3/bucket/api/mybucket
 const (
 	apiRequestsCollectorPath collectorPath = "/api/requests"
-	apiBucketCollectorPath   collectorPath = "/api/bucket"
+	apiBucketCollectorPath   collectorPath = "/bucket/api"
 
 	systemNetworkInternodeCollectorPath collectorPath = "/system/network/internode"
 	systemDriveCollectorPath            collectorPath = "/system/drive"

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -86,18 +86,18 @@ The standard metrics group for GoCollector is not shown below.
 | `minio_api_requests_traffic_sent_bytes`        | `counter` | Total number of bytes sent                              | `type,pool_index,server`         |
 | `minio_api_requests_traffic_received_bytes`    | `counter` | Total number of bytes received                          | `type,pool_index,server`         |
 
-### `/api/bucket`
+### `/bucket/api`
 
 | Name                                         | Type      | Help                                                             | Labels                                  |
 |----------------------------------------------|-----------|------------------------------------------------------------------|-----------------------------------------|
-| `minio_api_bucket_traffic_received_bytes`    | `counter` | Total number of bytes sent for a bucket                          | `bucket,type,server,pool_index`         |
-| `minio_api_bucket_traffic_sent_bytes`        | `counter` | Total number of bytes received for a bucket                      | `bucket,type,server,pool_index`         |
-| `minio_api_bucket_inflight_total`            | `gauge`   | Total number of requests currently in flight for a bucket        | `bucket,name,type,server,pool_index`    |
-| `minio_api_bucket_total`                     | `counter` | Total number of requests for a bucket                            | `bucket,name,type,server,pool_index`    |
-| `minio_api_bucket_canceled_total`            | `counter` | Total number of requests canceled by the client for a bucket     | `bucket,name,type,server,pool_index`    |
-| `minio_api_bucket_4xx_errors_total`          | `counter` | Total number of requests with 4xx errors for a bucket            | `bucket,name,type,server,pool_index`    |
-| `minio_api_bucket_5xx_errors_total`          | `counter` | Total number of requests with 5xx errors for a bucket            | `bucket,name,type,server,pool_index`    |
-| `minio_api_bucket_ttfb_seconds_distribution` | `counter` | Distribution of time to first byte across API calls for a bucket | `bucket,name,le,type,server,pool_index` |
+| `minio_bucket_api_traffic_received_bytes`    | `counter` | Total number of bytes sent for a bucket                          | `bucket,type,server,pool_index`         |
+| `minio_bucket_api_traffic_sent_bytes`        | `counter` | Total number of bytes received for a bucket                      | `bucket,type,server,pool_index`         |
+| `minio_bucket_api_inflight_total`            | `gauge`   | Total number of requests currently in flight for a bucket        | `bucket,name,type,server,pool_index`    |
+| `minio_bucket_api_total`                     | `counter` | Total number of requests for a bucket                            | `bucket,name,type,server,pool_index`    |
+| `minio_bucket_api_canceled_total`            | `counter` | Total number of requests canceled by the client for a bucket     | `bucket,name,type,server,pool_index`    |
+| `minio_bucket_api_4xx_errors_total`          | `counter` | Total number of requests with 4xx errors for a bucket            | `bucket,name,type,server,pool_index`    |
+| `minio_bucket_api_5xx_errors_total`          | `counter` | Total number of requests with 5xx errors for a bucket            | `bucket,name,type,server,pool_index`    |
+| `minio_bucket_api_ttfb_seconds_distribution` | `counter` | Distribution of time to first byte across API calls for a bucket | `bucket,name,le,type,server,pool_index` |
 
 ### `/system/drive`
 


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Per-bucket metrics endpoints always start with /bucket and the bucket name is appended to the path. e.g. if the collector path is `/bucket/api`, the endpoint for the bucket "mybucket" would be
`/minio/metrics/v3/bucket/api/mybucket`

Change the existing bucket api endpoint accordingly from `/api/bucket` to `/bucket/api`

## Motivation and Context

The current query-param based bucket filtering doesn't play well with prometheus scrapers.
So moving the bucket name as a path component.

## How to test this PR?

`curl -v "http://localhost:9010/minio/metrics/v3/bucket/api/<bucketname>"`

should return API metrics for the given bucket

`curl -v "http://localhost:9010/minio/metrics/v3/api"`

should return the overall API metrics

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
