### PR TITLE
Allow DELETE marker when object version reaches the configured MAX versions

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -1100,8 +1100,8 @@ func (x *xlMetaV2) addVersion(ver xlMetaV2Version) error {
 		return err
 	}
 
-	// returns error if we have exceeded configured object max versions
-	if int64(len(x.versions)+1) > globalAPIConfig.getObjectMaxVersions() {
+	// returns error if non DELETE marker versions have exceeded configured object max versions
+	if int64(len(x.versions)+1) > globalAPIConfig.getObjectMaxVersions() && ver.DeleteMarker == nil {
 		return errMaxVersionsExceeded
 	}
 


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

To allow at-most one DEL marker version even after the no of versions reaches the configured MINIO_API_OBJECT_MAX_VERSIONS.

## Motivation and Context
To allow deletion of the object even after the object versions reaches the configured max versions.

## How to test this PR?
- Set `MINIO_API_OBJECT_MAX_VERSIONS=1` env
- Create a versioned bucket and try to upload more than 1 version, it should fail with appropriate error.
- Try to delete the object, it should attach a DEL marker.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
