### PR TITLE
xl: Avoid marking a drive offline after one part read failure

### DIFF
--- a/cmd/erasure-decode.go
+++ b/cmd/erasure-decode.go
@@ -202,6 +202,9 @@ func (p *parallelReader) Read(dst [][]byte) ([][]byte, error) {
 
 				// This will be communicated upstream.
 				p.orgReaders[bufIdx] = nil
+				if br, ok := p.readers[i].(io.Closer); ok {
+					br.Close()
+				}
 				p.readers[i] = nil
 
 				// Since ReadAt returned error, trigger another read.

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -425,11 +425,6 @@ func (er erasureObjects) getObjectWithFileInfo(ctx context.Context, bucket, obje
 				return toObjectErr(err, bucket, object)
 			}
 		}
-		for i, r := range readers {
-			if r == nil {
-				onlineDisks[i] = OfflineDisk
-			}
-		}
 		// Track total bytes read from disk and written to the client.
 		totalBytesRead += partLength
 		// partOffset will be valid only for the first part, hence reset it to 0 for


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This commit will fix one rare case of a multipart object that can be read 
in theory but GetObject API returned an error.

It turned out that a six years old code was marking a drive offline when
the bitrot streaming fails to read a part in a disk with any error. This can affect
reading a subsequent part, though having enough shards, but unable to construct
because one drive was marked offline earlier.

This commit will remove the drive marking offline code. It will also close the 
bitstreaming reader before marking it as nil.


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
