### PR TITLE
fix: truncate Expiration to second when Add ServiceAccount

### DIFF
--- a/cmd/admin-handlers-users.go
+++ b/cmd/admin-handlers-users.go
@@ -2476,6 +2476,12 @@ func commonAddServiceAccount(r *http.Request) (context.Context, auth.Credentials
 		return ctx, auth.Credentials{}, newServiceAccountOpts{}, madmin.AddServiceAccountReq{}, "", errorCodes.ToAPIErrWithErr(ErrAdminConfigBadJSON, err)
 	}
 
+	if createReq.Expiration != nil && !createReq.Expiration.IsZero() {
+		// truncate expiration at the second.
+		truncateTime := createReq.Expiration.Truncate(time.Second)
+		createReq.Expiration = &truncateTime
+	}
+
 	// service account access key cannot have space characters beginning and end of the string.
 	if hasSpaceBE(createReq.AccessKey) {
 		return ctx, auth.Credentials{}, newServiceAccountOpts{}, madmin.AddServiceAccountReq{}, "", errorCodes.ToAPIErr(ErrAdminResourceInvalidArgument)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

truncate Expiration at the minute when Add ServiceAccount
Console UI page only support minutes / hours / date

```
package main

import (
	"encoding/json"
	"fmt"
	"time"
)

type A struct {
	Expiration time.Time
}

func main() {
	data := `{"Expiration":"2024-05-04T09:35:47.100Z"}`
	a := A{}
	err := json.Unmarshal([]byte(data), &a)
	if err != nil {
		fmt.Println(err)
		return
	}
	body, err := json.Marshal(a)
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(a)
	fmt.Println(string(body))
	fmt.Println(a.Expiration.Format(time.RFC3339Nano))
	a.Expiration = a.Expiration.Truncate(time.Second)
	fmt.Println(a.Expiration.Format(time.RFC3339Nano))
}
```
```
{2024-05-04 09:35:47.1 +0000 UTC}
{"Expiration":"2024-05-04T09:35:47.1Z"}
2024-05-04T09:35:47.1Z
2024-05-04T09:35:47Z
```
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix #19662 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
