### PR TITLE
Fix flipped EcM, EcN in metadata header

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -250,7 +250,7 @@ type xlMetaV2VersionHeader struct {
 	Signature [4]byte
 	Type      VersionType
 	Flags     xlFlags
-	EcM, EcN  uint8 // Note that these will be 0/0 for non-v2 objects and older xl.meta
+	EcN, EcM  uint8 // Note that these will be 0/0 for non-v2 objects and older xl.meta
 }
 
 func (x xlMetaV2VersionHeader) String() string {
@@ -368,8 +368,8 @@ func (j *xlMetaV2Version) header() xlMetaV2VersionHeader {
 		Signature: j.getSignature(),
 		Type:      j.Type,
 		Flags:     flags,
-		EcN:       ecM,
-		EcM:       ecN,
+		EcN:       ecN,
+		EcM:       ecM,
 	}
 }
 

--- a/cmd/xl-storage-format-v2_gen.go
+++ b/cmd/xl-storage-format-v2_gen.go
@@ -2235,14 +2235,14 @@ func (z *xlMetaV2VersionHeader) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		z.Flags = xlFlags(zb0003)
 	}
-	z.EcM, err = dc.ReadUint8()
-	if err != nil {
-		err = msgp.WrapError(err, "EcM")
-		return
-	}
 	z.EcN, err = dc.ReadUint8()
 	if err != nil {
 		err = msgp.WrapError(err, "EcN")
+		return
+	}
+	z.EcM, err = dc.ReadUint8()
+	if err != nil {
+		err = msgp.WrapError(err, "EcM")
 		return
 	}
 	return
@@ -2280,14 +2280,14 @@ func (z *xlMetaV2VersionHeader) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Flags")
 		return
 	}
-	err = en.WriteUint8(z.EcM)
-	if err != nil {
-		err = msgp.WrapError(err, "EcM")
-		return
-	}
 	err = en.WriteUint8(z.EcN)
 	if err != nil {
 		err = msgp.WrapError(err, "EcN")
+		return
+	}
+	err = en.WriteUint8(z.EcM)
+	if err != nil {
+		err = msgp.WrapError(err, "EcM")
 		return
 	}
 	return
@@ -2303,8 +2303,8 @@ func (z *xlMetaV2VersionHeader) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendBytes(o, (z.Signature)[:])
 	o = msgp.AppendUint8(o, uint8(z.Type))
 	o = msgp.AppendUint8(o, uint8(z.Flags))
-	o = msgp.AppendUint8(o, z.EcM)
 	o = msgp.AppendUint8(o, z.EcN)
+	o = msgp.AppendUint8(o, z.EcM)
 	return
 }
 
@@ -2353,14 +2353,14 @@ func (z *xlMetaV2VersionHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		z.Flags = xlFlags(zb0003)
 	}
-	z.EcM, bts, err = msgp.ReadUint8Bytes(bts)
-	if err != nil {
-		err = msgp.WrapError(err, "EcM")
-		return
-	}
 	z.EcN, bts, err = msgp.ReadUint8Bytes(bts)
 	if err != nil {
 		err = msgp.WrapError(err, "EcN")
+		return
+	}
+	z.EcM, bts, err = msgp.ReadUint8Bytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err, "EcM")
 		return
 	}
 	o = bts

--- a/docs/debugging/xl-meta/main.go
+++ b/docs/debugging/xl-meta/main.go
@@ -710,7 +710,7 @@ type xlMetaV2VersionHeaderV2 struct {
 	Signature [4]byte
 	Type      uint8
 	Flags     uint8
-	EcM, EcN  uint8 // Note that these will be 0/0 for non-v2 objects and older xl.meta
+	EcN, EcM  uint8 // Note that these will be 0/0 for non-v2 objects and older xl.meta
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
@@ -768,19 +768,19 @@ func (z *xlMetaV2VersionHeaderV2) UnmarshalMsg(bts []byte, hdrVer uint) (o []byt
 			var zb0004 uint8
 			zb0004, bts, err = msgp.ReadUint8Bytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "EcM")
+				err = msgp.WrapError(err, "EcN")
 				return
 			}
-			z.EcM = zb0004
+			z.EcN = zb0004
 		}
 		{
 			var zb0005 uint8
 			zb0005, bts, err = msgp.ReadUint8Bytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "EcN")
+				err = msgp.WrapError(err, "EcM")
 				return
 			}
-			z.EcN = zb0005
+			z.EcM = zb0005
 		}
 	}
 	o = bts


### PR DESCRIPTION
## Description

Since this is a tuple encoded field we can just flip the struct members without a new version.

No functional change - fields aren't used yet.

## How to test this PR?

Use `xl-meta` on files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
