### PR TITLE
pass around correct endpoint while registering remote storage

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1367,7 +1367,7 @@ func registerStorageRESTHandlers(router *mux.Router, endpointServerPools Endpoin
 				OutCapacity: 1,
 			}), "unable to register handler")
 
-			createStorage := func(server *storageRESTServer) bool {
+			createStorage := func(endpoint Endpoint) bool {
 				xl, err := newXLStorage(endpoint, false)
 				if err != nil {
 					// if supported errors don't fail, we proceed to
@@ -1391,19 +1391,19 @@ func registerStorageRESTHandlers(router *mux.Router, endpointServerPools Endpoin
 				return true
 			}
 
-			if createStorage(server) {
+			if createStorage(endpoint) {
 				continue
 			}
 
 			// Start async goroutine to create storage.
-			go func(server *storageRESTServer) {
+			go func(endpoint Endpoint) {
 				for {
 					time.Sleep(3 * time.Second)
-					if createStorage(server) {
+					if createStorage(endpoint) {
 						return
 					}
 				}
-			}(server)
+			}(endpoint)
 
 		}
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
pass around the correct endpoint while registering remote storage

## Motivation and Context
due to loop shadowing, this can show up as a problem

## How to test this PR?
It is tough to reproduce and requires particular conditions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression maybe but this is around since the changes to REST storage registration
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
