### PR TITLE
grid: Fix a window of a disconnected node not marked as offline

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -867,7 +867,7 @@ func (c *Connection) updateState(s State) {
 		return
 	}
 	if s == StateConnected {
-		atomic.StoreInt64(&c.LastPong, time.Now().UnixNano())
+		atomic.StoreInt64(&c.LastPong, time.Now().Unix())
 	}
 	atomic.StoreUint32((*uint32)(&c.state), uint32(s))
 	if debugPrint {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
LastPong is saved as nanoseconds after a connection or reconnection, 
but it is saved as seconds when receiving a pong message. The code 
deciding if a pong is too old can be skewed since it assumes LastPong 
is only in seconds.


## Motivation and Context
Fixing a case when a PUT object or others are stuck when a node availability fluctuates

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
