### PR TITLE
Change endpoint of v3 notification metrics

### DIFF
--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -51,12 +51,12 @@ const (
 	clusterUsageObjectsCollectorPath collectorPath = "/cluster/usage/objects"
 	clusterUsageBucketsCollectorPath collectorPath = "/cluster/usage/buckets"
 	clusterErasureSetCollectorPath   collectorPath = "/cluster/erasure-set"
-	clusterNotificationCollectorPath collectorPath = "/cluster/notification"
 	clusterIAMCollectorPath          collectorPath = "/cluster/iam"
 
 	auditCollectorPath         collectorPath = "/audit"
 	loggerWebhookCollectorPath collectorPath = "/logger/webhook"
 	replicationCollectorPath   collectorPath = "/replication"
+	notificationCollectorPath  collectorPath = "/notification"
 )
 
 const (
@@ -298,7 +298,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 		loadClusterErasureSetMetrics,
 	)
 
-	clusterNotificationMG := NewMetricsGroup(clusterNotificationCollectorPath,
+	clusterNotificationMG := NewMetricsGroup(notificationCollectorPath,
 		[]MetricDescriptor{
 			notificationCurrentSendInProgressMD,
 			notificationEventsErrorsTotalMD,

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -36,7 +36,7 @@ These are metrics about requests served by the (current) node.
 
 ### Audit metrics
 
-These are metrics about the minio process and the node.
+These are metrics about the minio audit functionality
 
 | Path     | Description                            |
 |----------|----------------------------------------|
@@ -49,6 +49,14 @@ These are metrics about the minio logger webhooks
 | Path              | Description                        |
 |-------------------|------------------------------------|
 | `/logger/webhook` | Metrics related to logger webhooks |
+
+### Notification metrics
+
+These are metrics about the minio notification functionality
+
+| Path     | Description                                          |
+|----------|------------------------------------------------------|
+| `/notification` | Metrics related to notification functionality |
 
 ### System metrics
 
@@ -295,15 +303,6 @@ The standard metrics group for GoCollector is not shown below.
 | `minio_cluster_erasure_set_read_health`          | `gauge` | Health of the erasure set in a pool for read operations (1=healthy, 0=unhealthy)  | `pool_id,set_id` |
 | `minio_cluster_erasure_set_write_health`         | `gauge` | Health of the erasure set in a pool for write operations (1=healthy, 0=unhealthy) | `pool_id,set_id` |
 
-### `/cluster/notification`
-
-| Name                                                  | Type      | Help                                                                                     | Labels |
-|-------------------------------------------------------|-----------|------------------------------------------------------------------------------------------|--------|
-| `minio_cluster_notification_current_send_in_progress` | `counter` | Number of concurrent async Send calls active to all targets                              |        |
-| `minio_cluster_notification_events_errors_total`      | `counter` | Events that were failed to be sent to the targets                                        |        |
-| `minio_cluster_notification_events_sent_total`        | `counter` | Total number of events sent to the targets                                               |        |
-| `minio_cluster_notification_events_skipped_total`     | `counter` | Events that were skipped to be sent to the targets due to the in-memory queue being full |        |
-
 ### `/cluster/iam`
 
 | Name                                                            | Type      | Help                                                                                                                     | Labels |
@@ -343,3 +342,12 @@ The standard metrics group for GoCollector is not shown below.
 | `minio_replication_max_queued_bytes`              | `gauge` | Maximum number of bytes queued for replication since server start           | `server` |
 | `minio_replication_max_queued_count`              | `gauge` | Maximum number of objects queued for replication since server start         | `server` |
 | `minio_replication_max_data_transfer_rate`        | `gauge` | Maximum replication data transfer rate in bytes/sec seen since server start | `server` |
+
+### `/notification`
+
+| Name                                          | Type      | Help                                                                                     | Labels   |
+|-----------------------------------------------|-----------|------------------------------------------------------------------------------------------|----------|
+| `minio_notification_current_send_in_progress` | `counter` | Number of concurrent async Send calls active to all targets                              | `server` |
+| `minio_notification_events_errors_total`      | `counter` | Events that were failed to be sent to the targets                                        | `server` |
+| `minio_notification_events_sent_total`        | `counter` | Total number of events sent to the targets                                               | `server` |
+| `minio_notification_events_skipped_total`     | `counter` | Events that were skipped to be sent to the targets due to the in-memory queue being full | `server` |


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

from `/cluster/notification` to `/notification`
as it is a server-level metric and not cluster-level

## Motivation and Context

More meaningful endpoint for notification metrics

## How to test this PR?

`curl -v "http://<endpoint>/minio/metrics/v3/notification`

should return the notification related metrics, along with the `server` label.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
