### PR TITLE
fix: must close the multipart for PostPolicyBucketHandler

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1042,7 +1042,12 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 		// we have found the File part of the request we are done processing multipart-form
 		break
 	}
-
+	_, err = mp.NextRawPart()
+	// can't use errors.Is(err, io.EOF) because err wrapped with io.EOF using `fmt.Errorf("multipart: NextPart: %w", err)`
+	if err != io.EOF {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMalformedPOSTRequest), r.URL)
+		return
+	}
 	if keyName, ok := formValues["Key"]; !ok {
 		apiErr := errorCodes.ToAPIErr(ErrMalformedPOSTRequest)
 		apiErr.Description = fmt.Sprintf("%s (%v)", apiErr.Description, errors.New("The name of the uploaded key is missing"))

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1044,7 +1044,7 @@ func (api objectAPIHandlers) PostPolicyBucketHandler(w http.ResponseWriter, r *h
 	}
 	_, err = mp.NextRawPart()
 	// can't use errors.Is(err, io.EOF) because err wrapped with io.EOF using `fmt.Errorf("multipart: NextPart: %w", err)`
-	if err != io.EOF {
+	if err != nil && err != io.EOF {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMalformedPOSTRequest), r.URL)
 		return
 	}

--- a/cmd/post-policy_test.go
+++ b/cmd/post-policy_test.go
@@ -729,6 +729,8 @@ func newPostRequestV4Generic(endPoint, bucketName, objectName string, objData []
 		writer.Write(objData)
 		// Close before creating the new request.
 		w.Close()
+	} else {
+		w.Close()
 	}
 
 	// Set the body equal to the created policy.


### PR DESCRIPTION
fix: must close the multipart for PostPolicyBucketHandler

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: must close the multipart for PostPolicyBucketHandler
aws:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>MalformedPOSTRequest</Code><Message>The body of your POST request is not well-formed multipart/form-data.</Message><RequestId>.............</RequestId><HostId>.............</HostId></Error>
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
