### PR TITLE
SFTP: Correctly inform client about unsupported commands

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -342,7 +342,7 @@ func (f *sftpDriver) Filecmd(r *sftp.Request) (err error) {
 
 	switch r.Method {
 	case "Setstat", "Rename", "Link", "Symlink":
-		return NotImplemented{}
+		return sftp.ErrSSHFxOpUnsupported
 
 	case "Rmdir":
 		bucket, prefix := path2BucketObject(r.Filepath)


### PR DESCRIPTION
## Description
Currently when user try rename file over SFTP the client will show non-user friendly error message.
Here is how it looks with sftp command line client:
```
sftp> rename test1.txt test2.txt
Couldn't rename file "/bucket/test1.txt" to "/bucket/test2.txt": Failure
```
and WinSCP error message is visible in #17505

## How to test this PR?
After this change in sftp command line client it looks like this:
```
sftp> rename test1.txt test2.txt
Couldn't rename file "/bucket/test1.txt" to "/bucket/test2.txt": Operation unsupported
```
and WinSCP it looks like this:
![image](https://github.com/minio/minio/assets/6213926/41a736c0-e46c-4a17-94a0-f78ba9a81942)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
