### PR TITLE
Test proxying of DEL marker for bucket replication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,10 @@ test-replication-3site:
 test-delete-replication:
 	@(env bash $(PWD)/docs/bucket/replication/delete-replication.sh)
 
-test-replication: install-race test-replication-2site test-replication-3site test-delete-replication test-sio-error ## verify multi site replication
+test-delete-marker-proxying:
+	@(env bash $(PWD)/docs/bucket/replication/test_del_marker_proxying.sh)
+
+test-replication: install-race test-replication-2site test-replication-3site test-delete-replication test-sio-error test-delete-marker-proxying ## verify multi site replication
 	@echo "Running tests for replicating three sites"
 
 test-site-replication-ldap: install-race ## verify automatic site replication

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -789,7 +789,7 @@ func generateInitiateMultipartUploadResponse(bucket, key, uploadID string) Initi
 }
 
 // generates CompleteMultipartUploadResponse for given bucket, key, location and ETag.
-func generateCompleteMultpartUploadResponse(bucket, key, location string, oi ObjectInfo) CompleteMultipartUploadResponse {
+func generateCompleteMultipartUploadResponse(bucket, key, location string, oi ObjectInfo) CompleteMultipartUploadResponse {
 	cs := oi.decryptChecksums(0)
 	c := CompleteMultipartUploadResponse{
 		Location: location,

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2914,7 +2914,7 @@ func testAPICompleteMultipartHandler(obj ObjectLayer, instanceType, bucketName s
 	s3MD5 := getCompleteMultipartMD5(inputParts[3].parts)
 
 	// generating the response body content for the success case.
-	successResponse := generateCompleteMultpartUploadResponse(bucketName, objectName, getGetObjectURL("", bucketName, objectName), ObjectInfo{ETag: s3MD5})
+	successResponse := generateCompleteMultipartUploadResponse(bucketName, objectName, getGetObjectURL("", bucketName, objectName), ObjectInfo{ETag: s3MD5})
 	encodedSuccessResponse := encodeResponse(successResponse)
 
 	ctx := context.Background()

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -1040,7 +1040,7 @@ func (api objectAPIHandlers) CompleteMultipartUploadHandler(w http.ResponseWrite
 	// Get object location.
 	location := getObjectLocation(r, globalDomainNames, bucket, object)
 	// Generate complete multipart response.
-	response := generateCompleteMultpartUploadResponse(bucket, object, location, objInfo)
+	response := generateCompleteMultipartUploadResponse(bucket, object, location, objInfo)
 	encodedSuccessResponse := encodeResponse(response)
 
 	// Write success response.

--- a/docs/bucket/replication/test_del_marker_proxying.sh
+++ b/docs/bucket/replication/test_del_marker_proxying.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2120
+exit_1() {
+	cleanup
+
+	for site in sitea siteb; do
+		echo "$site server logs ========="
+		cat "/tmp/${site}_1.log"
+		echo "==========================="
+		cat "/tmp/${site}_2.log"
+	done
+
+	exit 1
+}
+
+cleanup() {
+	echo -n "Cleaning up instances of MinIO ..."
+	pkill -9 minio || sudo pkill -9 minio
+	rm -rf /tmp/sitea
+	rm -rf /tmp/siteb
+	echo "done"
+}
+
+cleanup
+
+export MINIO_CI_CD=1
+export MINIO_BROWSER=off
+export MINIO_ROOT_USER="minio"
+export MINIO_ROOT_PASSWORD="minio123"
+
+# Start MinIO instances
+echo -n "Starting MinIO instances ..."
+minio server --address ":9001" --console-address ":10000" /tmp/sitea/{1...4}/disk{1...4} /tmp/sitea/{5...8}/disk{1...4} >/tmp/sitea_1.log 2>&1 &
+minio server --address ":9002" --console-address ":11000" /tmp/siteb/{1...4}/disk{1...4} /tmp/siteb/{5...8}/disk{1...4} >/tmp/siteb_1.log 2>&1 &
+echo "done"
+
+if [ ! -f ./mc ]; then
+	wget --quiet -O mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
+		chmod +x mc
+fi
+
+export MC_HOST_sitea=http://minio:minio123@127.0.0.1:9001
+export MC_HOST_siteb=http://minio:minio123@127.0.0.1:9002
+
+./mc ready sitea
+./mc ready siteb
+
+./mc mb sitea/bucket
+./mc version enable sitea/bucket
+./mc mb siteb/bucket
+./mc version enable siteb/bucket
+
+# Set bucket replication
+./mc replicate add sitea/bucket --remote-bucket siteb/bucket
+
+# Run the test to make sure proxying of DEL marker doesn't happen
+loop_count=0
+while true; do
+	if [ $loop_count -eq 100 ]; then
+		break
+	fi
+	echo "Hello World" | ./mc pipe sitea/bucket/obj$loop_count
+	./mc rm sitea/bucket/obj$loop_count
+	RESULT=$({ ./mc stat sitea/bucket/obj$loop_count; } 2>&1)
+	if [[ ${RESULT} != *"Object does not exist"* ]]; then
+		echo "BUG: stat should fail. succeeded."
+		exit_1
+	fi
+	loop_count=$((loop_count + 1))
+done
+
+cleanup


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Make sure proxying of DEL markers doesnt happen to remote site while stat calls.

## Motivation and Context


## How to test this PR?
make test-delete-marker-proxying

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
