### PR TITLE
Return NumVersions in quorum when available

### DIFF
--- a/cmd/erasure-metadata-utils.go
+++ b/cmd/erasure-metadata-utils.go
@@ -26,6 +26,20 @@ import (
 	"github.com/minio/pkg/v2/sync/errgroup"
 )
 
+// counterMap type adds GetValueWithQuorum method to a map[T]int used to count occurrences of values of type T.
+type counterMap[T comparable] map[T]int
+
+// GetValueWithQuorum returns the first key which occurs >= quorum number of times.
+func (c counterMap[T]) GetValueWithQuorum(quorum int) (T, bool) {
+	var zero T
+	for x, count := range c {
+		if count >= quorum {
+			return x, true
+		}
+	}
+	return zero, false
+}
+
 // figure out the most commonVersions across disk that satisfies
 // the 'writeQuorum' this function returns "" if quorum cannot
 // be achieved and disks have too many inconsistent versions.

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -344,9 +344,14 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 		return FileInfo{}, InsufficientReadQuorum{Err: errErasureReadQuorum, Type: RQInconsistentMeta}
 	}
 
-	// Find the successor mod time in quorum, otherwise leave the
-	// candidate's successor modTime as found
-	succModTimeMap := make(map[time.Time]int)
+	// objProps represents properties that go beyond a single version
+	type objProps struct {
+		succModTime time.Time
+		numVersions int
+	}
+	// Find the successor mod time and numVersions in quorum, otherwise leave the
+	// candidate as found
+	otherPropsMap := make(counterMap[objProps])
 	var candidate FileInfo
 	var found bool
 	for i, hash := range metaHashes {
@@ -356,24 +361,21 @@ func findFileInfoInQuorum(ctx context.Context, metaArr []FileInfo, modTime time.
 					candidate = metaArr[i]
 					found = true
 				}
-				succModTimeMap[metaArr[i].SuccessorModTime]++
+				props := objProps{
+					succModTime: metaArr[i].SuccessorModTime,
+					numVersions: metaArr[i].NumVersions,
+				}
+				otherPropsMap[props]++
 			}
-		}
-	}
-	var succModTime time.Time
-	var smodTimeQuorum bool
-	for smodTime, count := range succModTimeMap {
-		if count >= quorum {
-			smodTimeQuorum = true
-			succModTime = smodTime
-			break
 		}
 	}
 
 	if found {
-		if smodTimeQuorum {
-			candidate.SuccessorModTime = succModTime
-			candidate.IsLatest = succModTime.IsZero()
+		// Update candidate FileInfo with succModTime and numVersions in quorum when available
+		if props, ok := otherPropsMap.GetValueWithQuorum(quorum); ok {
+			candidate.SuccessorModTime = props.succModTime
+			candidate.IsLatest = props.succModTime.IsZero()
+			candidate.NumVersions = props.numVersions
 		}
 		return candidate, nil
 	}


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This can happen when the ObjectInfo value constructed from a quorum number of drives had its NumVersions field (incorrectly) set to zero. This is possible, however improbable, when the ObjectInfo (from a candidate of drives in quorum)  picked had an incorrect NumVersions value. 

Consider an object which has two versions where the current version is a DEL marker and the noncurrent version is a regular object.
e.g,
```
$ mc ls --versions play/krisis/obj-1
[2024-05-17 10:17:23 PDT]     0B STANDARD 95a561b3-f91f-46cb-a538-87f3b04adbf5 v2 DEL obj-1
[2024-05-17 10:17:21 PDT]    20B STANDARD dd5853a6-6932-4c05-95d9-96fab07eff78 v1 PUT obj-1

```

This can happen when,
- the DEL marker version is present on all the drives in this erasure set.
- the PUT version (noncurrent) is present in quorum drives
- There are a few drives that are present in the first quorum but not in the second quorum.

When MinIO picks a valid ObjectInfo value constructed, it could pick the one from a drive not present in the second quorum (i.e for the PUT version). This affects ObjectInfo fields that are not object specific, like NumVersions.
This PR looks for a quorum agreed value for NumVersions if available. This is similar to https://github.com/minio/minio/pull/17925

## How to test this PR?
Unit tests in erasure-metadata_test.go capture this possibility.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
