### PR TITLE
kms: use `GetClientCertificate` callback for KES API keys

### DIFF
--- a/internal/kms/config.go
+++ b/internal/kms/config.go
@@ -168,7 +168,7 @@ func Connect(ctx context.Context, opts *ConnectionOptions) (*KMS, error) {
 			if err != nil {
 				return nil, err
 			}
-			conf.Certificates = append(conf.Certificates, cert)
+			conf.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) { return &cert, nil }
 		} else {
 			loadX509KeyPair := func(certFile, keyFile string) (tls.Certificate, error) {
 				// Manually load the certificate and private key into memory.


### PR DESCRIPTION
## Description
This commit fixes an issue in the KES client configuration that can cause the following error when connecting to KES:
```
ERROR Failed to connect to KMS: failed to generate data key with KMS key: tls: client certificate is required
```

The Go TLS stack seems to not send a client certificate if it thinks the client certificate cannot be validated by the peer. In case of an API key, we don't care about this since we use public key pinning and the X.509 certificate is just a transport encoding.

The `GetClientCertificate` seems to be honored always such that this error does not occur.

## Motivation and Context
KMS

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
