### PR TITLE
Support 'If-None-Match: *' for PUT case

### DIFF
--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -182,7 +182,7 @@ func checkPreconditionsPUT(ctx context.Context, w http.ResponseWriter, r *http.R
 	// one specified otherwise, return a 304 (not modified).
 	ifNoneMatchETagHeader := r.Header.Get(xhttp.IfNoneMatch)
 	if ifNoneMatchETagHeader != "" {
-		if isETagEqual(objInfo.ETag, ifNoneMatchETagHeader) {
+		if ifNoneMatchETagHeader == "*" || isETagEqual(objInfo.ETag, ifNoneMatchETagHeader) {
 			// If the object ETag matches with the specified ETag.
 			writeHeaders()
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrPreconditionFailed), r.URL)


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

The code for If-None-Match works if the etag is specified, but actually the common user case for PUT is to use '*' as the match, which will match any etag, ie will PUT the resource only if there is currently no resource at the location. This is used for simply making sure no resource is overwritten, and is the usual mechanism for handling concurrent updates on object stores. This works elsewhere, eg CLoudflare R2.

Note there are other cases where '*' is allowed, eg in If-match and the copy operations, but these are very rarely used.

## Motivation and Context

Compatibility with other object stores that support conditional updates.

## How to test this PR?

PUT a new object with 'If-None-Match: *' header twice, first time should succeed, second time should fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
