### PR TITLE
fix: crash when audit webhook queue_dir is not writable

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -193,7 +193,20 @@ func (h *Target) initDiskStore(ctx context.Context) (err error) {
 	h.storeCtxCancel = cancel
 	h.lastStarted = time.Now()
 	go h.startQueueProcessor(ctx, true)
+
+	queueStore := store.NewQueueStore[interface{}](
+		filepath.Join(h.config.QueueDir, h.Name()),
+		uint64(h.config.QueueSize),
+		httpLoggerExtension,
+	)
+
+	if err := queueStore.Open(); err != nil {
+		return fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
+	}
+
+	h.store = queueStore
 	store.StreamItems(h.store, h, ctx.Done(), h.config.LogOnceIf)
+
 	return nil
 }
 
@@ -314,10 +327,7 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 	enc := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(buf)
 	defer bytebufferpool.Put(buf)
 
-	isDirQueue := false
-	if h.config.QueueDir != "" {
-		isDirQueue = true
-	}
+	isDirQueue := h.config.QueueDir != ""
 
 	// globalBuffer is always created or adjusted
 	// before this method is launched.
@@ -504,23 +514,6 @@ func New(config Config) (*Target, error) {
 	}
 
 	h.client = &http.Client{Transport: h.config.Transport}
-
-	if h.config.QueueDir != "" {
-
-		queueStore := store.NewQueueStore[interface{}](
-			filepath.Join(h.config.QueueDir, h.Name()),
-			uint64(h.config.QueueSize),
-			httpLoggerExtension,
-		)
-
-		if err := queueStore.Open(); err != nil {
-			return h, fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
-		}
-
-		h.store = queueStore
-
-	}
-
 	return h, nil
 }
 

--- a/internal/logger/target/kafka/kafka.go
+++ b/internal/logger/target/kafka/kafka.go
@@ -168,9 +168,8 @@ func (h *Target) Init(ctx context.Context) error {
 }
 
 func (h *Target) initQueueStore(ctx context.Context) (err error) {
-	var queueStore store.Store[interface{}]
 	queueDir := filepath.Join(h.kconfig.QueueDir, h.Name())
-	queueStore = store.NewQueueStore[interface{}](queueDir, uint64(h.kconfig.QueueSize), kafkaLoggerExtension)
+	queueStore := store.NewQueueStore[interface{}](queueDir, uint64(h.kconfig.QueueSize), kafkaLoggerExtension)
 	if err = queueStore.Open(); err != nil {
 		return fmt.Errorf("unable to initialize the queue store of %s webhook: %w", h.Name(), err)
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: crash when audit webhook queue_dir is not writable

## Motivation and Context
This is a regression introduced in #19275 refactor

## How to test this PR?
Just do `mc admin config set alias/ audit_webhook endpoint=http://localhost:9000 queue_dir=/proc` on not writable path

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #19275
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
