### PR TITLE
Add max buffering to SFTP

### DIFF
--- a/cmd/sftp-server-driver.go
+++ b/cmd/sftp-server-driver.go
@@ -39,6 +39,10 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// Maximum write offset for incoming SFTP blocks.
+// Set to 100MiB to prevent hostile DOS attacks.
+const ftpMaxWriteOffset = 100 << 20
+
 type sftpDriver struct {
 	permissions *ssh.Permissions
 	endpoint    string
@@ -269,6 +273,9 @@ func (w *writerAt) WriteAt(b []byte, offset int64) (n int, err error) {
 		n, err = w.w.Write(b)
 		w.nextOffset += int64(n)
 	} else {
+		if offset > w.nextOffset+ftpMaxWriteOffset {
+			return 0, fmt.Errorf("write offset %d is too far ahead of next offset %d", offset, w.nextOffset)
+		}
 		w.buffer[offset] = make([]byte, len(b))
 		copy(w.buffer[offset], b)
 		n = len(b)


### PR DESCRIPTION
## Description

Prevent OOM by adversarial use of SFTP upload by setting a 100MB max upload buffer.

## How to test this PR?

Probably requires a special sftp client.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
