### PR TITLE
Rename DelMarkerExpiration to DeletedObjectExpiration

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1322,7 +1322,7 @@ func applyExpiryOnNonTransitionedObjects(ctx context.Context, objLayer ObjectLay
 	case lifecycle.DeleteAllVersionsAction:
 		eventName = event.ObjectRemovedDeleteAllVersions
 	case lifecycle.DelMarkerDeleteAllVersionsAction:
-		eventName = event.ILMDelMarkerExpirationDelete
+		eventName = event.ILMDelObjExpirationDelete
 	}
 	// Notify object deleted event.
 	sendEvent(eventArgs{

--- a/cmd/data-scanner_test.go
+++ b/cmd/data-scanner_test.go
@@ -146,7 +146,7 @@ func TestApplyNewerNoncurrentVersionsLimit(t *testing.T) {
 }
 
 func TestEvalActionFromLifecycle(t *testing.T) {
-	// Tests cover only ExpiredObjectDeleteAllVersions and DelMarkerExpiration actions
+	// Tests cover only ExpiredObjectDeleteAllVersions and DeletedObjectExpiration actions
 	obj := ObjectInfo{
 		Name:        "foo",
 		ModTime:     time.Now().Add(-31 * 24 * time.Hour),
@@ -177,12 +177,12 @@ func TestEvalActionFromLifecycle(t *testing.T) {
 	                 </LifecycleConfiguration>`
 	delMarkerILM := `<LifecycleConfiguration>
                             <Rule>
-                              <ID>DelMarkerExpiration</ID>
+                              <ID>DeletedObjectExpiration</ID>
                               <Filter></Filter>
                               <Status>Enabled</Status>
-                              <DelMarkerExpiration>
+                              <DeletedObjectExpiration>
                                 <Days>60</Days>
-                              </DelMarkerExpiration>
+                              </DeletedObjectExpiration>
                              </Rule>
                        </LifecycleConfiguration>`
 	deleteAllLc, err := lifecycle.ParseLifecycleConfig(strings.NewReader(deleteAllILM))

--- a/internal/bucket/lifecycle/delmarker-expiration.go
+++ b/internal/bucket/lifecycle/delmarker-expiration.go
@@ -22,23 +22,23 @@ import (
 	"time"
 )
 
-var errInvalidDaysDelMarkerExpiration = Errorf("Days must be a positive integer with DelMarkerExpiration")
+var errInvalidDaysDeletedObjExpiration = Errorf("Days must be a positive integer with DeletedObjectExpiration")
 
-// DelMarkerExpiration used to xml encode/decode ILM action by the same name
-type DelMarkerExpiration struct {
-	XMLName xml.Name `xml:"DelMarkerExpiration"`
+// DeletedObjectExpiration used to xml encode/decode ILM action by the same name
+type DeletedObjectExpiration struct {
+	XMLName xml.Name `xml:"DeletedObjectExpiration"`
 	Days    int      `xml:"Days,omitempty"`
 }
 
-// Empty returns if a DelMarkerExpiration XML element is empty.
-// Used to detect if lifecycle.Rule contained a DelMarkerExpiration element.
-func (de DelMarkerExpiration) Empty() bool {
+// Empty returns if a DeletedObjectExpiration XML element is empty.
+// Used to detect if lifecycle.Rule contained a DeletedObjectExpiration element.
+func (de DeletedObjectExpiration) Empty() bool {
 	return de.Days == 0
 }
 
-// UnmarshalXML decodes a single XML element into a DelMarkerExpiration value
-func (de *DelMarkerExpiration) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
-	type delMarkerExpiration DelMarkerExpiration
+// UnmarshalXML decodes a single XML element into a DeletedObjectExpiration value
+func (de *DeletedObjectExpiration) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	type delMarkerExpiration DeletedObjectExpiration
 	var dexp delMarkerExpiration
 	err := dec.DecodeElement(&dexp, &start)
 	if err != nil {
@@ -46,26 +46,26 @@ func (de *DelMarkerExpiration) UnmarshalXML(dec *xml.Decoder, start xml.StartEle
 	}
 
 	if dexp.Days <= 0 {
-		return errInvalidDaysDelMarkerExpiration
+		return errInvalidDaysDeletedObjExpiration
 	}
 
-	*de = DelMarkerExpiration(dexp)
+	*de = DeletedObjectExpiration(dexp)
 	return nil
 }
 
-// MarshalXML encodes a DelMarkerExpiration value into an XML element
-func (de DelMarkerExpiration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+// MarshalXML encodes a DeletedObjectExpiration value into an XML element
+func (de DeletedObjectExpiration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	if de.Empty() {
 		return nil
 	}
 
-	type delMarkerExpiration DelMarkerExpiration
+	type delMarkerExpiration DeletedObjectExpiration
 	return enc.EncodeElement(delMarkerExpiration(de), start)
 }
 
-// NextDue returns upcoming DelMarkerExpiration date for obj if
+// NextDue returns upcoming DeletedObjectExpiration date for obj if
 // applicable, returns false otherwise.
-func (de DelMarkerExpiration) NextDue(obj ObjectOpts) (time.Time, bool) {
+func (de DeletedObjectExpiration) NextDue(obj ObjectOpts) (time.Time, bool) {
 	if !obj.IsLatest || !obj.DeleteMarker {
 		return time.Time{}, false
 	}

--- a/internal/bucket/lifecycle/delmarker-expiration_test.go
+++ b/internal/bucket/lifecycle/delmarker-expiration_test.go
@@ -23,24 +23,24 @@ import (
 	"testing"
 )
 
-func TestDelMarkerExpParseAndValidate(t *testing.T) {
+func TestDelObjExpParseAndValidate(t *testing.T) {
 	tests := []struct {
 		xml string
 		err error
 	}{
 		{
-			xml: `<DelMarkerExpiration> <Days> 1 </Days> </DelMarkerExpiration>`,
+			xml: `<DeletedObjectExpiration> <Days> 1 </Days> </DeletedObjectExpiration>`,
 			err: nil,
 		},
 		{
-			xml: `<DelMarkerExpiration> <Days> -1 </Days> </DelMarkerExpiration>`,
-			err: errInvalidDaysDelMarkerExpiration,
+			xml: `<DeletedObjectExpiration> <Days> -1 </Days> </DeletedObjectExpiration>`,
+			err: errInvalidDaysDeletedObjExpiration,
 		},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("TestDelMarker-%d", i), func(t *testing.T) {
-			var dexp DelMarkerExpiration
+			var dexp DeletedObjectExpiration
 			var fail bool
 			err := xml.Unmarshal([]byte(test.xml), &dexp)
 			if test.err == nil {

--- a/internal/bucket/lifecycle/lifecycle.go
+++ b/internal/bucket/lifecycle/lifecycle.go
@@ -385,9 +385,9 @@ func (lc Lifecycle) eval(obj ObjectOpts, now time.Time) Event {
 			}
 		}
 
-		// DelMarkerExpiration
-		if obj.IsLatest && obj.DeleteMarker && !rule.DelMarkerExpiration.Empty() {
-			if due, ok := rule.DelMarkerExpiration.NextDue(obj); ok && (now.IsZero() || now.After(due)) {
+		// DeletedObjectExpiration
+		if obj.IsLatest && obj.DeleteMarker && !rule.DeletedObjectExpiration.Empty() {
+			if due, ok := rule.DeletedObjectExpiration.NextDue(obj); ok && (now.IsZero() || now.After(due)) {
 				events = append(events, Event{
 					Action: DelMarkerDeleteAllVersionsAction,
 					RuleID: rule.ID,
@@ -396,7 +396,7 @@ func (lc Lifecycle) eval(obj ObjectOpts, now time.Time) Event {
 			}
 			// No other conflicting actions in this rule can apply to an object with current version as DEL marker
 			// Note: There could be other rules with earlier expiration which need to be considered.
-			// See TestDelMarkerExpiration
+			// See TestDeletedObjectExpiration
 			continue
 		}
 

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -121,14 +121,14 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 		},
 		// Lifecycle with delmarker expiration
 		{
-			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Status>Enabled</Status><Filter></Filter><DelMarkerExpiration><Days>5</Days></DelMarkerExpiration></Rule></LifecycleConfiguration>`,
+			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Status>Enabled</Status><Filter></Filter><DeletedObjectExpiration><Days>5</Days></DeletedObjectExpiration></Rule></LifecycleConfiguration>`,
 			expectedParsingErr:    nil,
 			expectedValidationErr: nil,
 		},
 		// Lifecycle with empty delmarker expiration
 		{
-			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Status>Enabled</Status><Filter></Filter><DelMarkerExpiration><Days></Days></DelMarkerExpiration></Rule></LifecycleConfiguration>`,
-			expectedParsingErr:    errInvalidDaysDelMarkerExpiration,
+			inputConfig:           `<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Rule><ID>rule</ID><Status>Enabled</Status><Filter></Filter><DeletedObjectExpiration><Days></Days></DeletedObjectExpiration></Rule></LifecycleConfiguration>`,
+			expectedParsingErr:    errInvalidDaysDeletedObjExpiration,
 			expectedValidationErr: nil,
 		},
 	}
@@ -609,15 +609,15 @@ func TestEval(t *testing.T) {
 			expectedAction:         DeleteVersionAction,
 		},
 		{
-			// DelMarkerExpiration is preferred since object age is past both transition and expiration days.
+			// DeletedObjectExpiration is preferred since object age is past both transition and expiration days.
 			inputConfig: `<LifecycleConfiguration>
                             <Rule>
-                              <ID>DelMarkerExpiration with Transition</ID>
+                              <ID>DeletedObjectExpiration with Transition</ID>
                               <Filter></Filter>
                               <Status>Enabled</Status>
-                              <DelMarkerExpiration>
+                              <DeletedObjectExpiration>
                                 <Days>60</Days>
-                              </DelMarkerExpiration>
+                              </DeletedObjectExpiration>
 	                      <Transition>
                                 <StorageClass>WARM-1</StorageClass>
                                 <Days>30</Days>
@@ -630,16 +630,16 @@ func TestEval(t *testing.T) {
 			expectedAction: DelMarkerDeleteAllVersionsAction,
 		},
 		{
-			// NoneAction since object doesn't qualify for DelMarkerExpiration yet.
+			// NoneAction since object doesn't qualify for DeletedObjectExpiration yet.
 			// Note: TransitionAction doesn't apply to DEL marker
 			inputConfig: `<LifecycleConfiguration>
                             <Rule>
-                              <ID>DelMarkerExpiration with Transition</ID>
+                              <ID>DeletedObjectExpiration with Transition</ID>
                               <Filter></Filter>
                               <Status>Enabled</Status>
-                              <DelMarkerExpiration>
+                              <DeletedObjectExpiration>
                                 <Days>60</Days>
-                              </DelMarkerExpiration>
+                              </DeletedObjectExpiration>
 	                      <Transition>
                                 <StorageClass>WARM-1</StorageClass>
                                 <Days>30</Days>
@@ -654,12 +654,12 @@ func TestEval(t *testing.T) {
 		{
 			inputConfig: `<LifecycleConfiguration>
                             <Rule>
-                              <ID>DelMarkerExpiration with non DEL-marker object</ID>
+                              <ID>DeletedObjectExpiration with non DEL-marker object</ID>
                               <Filter></Filter>
                               <Status>Enabled</Status>
-                              <DelMarkerExpiration>
+                              <DeletedObjectExpiration>
                                 <Days>60</Days>
-                              </DelMarkerExpiration>
+                              </DeletedObjectExpiration>
                              </Rule>
                        </LifecycleConfiguration>`,
 			objectName:     "obj-1",
@@ -669,12 +669,12 @@ func TestEval(t *testing.T) {
 		{
 			inputConfig: `<LifecycleConfiguration>
                             <Rule>
-                              <ID>DelMarkerExpiration with noncurrent DEL-marker</ID>
+                              <ID>DeletedObjectExpiration with noncurrent DEL-marker</ID>
                               <Filter></Filter>
                               <Status>Enabled</Status>
-                              <DelMarkerExpiration>
+                              <DeletedObjectExpiration>
                                 <Days>60</Days>
-                              </DelMarkerExpiration>
+                              </DeletedObjectExpiration>
                              </Rule>
                        </LifecycleConfiguration>`,
 			objectName:             "obj-1",
@@ -1381,7 +1381,7 @@ func TestFilterRules(t *testing.T) {
 
 // TestDeleteAllVersions tests ordering among events, especially ones which
 // expire all versions like ExpiredObjectDeleteAllVersions and
-// DelMarkerExpiration
+// DeletedObjectExpiration
 func TestDeleteAllVersions(t *testing.T) {
 	// ExpiredObjectDeleteAllVersions
 	lc := Lifecycle{
@@ -1424,20 +1424,20 @@ func TestDeleteAllVersions(t *testing.T) {
 		t.Fatalf("Expected due %v but got %v, ruleID=%v", exp, event.Due, event.RuleID)
 	}
 
-	// DelMarkerExpiration
+	// DeletedObjectExpiration
 	lc = Lifecycle{
 		Rules: []Rule{
 			{
 				ID:     "delmarker-exp-20",
 				Status: "Enabled",
-				DelMarkerExpiration: DelMarkerExpiration{
+				DeletedObjectExpiration: DeletedObjectExpiration{
 					Days: 20,
 				},
 			},
 			{
 				ID:     "delmarker-exp-10",
 				Status: "Enabled",
-				DelMarkerExpiration: DelMarkerExpiration{
+				DeletedObjectExpiration: DeletedObjectExpiration{
 					Days: 10,
 				},
 			},

--- a/internal/bucket/lifecycle/rule.go
+++ b/internal/bucket/lifecycle/rule.go
@@ -33,24 +33,24 @@ const (
 
 // Rule - a rule for lifecycle configuration.
 type Rule struct {
-	XMLName             xml.Name            `xml:"Rule"`
-	ID                  string              `xml:"ID,omitempty"`
-	Status              Status              `xml:"Status"`
-	Filter              Filter              `xml:"Filter,omitempty"`
-	Prefix              Prefix              `xml:"Prefix,omitempty"`
-	Expiration          Expiration          `xml:"Expiration,omitempty"`
-	Transition          Transition          `xml:"Transition,omitempty"`
-	DelMarkerExpiration DelMarkerExpiration `xml:"DelMarkerExpiration,omitempty"`
+	XMLName                 xml.Name                `xml:"Rule"`
+	ID                      string                  `xml:"ID,omitempty"`
+	Status                  Status                  `xml:"Status"`
+	Filter                  Filter                  `xml:"Filter,omitempty"`
+	Prefix                  Prefix                  `xml:"Prefix,omitempty"`
+	Expiration              Expiration              `xml:"Expiration,omitempty"`
+	Transition              Transition              `xml:"Transition,omitempty"`
+	DeletedObjectExpiration DeletedObjectExpiration `xml:"DeletedObjectExpiration,omitempty"`
 	// FIXME: add a type to catch unsupported AbortIncompleteMultipartUpload AbortIncompleteMultipartUpload `xml:"AbortIncompleteMultipartUpload,omitempty"`
 	NoncurrentVersionExpiration NoncurrentVersionExpiration `xml:"NoncurrentVersionExpiration,omitempty"`
 	NoncurrentVersionTransition NoncurrentVersionTransition `xml:"NoncurrentVersionTransition,omitempty"`
 }
 
 var (
-	errInvalidRuleID                  = Errorf("ID length is limited to 255 characters")
-	errEmptyRuleStatus                = Errorf("Status should not be empty")
-	errInvalidRuleStatus              = Errorf("Status must be set to either Enabled or Disabled")
-	errInvalidRuleDelMarkerExpiration = Errorf("Rule with DelMarkerExpiration cannot have tags based filtering")
+	errInvalidRuleID               = Errorf("ID length is limited to 255 characters")
+	errEmptyRuleStatus             = Errorf("Status should not be empty")
+	errInvalidRuleStatus           = Errorf("Status must be set to either Enabled or Disabled")
+	errInvalidRuleDelObjExpiration = Errorf("Rule with DeletedObjectExpiration cannot have tags based filtering")
 )
 
 // validateID - checks if ID is valid or not.
@@ -160,10 +160,10 @@ func (r Rule) Validate() error {
 	if err := r.validateNoncurrentTransition(); err != nil {
 		return err
 	}
-	if (!r.Filter.Tag.IsEmpty() || len(r.Filter.And.Tags) != 0) && !r.DelMarkerExpiration.Empty() {
-		return errInvalidRuleDelMarkerExpiration
+	if (!r.Filter.Tag.IsEmpty() || len(r.Filter.And.Tags) != 0) && !r.DeletedObjectExpiration.Empty() {
+		return errInvalidRuleDelObjExpiration
 	}
-	if !r.Expiration.set && !r.Transition.set && !r.NoncurrentVersionExpiration.set && !r.NoncurrentVersionTransition.set && r.DelMarkerExpiration.Empty() {
+	if !r.Expiration.set && !r.Transition.set && !r.NoncurrentVersionExpiration.set && !r.NoncurrentVersionTransition.set && r.DeletedObjectExpiration.Empty() {
 		return errXMLNotWellFormed
 	}
 	return nil

--- a/internal/bucket/lifecycle/rule_test.go
+++ b/internal/bucket/lifecycle/rule_test.go
@@ -107,28 +107,28 @@ func TestInvalidRules(t *testing.T) {
 		},
 		{
 			inputXML: `<Rule>
-				<ID>Rule with a tag and DelMarkerExpiration</ID>
+				<ID>Rule with a tag and DeletedObjectExpiration</ID>
 				<Filter><Tag><Key>k1</Key><Value>v1</Value></Tag></Filter>
-				<DelMarkerExpiration>
+				<DeletedObjectExpiration>
 					<Days>365</Days>
-				</DelMarkerExpiration>
+				</DeletedObjectExpiration>
                             <Status>Enabled</Status>
 	                    </Rule>`,
-			expectedErr: errInvalidRuleDelMarkerExpiration,
+			expectedErr: errInvalidRuleDelObjExpiration,
 		},
 		{
 			inputXML: `<Rule>
-				<ID>Rule with multiple tags and DelMarkerExpiration</ID>
+				<ID>Rule with multiple tags and DeletedObjectExpiration</ID>
 				<Filter><And>
 				<Tag><Key>k1</Key><Value>v1</Value></Tag>
 				<Tag><Key>k2</Key><Value>v2</Value></Tag>
 				</And></Filter>
-				<DelMarkerExpiration>
+				<DeletedObjectExpiration>
 					<Days>365</Days>
-				</DelMarkerExpiration>
+				</DeletedObjectExpiration>
                             <Status>Enabled</Status>
 	                    </Rule>`,
-			expectedErr: errInvalidRuleDelMarkerExpiration,
+			expectedErr: errInvalidRuleDelObjExpiration,
 		},
 	}
 

--- a/internal/event/name.go
+++ b/internal/event/name.go
@@ -63,7 +63,7 @@ const (
 	ObjectManyVersions
 	ObjectLargeVersions
 	PrefixManyFolders
-	ILMDelMarkerExpirationDelete
+	ILMDelObjExpirationDelete
 
 	objectSingleTypesEnd
 	// Start Compound types that require expansion:
@@ -200,8 +200,8 @@ func (name Name) String() string {
 		return "s3:ObjectRemoved:NoOP"
 	case ObjectRemovedDeleteAllVersions:
 		return "s3:ObjectRemoved:DeleteAllVersions"
-	case ILMDelMarkerExpirationDelete:
-		return "s3:LifecycleDelMarkerExpiration:Delete"
+	case ILMDelObjExpirationDelete:
+		return "s3:LifecycleDeletedObjectExpiration:Delete"
 	case ObjectReplicationAll:
 		return "s3:Replication:*"
 	case ObjectReplicationFailed:
@@ -327,8 +327,8 @@ func ParseName(s string) (Name, error) {
 		return ObjectRemovedNoOP, nil
 	case "s3:ObjectRemoved:DeleteAllVersions":
 		return ObjectRemovedDeleteAllVersions, nil
-	case "s3:LifecycleDelMarkerExpiration:Delete":
-		return ILMDelMarkerExpirationDelete, nil
+	case "s3:LifecycleDeletedObjectExpiration:Delete":
+		return ILMDelObjExpirationDelete, nil
 	case "s3:Replication:*":
 		return ObjectReplicationAll, nil
 	case "s3:Replication:OperationFailedReplication":

--- a/internal/event/name_test.go
+++ b/internal/event/name_test.go
@@ -69,7 +69,7 @@ func TestNameString(t *testing.T) {
 		{ObjectRemovedAll, "s3:ObjectRemoved:*"},
 		{ObjectRemovedDelete, "s3:ObjectRemoved:Delete"},
 		{ObjectRemovedDeleteAllVersions, "s3:ObjectRemoved:DeleteAllVersions"},
-		{ILMDelMarkerExpirationDelete, "s3:LifecycleDelMarkerExpiration:Delete"},
+		{ILMDelObjExpirationDelete, "s3:LifecycleDeletedObjectExpiration:Delete"},
 		{ObjectRemovedNoOP, "s3:ObjectRemoved:NoOP"},
 		{ObjectCreatedPutRetention, "s3:ObjectCreated:PutRetention"},
 		{ObjectCreatedPutLegalHold, "s3:ObjectCreated:PutLegalHold"},
@@ -221,7 +221,7 @@ func TestParseName(t *testing.T) {
 		{"s3:ObjectAccessed:*", ObjectAccessedAll, false},
 		{"s3:ObjectRemoved:Delete", ObjectRemovedDelete, false},
 		{"s3:ObjectRemoved:NoOP", ObjectRemovedNoOP, false},
-		{"s3:LifecycleDelMarkerExpiration:Delete", ILMDelMarkerExpirationDelete, false},
+		{"s3:LifecycleDeletedObjectExpiration:Delete", ILMDelObjExpirationDelete, false},
 		{"", blankName, true},
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Rename the recently introduced ILM action DelMarkerExpiration to DeletedObjectExpiration. This action is not yet usable without the necessary client-side support like `mc` for e.g.

## Motivation and Context
DeletedObjectExpiration captures two important consequences of this ILM action better.
1. It applies on a deleted object, i.e an object with DEL marker as its current (latest) version.
2. It removes the entire object, i.e all current and noncurrent versions of a qualifying deleted object.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
