### PR TITLE
support 'mc support perf object' with root login disabled

### DIFF
--- a/cmd/peer-rest-client.go
+++ b/cmd/peer-rest-client.go
@@ -715,6 +715,7 @@ func (client *peerRESTClient) SpeedTest(ctx context.Context, opts speedTestOpts)
 	values.Set(peerRESTStorageClass, opts.storageClass)
 	values.Set(peerRESTBucket, opts.bucketName)
 	values.Set(peerRESTEnableSha256, strconv.FormatBool(opts.enableSha256))
+	values.Set(peerRESTEnableMultipart, strconv.FormatBool(opts.enableMultipart))
 
 	respBody, err := client.callWithContext(context.Background(), peerRESTMethodSpeedTest, values, nil, -1)
 	if err != nil {

--- a/cmd/peer-rest-common.go
+++ b/cmd/peer-rest-common.go
@@ -18,7 +18,7 @@
 package cmd
 
 const (
-	peerRESTVersion       = "v38" // Convert RPC calls
+	peerRESTVersion       = "v39" // add more flags to speedtest API
 	peerRESTVersionPrefix = SlashSeparator + peerRESTVersion
 	peerRESTPrefix        = minioReservedBucketPath + "/peer"
 	peerRESTPath          = peerRESTPrefix + peerRESTVersionPrefix
@@ -38,31 +38,33 @@ const (
 )
 
 const (
-	peerRESTBucket         = "bucket"
-	peerRESTBuckets        = "buckets"
-	peerRESTUser           = "user"
-	peerRESTGroup          = "group"
-	peerRESTUserTemp       = "user-temp"
-	peerRESTPolicy         = "policy"
-	peerRESTUserOrGroup    = "user-or-group"
-	peerRESTUserType       = "user-type"
-	peerRESTIsGroup        = "is-group"
-	peerRESTSignal         = "signal"
-	peerRESTSubSys         = "sub-sys"
-	peerRESTProfiler       = "profiler"
-	peerRESTSize           = "size"
-	peerRESTConcurrent     = "concurrent"
-	peerRESTDuration       = "duration"
-	peerRESTStorageClass   = "storage-class"
-	peerRESTEnableSha256   = "enableSha256"
-	peerRESTMetricsTypes   = "types"
-	peerRESTDisk           = "disk"
-	peerRESTHost           = "host"
-	peerRESTJobID          = "job-id"
-	peerRESTDepID          = "depID"
-	peerRESTStartRebalance = "start-rebalance"
-	peerRESTMetrics        = "metrics"
-	peerRESTDryRun         = "dry-run"
+	peerRESTBucket          = "bucket"
+	peerRESTBuckets         = "buckets"
+	peerRESTUser            = "user"
+	peerRESTGroup           = "group"
+	peerRESTUserTemp        = "user-temp"
+	peerRESTPolicy          = "policy"
+	peerRESTUserOrGroup     = "user-or-group"
+	peerRESTUserType        = "user-type"
+	peerRESTIsGroup         = "is-group"
+	peerRESTSignal          = "signal"
+	peerRESTSubSys          = "sub-sys"
+	peerRESTProfiler        = "profiler"
+	peerRESTSize            = "size"
+	peerRESTConcurrent      = "concurrent"
+	peerRESTDuration        = "duration"
+	peerRESTStorageClass    = "storage-class"
+	peerRESTEnableSha256    = "enableSha256"
+	peerRESTEnableMultipart = "enableMultipart"
+	peerRESTAccessKey       = "access-key"
+	peerRESTMetricsTypes    = "types"
+	peerRESTDisk            = "disk"
+	peerRESTHost            = "host"
+	peerRESTJobID           = "job-id"
+	peerRESTDepID           = "depID"
+	peerRESTStartRebalance  = "start-rebalance"
+	peerRESTMetrics         = "metrics"
+	peerRESTDryRun          = "dry-run"
 
 	peerRESTURL         = "url"
 	peerRESTSha256Sum   = "sha256sum"

--- a/cmd/speedtest.go
+++ b/cmd/speedtest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -27,6 +27,7 @@ import (
 
 	"github.com/minio/dperf/pkg/dperf"
 	"github.com/minio/madmin-go/v3"
+	"github.com/minio/minio/internal/auth"
 	xioutil "github.com/minio/minio/internal/ioutil"
 )
 
@@ -41,6 +42,8 @@ type speedTestOpts struct {
 	storageClass     string
 	bucketName       string
 	enableSha256     bool
+	enableMultipart  bool
+	creds            auth.Credentials
 }
 
 // Get the max throughput and iops numbers.
@@ -107,12 +110,14 @@ func objectSpeedTest(ctx context.Context, opts speedTestOpts) chan madmin.SpeedT
 
 				// if the default concurrency yields zero results, throw an error.
 				if throughputHighestResults[i].Downloads == 0 && opts.concurrencyStart == concurrency {
-					errStr = fmt.Sprintf("no results for downloads upon first attempt, concurrency %d and duration %s", opts.concurrencyStart, opts.duration)
+					errStr = fmt.Sprintf("no results for downloads upon first attempt, concurrency %d and duration %s",
+						opts.concurrencyStart, opts.duration)
 				}
 
 				// if the default concurrency yields zero results, throw an error.
 				if throughputHighestResults[i].Uploads == 0 && opts.concurrencyStart == concurrency {
-					errStr = fmt.Sprintf("no results for uploads upon first attempt, concurrency %d and duration %s", opts.concurrencyStart, opts.duration)
+					errStr = fmt.Sprintf("no results for uploads upon first attempt, concurrency %d and duration %s",
+						opts.concurrencyStart, opts.duration)
 				}
 
 				result.PUTStats.Servers = append(result.PUTStats.Servers, madmin.SpeedTestStatServer{
@@ -160,12 +165,14 @@ func objectSpeedTest(ctx context.Context, opts speedTestOpts) chan madmin.SpeedT
 			}
 
 			sopts := speedTestOpts{
-				objectSize:   opts.objectSize,
-				concurrency:  concurrency,
-				duration:     opts.duration,
-				storageClass: opts.storageClass,
-				bucketName:   opts.bucketName,
-				enableSha256: opts.enableSha256,
+				objectSize:      opts.objectSize,
+				concurrency:     concurrency,
+				duration:        opts.duration,
+				storageClass:    opts.storageClass,
+				bucketName:      opts.bucketName,
+				enableSha256:    opts.enableSha256,
+				enableMultipart: opts.enableMultipart,
+				creds:           opts.creds,
 			}
 
 			results := globalNotificationSys.SpeedTest(ctx, sopts)


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
support 'mc support perf object' with root login disabled

## Motivation and Context
It is expected that whoever is using the credentials which has 
the proper set of permissions must be able to run.

`mc support perf object`

While the root login is disabled.

## How to test this PR?
Turn-off root login and run `mc support perf object` on a registered cluster with admin permissions. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
