### PR TITLE
Consolidate drive health related metrics into single metric

### DIFF
--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -185,8 +185,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			driveAvailabilityErrorsMD,
 			driveWaitingIOMD,
 			driveAPILatencyMD,
-			driveHealingMD,
-			driveOnlineMD,
+			driveHealthMD,
 
 			driveOfflineCountMD,
 			driveOnlineCountMD,

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -117,8 +117,7 @@ The standard metrics group for GoCollector is not shown below.
 | `minio_system_drive_offline_count`             | `gauge`   | Count of offline drives                                            | `pool_index,server`                                 |
 | `minio_system_drive_online_count`              | `gauge`   | Count of online drives                                             | `pool_index,server`                                 |
 | `minio_system_drive_count`                     | `gauge`   | Count of all drives                                                | `pool_index,server`                                 |
-| `minio_system_drive_healing`                   | `gauge`   | Is it healing?                                                     | `drive,set_index,drive_index,pool_index,server`     |
-| `minio_system_drive_online`                    | `gauge`   | Is it online?                                                      | `drive,set_index,drive_index,pool_index,server`     |
+| `minio_system_drive_health`                    | `gauge`   | Drive health (0 = offline, 1 = healthy, 2 = healing)               | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_reads_per_sec`             | `gauge`   | Reads per second on a drive                                        | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_reads_kb_per_sec`          | `gauge`   | Kilobytes read per second on a drive                               | `drive,set_index,drive_index,pool_index,server`     |
 | `minio_system_drive_reads_await`               | `gauge`   | Average time for read requests served on a drive                   | `drive,set_index,drive_index,pool_index,server`     |


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Instead of having "online" and "healing" as two metrics, replace with a single metric "health" which can have following values:

0 = offline
1 = healthy
2 = healing

## Motivation and Context

better metrics

## How to test this PR?

`curl "http://<endpoint>/minio/metrics/v3/system/drive"`

should return a new metric `minio_system_drive_health` in place of the two erstwhile metrics `minio_system_drive_online` and `minio_system_drive_healing` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
