### PR TITLE
fix: log diskerror when detect the disk space failed

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -789,7 +789,7 @@ func generateInitiateMultipartUploadResponse(bucket, key, uploadID string) Initi
 }
 
 // generates CompleteMultipartUploadResponse for given bucket, key, location and ETag.
-func generateCompleteMultpartUploadResponse(bucket, key, location string, oi ObjectInfo) CompleteMultipartUploadResponse {
+func generateCompleteMultipartUploadResponse(bucket, key, location string, oi ObjectInfo) CompleteMultipartUploadResponse {
 	cs := oi.decryptChecksums(0)
 	c := CompleteMultipartUploadResponse{
 		Location: location,

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1206,19 +1206,18 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 	}
 
 	if nDisks < len(di)/2 || nDisks <= 0 {
-		var errs []string
-		for _, disk := range di {
+		var errs []error
+		for index, disk := range di {
 			if disk == nil {
-				continue
-			}
-			if disk.Error != "" {
-				errs = append(errs, fmt.Sprintf("disk %s: %s", disk.Endpoint, disk.Error))
+				errs = append(errs, fmt.Errorf("disk[%d]: offline", index))
+			} else if disk.Error != "" {
+				errs = append(errs, fmt.Errorf("disk %s: %s", disk.Endpoint, disk.Error))
 			} else if disk.Total == 0 {
-				errs = append(errs, fmt.Sprintf("disk %s: total is zero", disk.Endpoint))
+				errs = append(errs, fmt.Errorf("disk %s: total is zero", disk.Endpoint))
 			}
 		}
 		// Log disk errors.
-		peersLogIf(context.Background(), errors.New(strings.Join(errs, ", ")))
+		peersLogIf(context.Background(), errors.Join(errs...))
 		return false, fmt.Errorf("not enough online disks to calculate the available space, need %d, found %d", (len(di)/2)+1, nDisks)
 	}
 

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1206,6 +1206,19 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 	}
 
 	if nDisks < len(di)/2 || nDisks <= 0 {
+		var errs []string
+		for _, disk := range di {
+			if disk == nil {
+				continue
+			}
+			if disk.Error != "" {
+				errs = append(errs, fmt.Sprintf("disk %s: %s", disk.Endpoint, disk.Error))
+			} else if disk.Total == 0 {
+				errs = append(errs, fmt.Sprintf("disk %s: total is zero", disk.Endpoint))
+			}
+		}
+		// Log disk errors.
+		peersLogIf(context.Background(), errors.New(strings.Join(errs, ", ")))
 		return false, fmt.Errorf("not enough online disks to calculate the available space, expected (%d)/(%d)", (len(di)/2)+1, nDisks)
 	}
 

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1219,7 +1219,7 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 		}
 		// Log disk errors.
 		peersLogIf(context.Background(), errors.New(strings.Join(errs, ", ")))
-		return false, fmt.Errorf("not enough online disks to calculate the available space, expected (%d)/(%d)", (len(di)/2)+1, nDisks)
+		return false, fmt.Errorf("not enough online disks to calculate the available space, expected (%d)/(%d)", nDisks, (len(di)/2)+1)
 	}
 
 	// Check we have enough on each disk, ignoring diskFillFraction.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1208,11 +1208,12 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 	if nDisks < len(di)/2 || nDisks <= 0 {
 		var errs []error
 		for index, disk := range di {
-			if disk == nil {
+			switch {
+			case disk == nil:
 				errs = append(errs, fmt.Errorf("disk[%d]: offline", index))
-			} else if disk.Error != "" {
+			case disk.Error != "":
 				errs = append(errs, fmt.Errorf("disk %s: %s", disk.Endpoint, disk.Error))
-			} else if disk.Total == 0 {
+			case disk.Total == 0:
 				errs = append(errs, fmt.Errorf("disk %s: total is zero", disk.Endpoint))
 			}
 		}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1219,7 +1219,7 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 		}
 		// Log disk errors.
 		peersLogIf(context.Background(), errors.New(strings.Join(errs, ", ")))
-		return false, fmt.Errorf("not enough online disks to calculate the available space, expected (%d)/(%d)", nDisks, (len(di)/2)+1)
+		return false, fmt.Errorf("not enough online disks to calculate the available space, need %d, found %d",  (len(di)/2)+1, nDisks)
 	}
 
 	// Check we have enough on each disk, ignoring diskFillFraction.

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -1219,7 +1219,7 @@ func hasSpaceFor(di []*DiskInfo, size int64) (bool, error) {
 		}
 		// Log disk errors.
 		peersLogIf(context.Background(), errors.New(strings.Join(errs, ", ")))
-		return false, fmt.Errorf("not enough online disks to calculate the available space, need %d, found %d",  (len(di)/2)+1, nDisks)
+		return false, fmt.Errorf("not enough online disks to calculate the available space, need %d, found %d", (len(di)/2)+1, nDisks)
 	}
 
 	// Check we have enough on each disk, ignoring diskFillFraction.

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2914,7 +2914,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 	s3MD5 := getCompleteMultipartMD5(inputParts[3].parts)
 
 	// generating the response body content for the success case.
-	successResponse := generateCompleteMultpartUploadResponse(bucketName, objectName, getGetObjectURL("", bucketName, objectName), ObjectInfo{ETag: s3MD5})
+	successResponse := generateCompleteMultipartUploadResponse(bucketName, objectName, getGetObjectURL("", bucketName, objectName), ObjectInfo{ETag: s3MD5})
 	encodedSuccessResponse := encodeResponse(successResponse)
 
 	ctx := context.Background()

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -1040,7 +1040,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	// Get object location.
 	location := getObjectLocation(r, globalDomainNames, bucket, object)
 	// Generate complete multipart response.
-	response := generateCompleteMultpartUploadResponse(bucket, object, location, objInfo)
+	response := generateCompleteMultipartUploadResponse(bucket, object, location, objInfo)
 	encodedSuccessResponse := encodeResponse(response)
 
 	// Write success response.


### PR DESCRIPTION
fix: log diskerror when delect the disk space failed

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix: log diskerror when delect the disk space failed
when we got `not enough online disks to calculate the available space`
we don't print the error and provide a way to print the error here.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
