### PR TITLE
extend server config.yaml to support per pool set drive count

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -443,11 +443,8 @@ func checkFormatErasureValues(formats []*formatErasureV3, disks []StorageAPI, se
 			return fmt.Errorf("%s drive is already being used in another erasure deployment. (Number of drives specified: %d but the number of drives found in the %s drive's format.json: %d)",
 				disks[i], len(formats), humanize.Ordinal(i+1), len(formatErasure.Erasure.Sets)*len(formatErasure.Erasure.Sets[0]))
 		}
-		// Only if custom erasure drive count is set, verify if the
-		// set_drive_count was manually set - we need to honor what is
-		// present on the drives.
-		if globalCustomErasureDriveCount && len(formatErasure.Erasure.Sets[0]) != setDriveCount {
-			return fmt.Errorf("%s drive is already formatted with %d drives per erasure set. This cannot be changed to %d, please revert your MINIO_ERASURE_SET_DRIVE_COUNT setting", disks[i], len(formatErasure.Erasure.Sets[0]), setDriveCount)
+		if len(formatErasure.Erasure.Sets[0]) != setDriveCount {
+			return fmt.Errorf("%s drive is already formatted with %d drives per erasure set. This cannot be changed to %d", disks[i], len(formatErasure.Erasure.Sets[0]), setDriveCount)
 		}
 	}
 	return nil

--- a/docs/distributed/CONFIG.md
+++ b/docs/distributed/CONFIG.md
@@ -15,34 +15,57 @@ minio server --config config.yaml
 Lets you start MinIO server with all inputs to start MinIO server provided via this configuration file, once the configuration file is provided all other pre-existing values on disk for configuration are overridden by the new values set in this configuration file.
 
 Following is an example YAML configuration structure.
-```
-version: v1
-address: ':9000'
-rootUser: 'minioadmin'
-rootPassword: 'pBU94AGAY85e'
-console-address: ':9001'
-certs-dir: '/home/user/.minio/certs/'
+```yaml
+version: v2
+address: ":9000"
+rootUser: "minioadmin"
+rootPassword: "minioadmin"
+console-address: ":9001"
+certs-dir: "/home/user/.minio/certs/"
 pools: # Specify the nodes and drives with pools
-  -
-	- 'https://server-example-pool1:9000/mnt/disk{1...4}/'
-	- 'https://server{1...2}-pool1:9000/mnt/disk{1...4}/'
-	- 'https://server3-pool1:9000/mnt/disk{1...4}/'
-	- 'https://server4-pool1:9000/mnt/disk{1...4}/'
-  -
-	- 'https://server-example-pool2:9000/mnt/disk{1...4}/'
-	- 'https://server{1...2}-pool2:9000/mnt/disk{1...4}/'
-	- 'https://server3-pool2:9000/mnt/disk{1...4}/'
-	- 'https://server4-pool2:9000/mnt/disk{1...4}/'
-
-...
+  - args:
+      - "https://server-example-pool1:9000/mnt/disk{1...4}/"
+      - "https://server{1...2}-pool1:9000/mnt/disk{1...4}/"
+      - "https://server3-pool1:9000/mnt/disk{1...4}/"
+      - "https://server4-pool1:9000/mnt/disk{1...4}/"
+  - args:
+      - "https://server-example-pool2:9000/mnt/disk{1...4}/"
+      - "https://server{1...2}-pool2:9000/mnt/disk{1...4}/"
+      - "https://server3-pool2:9000/mnt/disk{1...4}/"
+      - "https://server4-pool2:9000/mnt/disk{1...4}/"
+  # more args
 
 options:
   ftp: # settings for MinIO to act as an ftp server
-	address: ':8021'
-	passive-port-range: '30000-40000'
+    address: ":8021"
+    passive-port-range: "30000-40000"
   sftp: # settings for MinIO to act as an sftp server
-	address: ':8022'
-	ssh-private-key: '/home/user/.ssh/id_rsa'
+    address: ":8022"
+    ssh-private-key: "/home/user/.ssh/id_rsa"
+```
+
+If you are using the config `v1` YAML you should migrate your `pools:` field values to the following format
+
+`v1` format
+```yaml
+pools: # Specify the nodes and drives with pools
+  -
+    - "https://server-example-pool1:9000/mnt/disk{1...4}/"
+    - "https://server{1...2}-pool1:9000/mnt/disk{1...4}/"
+    - "https://server3-pool1:9000/mnt/disk{1...4}/"
+    - "https://server4-pool1:9000/mnt/disk{1...4}/"
+```
+
+to `v2` format
+
+```yaml
+pools:
+  - args:
+      - "https://server-example-pool1:9000/mnt/disk{1...4}/"
+      - "https://server{1...2}-pool1:9000/mnt/disk{1...4}/"
+      - "https://server3-pool1:9000/mnt/disk{1...4}/"
+      - "https://server4-pool1:9000/mnt/disk{1...4}/"
+    set-drive-count: 4 # Advanced option, must be used under guidance from MinIO team.
 ```
 
 ### Things to know

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -29,14 +29,34 @@ type Opts struct {
 	} `yaml:"sftp"`
 }
 
+// ServerConfigVersion struct is used to extract the version
+type ServerConfigVersion struct {
+	Version string `yaml:"version"`
+}
+
+// ServerConfigCommon struct for server config common options
+type ServerConfigCommon struct {
+	RootUser    string `yaml:"rootUser"`
+	RootPwd     string `yaml:"rootPassword"`
+	Addr        string `yaml:"address"`
+	ConsoleAddr string `yaml:"console-address"`
+	CertsDir    string `yaml:"certs-dir"`
+	Options     Opts   `yaml:"options"`
+}
+
+// ServerConfigV1 represents a MinIO configuration file v1
+type ServerConfigV1 struct {
+	ServerConfigVersion
+	ServerConfigCommon
+	Pools [][]string `yaml:"pools"`
+}
+
 // ServerConfig represents a MinIO configuration file
 type ServerConfig struct {
-	Version     string     `yaml:"version"`
-	RootUser    string     `yaml:"rootUser"`
-	RootPwd     string     `yaml:"rootPassword"`
-	Addr        string     `yaml:"address"`
-	ConsoleAddr string     `yaml:"console-address"`
-	CertsDir    string     `yaml:"certs-dir"`
-	Pools       [][]string `yaml:"pools"`
-	Options     Opts       `yaml:"options"`
+	ServerConfigVersion
+	ServerConfigCommon
+	Pools []struct {
+		Args          []string `yaml:"args"`
+		SetDriveCount uint64   `yaml:"set-drive-count"`
+	} `yaml:"pools"`
 }


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
extend server config.yaml to support per pool set drive count

## Motivation and Context
This is to support deployments migrating from a multi-pooled wider stripe to a lower stripe. MINIO_STORAGE_CLASS_STANDARD is still expected to be the same for all pools. So, you can satisfy adding custom drive count-based pools by adjusting the storage class value.

```yaml
version: v2
address: ':9000'
rootUser: 'minioadmin'
rootPassword: 'minioadmin'
console-address: ':9001'
pools: # Specify the nodes and drives with pools
  -
    args:
        - 'node{11...14}.example.net/data{1...4}'
  -
    args:
        - 'node{15...18}.example.net/data{1...4}'
  -
    args:
        - 'node{19...22}.example.net/data{1...4}'
  -
    args:
        - 'node{23...34}.example.net/data{1...10}'
    set-drive-count: 6
```


## How to test this PR?
```
MINIO_STORAGE_CLASS_STANDARD=EC:2 minio server --config config.yaml
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
