### PR TITLE
Capture ttfb api metrics only for GetObject

### DIFF
--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -27,6 +27,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	apiGetObject = "GetObject"
+)
+
 // connStats - Network statistics
 // Count total input/output transferred bytes during
 // the server's life.
@@ -128,7 +132,7 @@ func (bh *bucketHTTPStats) updateHTTPStats(bucket, api string, w *xhttp.Response
 		return
 	}
 
-	if w != nil {
+	if w != nil && api == apiGetObject {
 		// Increment the prometheus http request response histogram with API, Bucket
 		bucketHTTPRequestsDuration.With(prometheus.Labels{
 			"api":    api,
@@ -433,7 +437,9 @@ func (st *HTTPStats) updateStats(api string, w *xhttp.ResponseRecorder) {
 	st.totalS3Requests.Inc(api)
 
 	// Increment the prometheus http request response histogram with appropriate label
-	httpRequestsDuration.With(prometheus.Labels{"api": api}).Observe(w.TimeToFirstByte.Seconds())
+	if api == apiGetObject {
+		httpRequestsDuration.With(prometheus.Labels{"api": api}).Observe(w.TimeToFirstByte.Seconds())
+	}
 
 	code := w.StatusCode
 


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

as that is the only api where the ttfb metric is really useful, and capturing this for all apis exponentially increases the response size in large clusters.

## Motivation and Context

keep response size of api metrics as small as possible

## How to test this PR?

- perform a variety of operations on the cluster
- verify that following api calls:
  - `curl -v "http://<endpoint>/minio/metrics/v3/api" | grep -i ttfb`
  - `curl -v "http://<endpoint>/minio/metrics/v3/bucket/api/<bucket-name>" | grep -i ttfb`
  return metrics only for the `GetObject` api

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
