### PR TITLE
fix: reject ilm rule when bucket LockEnabled

### DIFF
--- a/cmd/admin-bucket-handlers.go
+++ b/cmd/admin-bucket-handlers.go
@@ -837,9 +837,13 @@ func (a adminAPIHandlers) ImportBucketMetadataHandler(w http.ResponseWriter, r *
 				rpt.SetStatus(bucket, fileName, err)
 				continue
 			}
-
+			rcfg, err := globalBucketObjectLockSys.Get(bucket)
+			if err != nil {
+				rpt.SetStatus(bucket, fileName, err)
+				continue
+			}
 			// Validate the received bucket policy document
-			if err = bucketLifecycle.Validate(); err != nil {
+			if err = bucketLifecycle.Validate(rcfg); err != nil {
 				rpt.SetStatus(bucket, fileName, err)
 				continue
 			}

--- a/cmd/bucket-lifecycle-handlers.go
+++ b/cmd/bucket-lifecycle-handlers.go
@@ -64,7 +64,8 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	}
 
 	// Check if bucket exists.
-	if _, err := objAPI.GetBucketInfo(ctx, bucket, BucketOptions{}); err != nil {
+	rcfg, err := globalBucketObjectLockSys.Get(bucket)
+	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}
@@ -76,7 +77,7 @@ func (api objectAPIHandlers) PutBucketLifecycleHandler(w http.ResponseWriter, r 
 	}
 
 	// Validate the received bucket policy document
-	if err = bucketLifecycle.Validate(); err != nil {
+	if err = bucketLifecycle.Validate(rcfg); err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 		return
 	}

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -6211,7 +6211,13 @@ func mergeWithCurrentLCConfig(ctx context.Context, bucket string, expLCCfg *stri
 		Rules:           rules,
 		ExpiryUpdatedAt: &updatedAt,
 	}
-	if err := finalLcCfg.Validate(); err != nil {
+
+	rcfg, err := globalBucketObjectLockSys.Get(bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := finalLcCfg.Validate(rcfg); err != nil {
 		return []byte{}, err
 	}
 	finalConfigData, err := xml.Marshal(finalLcCfg)

--- a/internal/bucket/lifecycle/lifecycle_test.go
+++ b/internal/bucket/lifecycle/lifecycle_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
+	"github.com/minio/minio/internal/bucket/object/lock"
 	xhttp "github.com/minio/minio/internal/http"
 )
 
@@ -144,7 +145,7 @@ func TestParseAndValidateLifecycleConfig(t *testing.T) {
 				// no need to continue this test.
 				return
 			}
-			err = lc.Validate()
+			err = lc.Validate(lock.Retention{})
 			if err != tc.expectedValidationErr {
 				t.Fatalf("%d: Expected %v during validation but got %v", i+1, tc.expectedValidationErr, err)
 			}
@@ -779,7 +780,7 @@ func TestHasActiveRules(t *testing.T) {
 				t.Fatalf("Got unexpected error: %v", err)
 			}
 			// To ensure input lifecycle configurations are valid
-			if err := lc.Validate(); err != nil {
+			if err := lc.Validate(lock.Retention{}); err != nil {
 				t.Fatalf("Invalid test case: %d %v", i+1, err)
 			}
 			if got := lc.HasActiveRules(tc.prefix); got != tc.want {
@@ -1365,7 +1366,7 @@ func TestFilterRules(t *testing.T) {
 
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("test-%d", i+1), func(t *testing.T) {
-			if err := tc.lc.Validate(); err != nil {
+			if err := tc.lc.Validate(lock.Retention{}); err != nil {
 				t.Fatalf("Lifecycle validation failed - %v", err)
 			}
 			rules := tc.lc.FilterRules(tc.opts)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: reject ilm rule
https://github.com/minio/minio/blob/9667a170de51cc583c8baad78dbda1da1367e10d/cmd/data-scanner.go#L1203-L1230
We should reject the ilm rule when config.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
