### PR TITLE
allow purge expired STS while loading credentials

### DIFF
--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -532,16 +532,6 @@ func setDefaultCannedPolicies(policies map[string]PolicyDoc) {
 	}
 }
 
-// PurgeExpiredSTS - purges expired STS credentials.
-func (store *IAMStoreSys) PurgeExpiredSTS(ctx context.Context) error {
-	iamOS, ok := store.IAMStorageAPI.(*IAMObjectStore)
-	if !ok {
-		// No purging is done for non-object storage.
-		return nil
-	}
-	return iamOS.PurgeExpiredSTS(ctx)
-}
-
 // LoadIAMCache reads all IAM items and populates a new iamCache object and
 // replaces the in-memory cache object.
 func (store *IAMStoreSys) LoadIAMCache(ctx context.Context, firstTime bool) error {

--- a/cmd/sts-handlers_test.go
+++ b/cmd/sts-handlers_test.go
@@ -50,7 +50,6 @@ func runAllIAMSTSTests(suite *TestSuiteIAM, c *check) {
 }
 
 func TestIAMInternalIDPSTSServerSuite(t *testing.T) {
-	t.Skip("FIXME: Skipping internal IDP tests. Flaky test, needs to be fixed.")
 	baseTestCases := []TestSuiteCommon{
 		// Init and run test on ErasureSD backend with signature v4.
 		{serverType: "ErasureSD", signer: signerV4},


### PR DESCRIPTION



## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow purge expired STS while loading credentials

## Motivation and Context
the reason for this is to avoid STS mappings to be purged 
without a successful load of other policies and all the 
credentials only loaded successfully are correctly handled.

This also avoids unnecessary cache stores, which were 
implemented earlier for optimization.

## How to test this PR?
CI/CD flaky tests have been fixed since this change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression kind of have been flaky since #19376
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
