### PR TITLE
Fix Walk missing entries with opts.Marker set

### DIFF
--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -217,6 +217,27 @@ func prepareErasure(ctx context.Context, nDisks int) (ObjectLayer, []string, err
 		return nil, nil, err
 	}
 
+	// Wait up to 10 seconds for disks to come online.
+	pools := obj.(*erasureServerPools)
+	t := time.Now()
+	for _, pool := range pools.serverPools {
+		for _, sets := range pool.erasureDisks {
+			for _, s := range sets {
+				if !s.IsLocal() {
+					for {
+						if s.IsOnline() {
+							break
+						}
+						time.Sleep(100 * time.Millisecond)
+						if time.Since(t) > 10*time.Second {
+							return nil, nil, errors.New("timeout waiting for disk to come online")
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return obj, fsDirs, nil
 }
 


### PR DESCRIPTION
## Description

'opts.Marker` is causing many missed entries if used since results are returned unsorted. Also since pools are serialized making the marker even less reliable.

Switch to do fully concurrent listing and merging across pools to return sorted entries.

Returning errors on listings is impossible with the current API, so document that.

Return an error at once if no drives are found instead of just returning an empty listing and no error.

## How to test this PR?

Most batch functions uses this. IAM uses it for something.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
