### PR TITLE
usage of deadline conn at Accept() breaks websocket

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -407,10 +407,6 @@ func buildServerCtxt(ctx *cli.Context, ctxt *serverCtxt) (err error) {
 
 	ctxt.Interface = ctx.String("interface")
 	ctxt.UserTimeout = ctx.Duration("conn-user-timeout")
-	ctxt.ConnReadDeadline = ctx.Duration("conn-read-deadline")
-	ctxt.ConnWriteDeadline = ctx.Duration("conn-write-deadline")
-	ctxt.ConnClientReadDeadline = ctx.Duration("conn-client-read-deadline")
-	ctxt.ConnClientWriteDeadline = ctx.Duration("conn-client-write-deadline")
 	ctxt.SendBufSize = ctx.Int("send-buf-size")
 	ctxt.RecvBufSize = ctx.Int("recv-buf-size")
 

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -160,12 +160,7 @@ type serverCtxt struct {
 	FTP  []string
 	SFTP []string
 
-	UserTimeout             time.Duration
-	ConnReadDeadline        time.Duration
-	ConnWriteDeadline       time.Duration
-	ConnClientReadDeadline  time.Duration
-	ConnClientWriteDeadline time.Duration
-
+	UserTimeout         time.Duration
 	ShutdownTimeout     time.Duration
 	IdleTimeout         time.Duration
 	ReadHeaderTimeout   time.Duration

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -104,32 +104,6 @@ var ServerFlags = []cli.Flag{
 		Hidden: true,
 	},
 	cli.DurationFlag{
-		Name:   "conn-client-read-deadline",
-		Usage:  "custom connection READ deadline for incoming requests",
-		Hidden: true,
-		EnvVar: "MINIO_CONN_CLIENT_READ_DEADLINE",
-	},
-	cli.DurationFlag{
-		Name:   "conn-client-write-deadline",
-		Usage:  "custom connection WRITE deadline for outgoing requests",
-		Hidden: true,
-		EnvVar: "MINIO_CONN_CLIENT_WRITE_DEADLINE",
-	},
-	cli.DurationFlag{
-		Name:   "conn-read-deadline",
-		Usage:  "custom connection READ deadline",
-		Hidden: true,
-		Value:  10 * time.Minute,
-		EnvVar: "MINIO_CONN_READ_DEADLINE",
-	},
-	cli.DurationFlag{
-		Name:   "conn-write-deadline",
-		Usage:  "custom connection WRITE deadline",
-		Hidden: true,
-		Value:  10 * time.Minute,
-		EnvVar: "MINIO_CONN_WRITE_DEADLINE",
-	},
-	cli.DurationFlag{
 		Name:   "conn-user-timeout",
 		Usage:  "custom TCP_USER_TIMEOUT for socket buffers",
 		Hidden: true,
@@ -440,12 +414,10 @@ func serverHandleCmdArgs(ctxt serverCtxt) {
 	setGlobalInternodeInterface(ctxt.Interface)
 
 	globalTCPOptions = xhttp.TCPOptions{
-		UserTimeout:        int(ctxt.UserTimeout.Milliseconds()),
-		ClientReadTimeout:  ctxt.ConnClientReadDeadline,
-		ClientWriteTimeout: ctxt.ConnClientWriteDeadline,
-		Interface:          ctxt.Interface,
-		SendBufSize:        ctxt.SendBufSize,
-		RecvBufSize:        ctxt.RecvBufSize,
+		UserTimeout: int(ctxt.UserTimeout.Milliseconds()),
+		Interface:   ctxt.Interface,
+		SendBufSize: ctxt.SendBufSize,
+		RecvBufSize: ctxt.RecvBufSize,
 	}
 
 	// allow transport to be HTTP/1.1 for proxying.

--- a/internal/http/dial_linux.go
+++ b/internal/http/dial_linux.go
@@ -39,10 +39,12 @@ func setTCPParametersFn(opts TCPOptions) func(network, address string, c syscall
 
 			_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 
-			{
+			if opts.SendBufSize > 0 {
 				// Enable big buffers
 				_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_SNDBUF, opts.SendBufSize)
+			}
 
+			if opts.RecvBufSize > 0 {
 				_ = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_RCVBUF, opts.RecvBufSize)
 			}
 


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
usage of deadline conn at Accept() breaks websocket

## Motivation and Context
fortunately not wired up to use, however if anyone enables 
deadlines for conn then sporadically MinIO startups fail.

## How to test this PR?
we should simply rely on context timeouts, net.conn deadlines
don't work safely. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
