### PR TITLE
Optimizing Event Sending

### DIFF
--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -57,10 +57,7 @@ func (ps *PubSub[T, M]) Publish(item T) {
 	defer ps.RUnlock()
 	for _, sub := range ps.subs {
 		if sub.types.Contains(Mask(item.Mask())) && (sub.filter == nil || sub.filter(item)) {
-			select {
-			case sub.ch <- item:
-			default:
-			}
+			go func() { sub.ch <- item }()
 		}
 	}
 }


### PR DESCRIPTION
Solving the Event Loss Problem in High Concurrency Scenarios

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
When the event buffer pool overflows, events are lost.


## Motivation and Context


## How to test this PR?
step1:
keep mc watch
```
mc watch test/bucket --events put > event.log
```
step2:
use warp put object 10 minutes
```
warp put --concurrent=200 --obj.size=10k --bucket=bucket  --noclear --duration=600s
``` 
step3:
Counting the number of objects in bucket
```
mc du test/bucket
```
step4:
Counting the number of event
```
cat event.log|wc -l
```
The number of events is the same as the number of files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
