### PR TITLE
re-use StorageAPI while loading drive formats

### DIFF
--- a/internal/logger/console.go
+++ b/internal/logger/console.go
@@ -69,13 +69,16 @@ func Fatal(err error, msg string, data ...interface{}) {
 }
 
 func fatal(err error, msg string, data ...interface{}) {
-	var errMsg string
-	if msg != "" {
-		errMsg = errorFmtFunc(fmt.Sprintf(msg, data...), err, jsonFlag)
+	if msg == "" {
+		if len(data) > 0 {
+			msg = fmt.Sprint(data...)
+		} else {
+			msg = "a fatal error"
+		}
 	} else {
-		errMsg = err.Error()
+		msg = fmt.Sprintf(msg, data...)
 	}
-	consoleLog(fatalMessage, errMsg)
+	consoleLog(fatalMessage, errorFmtFunc(msg, err, jsonFlag))
 }
 
 var fatalMessage fatalMsg
@@ -183,13 +186,14 @@ func (i infoMsg) quiet(msg string, args ...interface{}) {
 func (i infoMsg) pretty(msg string, args ...interface{}) {
 	if msg == "" {
 		fmt.Fprintln(Output, args...)
+	} else {
+		fmt.Fprintf(Output, msg, args...)
 	}
-	fmt.Fprintf(Output, msg, args...)
 }
 
 type errorMsg struct{}
 
-var errorm errorMsg
+var errorMessage errorMsg
 
 func (i errorMsg) json(msg string, args ...interface{}) {
 	var message string
@@ -217,8 +221,9 @@ func (i errorMsg) quiet(msg string, args ...interface{}) {
 func (i errorMsg) pretty(msg string, args ...interface{}) {
 	if msg == "" {
 		fmt.Fprintln(Output, args...)
+	} else {
+		fmt.Fprintf(Output, msg, args...)
 	}
-	fmt.Fprintf(Output, msg, args...)
 }
 
 // Error :
@@ -226,7 +231,7 @@ func Error(msg string, data ...interface{}) {
 	if DisableErrorLog {
 		return
 	}
-	consoleLog(errorm, msg, data...)
+	consoleLog(errorMessage, msg, data...)
 }
 
 // Info :


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
re-use StorageAPI while loading drive formats

## Motivation and Context
Bonus: safe settings for deployment ID to avoid races

## How to test this PR?
Nothing generally should change, instead, this should
provide speed up and more re-usability of the buffers
and avoids short-lived goroutines, if any.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
