### PR TITLE
Add usage cache cleanup and lower forced top compaction

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -53,7 +53,7 @@ const (
 	dataScannerCompactLeastObject    = 500                              // Compact when there is less than this many objects in a branch.
 	dataScannerCompactAtChildren     = 10000                            // Compact when there are this many children in a branch.
 	dataScannerCompactAtFolders      = dataScannerCompactAtChildren / 4 // Compact when this many subfolders in a single folder.
-	dataScannerForceCompactAtFolders = 1_000_000                        // Compact when this many subfolders in a single folder (even top level).
+	dataScannerForceCompactAtFolders = 250_000                          // Compact when this many subfolders in a single folder (even top level).
 	dataScannerStartDelay            = 1 * time.Minute                  // Time to wait on startup and between cycles.
 
 	healDeleteDangling   = true
@@ -349,6 +349,7 @@ func scanDataFolder(ctx context.Context, disks []StorageAPI, basePath string, ca
 		// No useful information...
 		return cache, err
 	}
+	s.newCache.forceCompact(dataScannerCompactAtChildren)
 	s.newCache.Info.LastUpdate = UTCNow()
 	s.newCache.Info.NextCycle = cache.Info.NextCycle
 	return s.newCache, nil

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -765,6 +765,7 @@ func (d *dataUsageCache) forceCompact(limit int) {
 			}
 		}
 	}
+	found[top] = struct{}{}
 	mark(*topE)
 
 	// Delete all entries not found.


### PR DESCRIPTION
## Description

Lower forced compaction to 250K entries.

If there is more than 250K entries on the top level force compact it and log an error. (I don't really expect this to be hit. It should be compacted upstream, but as a double safety)

## How to test this PR?

Dump a huge amount of objects in the root of a bucket.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
