### PR TITLE
Add xl-meta partial shard reconstruction

### DIFF
--- a/docs/debugging/inspect/main.go
+++ b/docs/debugging/inspect/main.go
@@ -59,7 +59,7 @@ func main() {
 		}
 
 		// Prompt for decryption key if no --key or --private-key are provided
-		if len(privateKey) == 0 {
+		if len(privateKey) == 0 && !*stdin {
 			reader := bufio.NewReader(os.Stdin)
 			fmt.Print("Enter Decryption Key: ")
 


### PR DESCRIPTION
## Description

* Add partial shard reconstruction
* Fix padding causing the last shard to be rejected
* Add md5 checks on single parts
* Move md5 verified to `verified/filename.ext`
* Move complete (without md5) to `complete/filename.ext.partno`

It's not pretty, but at least now the md5 gives some confidence it works correctly.

## How to test this PR?

`xl-meta -export -xver -combine file.zip`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
