### PR TITLE
skip healing properly in the scanner when a drive is hotplugged

### DIFF
--- a/cmd/background-newdisks-heal-ops.go
+++ b/cmd/background-newdisks-heal-ops.go
@@ -464,10 +464,7 @@ func healFreshDisk(ctx context.Context, z *erasureServerPools, endpoint Endpoint
 	}
 
 	// Remove .healing.bin from all disks with similar heal-id
-	disks, err := z.GetDisks(poolIdx, setIdx)
-	if err != nil {
-		return err
-	}
+	disks := z.serverPools[poolIdx].sets[setIdx].getDisks()
 
 	for _, disk := range disks {
 		if disk == nil {

--- a/cmd/data-usage-cache.go
+++ b/cmd/data-usage-cache.go
@@ -352,9 +352,6 @@ type dataUsageCacheInfo struct {
 	Name       string
 	NextCycle  uint32
 	LastUpdate time.Time
-	// indicates if the disk is being healed and scanner
-	// should skip healing the disk
-	SkipHealing bool
 
 	// Active lifecycle, if any on the bucket
 	lifeCycle *lifecycle.Lifecycle `msg:"-"`

--- a/cmd/data-usage-cache_gen.go
+++ b/cmd/data-usage-cache_gen.go
@@ -400,27 +400,62 @@ func (z *dataUsageCache) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntry, zb0002)
+				z.Cache = make(map[string]dataUsageEntry, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntry
 				za0001, err = dc.ReadString()
@@ -454,9 +489,35 @@ func (z *dataUsageCache) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = z.Info.EncodeMsg(en)
+	// map header, size 3
+	// write "Name"
+	err = en.Append(0x83, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	if err != nil {
-		err = msgp.WrapError(err, "Info")
+		return
+	}
+	err = en.WriteString(z.Info.Name)
+	if err != nil {
+		err = msgp.WrapError(err, "Info", "Name")
+		return
+	}
+	// write "NextCycle"
+	err = en.Append(0xa9, 0x4e, 0x65, 0x78, 0x74, 0x43, 0x79, 0x63, 0x6c, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteUint32(z.Info.NextCycle)
+	if err != nil {
+		err = msgp.WrapError(err, "Info", "NextCycle")
+		return
+	}
+	// write "LastUpdate"
+	err = en.Append(0xaa, 0x4c, 0x61, 0x73, 0x74, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteTime(z.Info.LastUpdate)
+	if err != nil {
+		err = msgp.WrapError(err, "Info", "LastUpdate")
 		return
 	}
 	// write "Cache"
@@ -490,11 +551,16 @@ func (z *dataUsageCache) MarshalMsg(b []byte) (o []byte, err error) {
 	// map header, size 2
 	// string "Info"
 	o = append(o, 0x82, 0xa4, 0x49, 0x6e, 0x66, 0x6f)
-	o, err = z.Info.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "Info")
-		return
-	}
+	// map header, size 3
+	// string "Name"
+	o = append(o, 0x83, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.Info.Name)
+	// string "NextCycle"
+	o = append(o, 0xa9, 0x4e, 0x65, 0x78, 0x74, 0x43, 0x79, 0x63, 0x6c, 0x65)
+	o = msgp.AppendUint32(o, z.Info.NextCycle)
+	// string "LastUpdate"
+	o = append(o, 0xaa, 0x4c, 0x61, 0x73, 0x74, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65)
+	o = msgp.AppendTime(o, z.Info.LastUpdate)
 	// string "Cache"
 	o = append(o, 0xa5, 0x43, 0x61, 0x63, 0x68, 0x65)
 	o = msgp.AppendMapHeader(o, uint32(len(z.Cache)))
@@ -528,29 +594,64 @@ func (z *dataUsageCache) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntry, zb0002)
+				z.Cache = make(map[string]dataUsageEntry, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntry
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -577,7 +678,7 @@ func (z *dataUsageCache) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCache) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -623,12 +724,6 @@ func (z *dataUsageCacheInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
 			}
-		case "SkipHealing":
-			z.SkipHealing, err = dc.ReadBool()
-			if err != nil {
-				err = msgp.WrapError(err, "SkipHealing")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -641,10 +736,10 @@ func (z *dataUsageCacheInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 }
 
 // EncodeMsg implements msgp.Encodable
-func (z *dataUsageCacheInfo) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
+func (z dataUsageCacheInfo) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 3
 	// write "Name"
-	err = en.Append(0x84, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	err = en.Append(0x83, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	if err != nil {
 		return
 	}
@@ -673,25 +768,15 @@ func (z *dataUsageCacheInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "LastUpdate")
 		return
 	}
-	// write "SkipHealing"
-	err = en.Append(0xab, 0x53, 0x6b, 0x69, 0x70, 0x48, 0x65, 0x61, 0x6c, 0x69, 0x6e, 0x67)
-	if err != nil {
-		return
-	}
-	err = en.WriteBool(z.SkipHealing)
-	if err != nil {
-		err = msgp.WrapError(err, "SkipHealing")
-		return
-	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
-func (z *dataUsageCacheInfo) MarshalMsg(b []byte) (o []byte, err error) {
+func (z dataUsageCacheInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 3
 	// string "Name"
-	o = append(o, 0x84, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
+	o = append(o, 0x83, 0xa4, 0x4e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.Name)
 	// string "NextCycle"
 	o = append(o, 0xa9, 0x4e, 0x65, 0x78, 0x74, 0x43, 0x79, 0x63, 0x6c, 0x65)
@@ -699,9 +784,6 @@ func (z *dataUsageCacheInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "LastUpdate"
 	o = append(o, 0xaa, 0x4c, 0x61, 0x73, 0x74, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65)
 	o = msgp.AppendTime(o, z.LastUpdate)
-	// string "SkipHealing"
-	o = append(o, 0xab, 0x53, 0x6b, 0x69, 0x70, 0x48, 0x65, 0x61, 0x6c, 0x69, 0x6e, 0x67)
-	o = msgp.AppendBool(o, z.SkipHealing)
 	return
 }
 
@@ -741,12 +823,6 @@ func (z *dataUsageCacheInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "LastUpdate")
 				return
 			}
-		case "SkipHealing":
-			z.SkipHealing, bts, err = msgp.ReadBoolBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "SkipHealing")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -760,8 +836,8 @@ func (z *dataUsageCacheInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *dataUsageCacheInfo) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 12 + msgp.BoolSize
+func (z dataUsageCacheInfo) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize
 	return
 }
 
@@ -784,27 +860,62 @@ func (z *dataUsageCacheV2) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV2, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV2, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV2
 				za0001, err = dc.ReadString()
@@ -849,29 +960,64 @@ func (z *dataUsageCacheV2) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV2, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV2, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV2
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -898,7 +1044,7 @@ func (z *dataUsageCacheV2) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV2) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -927,27 +1073,62 @@ func (z *dataUsageCacheV3) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV3, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV3, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV3
 				za0001, err = dc.ReadString()
@@ -992,29 +1173,64 @@ func (z *dataUsageCacheV3) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV3, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV3, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV3
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -1041,7 +1257,7 @@ func (z *dataUsageCacheV3) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV3) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -1070,27 +1286,62 @@ func (z *dataUsageCacheV4) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV4, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV4, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV4
 				za0001, err = dc.ReadString()
@@ -1135,29 +1386,64 @@ func (z *dataUsageCacheV4) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV4, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV4, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV4
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -1184,7 +1470,7 @@ func (z *dataUsageCacheV4) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV4) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -1213,27 +1499,62 @@ func (z *dataUsageCacheV5) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV5, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV5, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV5
 				za0001, err = dc.ReadString()
@@ -1278,29 +1599,64 @@ func (z *dataUsageCacheV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV5, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV5, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV5
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -1327,7 +1683,7 @@ func (z *dataUsageCacheV5) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV5) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -1356,27 +1712,62 @@ func (z *dataUsageCacheV6) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV6, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV6, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV6
 				za0001, err = dc.ReadString()
@@ -1421,29 +1812,64 @@ func (z *dataUsageCacheV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV6, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV6, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV6
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -1470,7 +1896,7 @@ func (z *dataUsageCacheV6) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV6) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002
@@ -1499,27 +1925,62 @@ func (z *dataUsageCacheV7) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			err = z.Info.DecodeMsg(dc)
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, err = dc.ReadString()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, err = dc.ReadUint32()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, err = dc.ReadTime()
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, err = dc.ReadMapHeader()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV7, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV7, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
-				zb0002--
+			for zb0003 > 0 {
+				zb0003--
 				var za0001 string
 				var za0002 dataUsageEntryV7
 				za0001, err = dc.ReadString()
@@ -1564,29 +2025,64 @@ func (z *dataUsageCacheV7) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "Info":
-			bts, err = z.Info.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Info")
 				return
 			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Info")
+					return
+				}
+				switch msgp.UnsafeString(field) {
+				case "Name":
+					z.Info.Name, bts, err = msgp.ReadStringBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "Name")
+						return
+					}
+				case "NextCycle":
+					z.Info.NextCycle, bts, err = msgp.ReadUint32Bytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "NextCycle")
+						return
+					}
+				case "LastUpdate":
+					z.Info.LastUpdate, bts, err = msgp.ReadTimeBytes(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info", "LastUpdate")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Info")
+						return
+					}
+				}
+			}
 		case "Cache":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Cache")
 				return
 			}
 			if z.Cache == nil {
-				z.Cache = make(map[string]dataUsageEntryV7, zb0002)
+				z.Cache = make(map[string]dataUsageEntryV7, zb0003)
 			} else if len(z.Cache) > 0 {
 				for key := range z.Cache {
 					delete(z.Cache, key)
 				}
 			}
-			for zb0002 > 0 {
+			for zb0003 > 0 {
 				var za0001 string
 				var za0002 dataUsageEntryV7
-				zb0002--
+				zb0003--
 				za0001, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Cache")
@@ -1613,7 +2109,7 @@ func (z *dataUsageCacheV7) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *dataUsageCacheV7) Msgsize() (s int) {
-	s = 1 + 5 + z.Info.Msgsize() + 6 + msgp.MapHeaderSize
+	s = 1 + 5 + 1 + 5 + msgp.StringPrefixSize + len(z.Info.Name) + 10 + msgp.Uint32Size + 11 + msgp.TimeSize + 6 + msgp.MapHeaderSize
 	if z.Cache != nil {
 		for za0001, za0002 := range z.Cache {
 			_ = za0002

--- a/cmd/data-usage_test.go
+++ b/cmd/data-usage_test.go
@@ -64,7 +64,7 @@ func TestDataUsageUpdate(t *testing.T) {
 
 	weSleep := func() bool { return false }
 
-	got, err := scanDataFolder(context.Background(), nil, base, dataUsageCache{Info: dataUsageCacheInfo{Name: bucket}}, getSize, 0, weSleep)
+	got, err := scanDataFolder(context.Background(), nil, base, false, dataUsageCache{Info: dataUsageCacheInfo{Name: bucket}}, getSize, 0, weSleep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestDataUsageUpdate(t *testing.T) {
 	}
 	// Changed dir must be picked up in this many cycles.
 	for i := 0; i < dataUsageUpdateDirCycles; i++ {
-		got, err = scanDataFolder(context.Background(), nil, base, got, getSize, 0, weSleep)
+		got, err = scanDataFolder(context.Background(), nil, base, false, got, getSize, 0, weSleep)
 		got.Info.NextCycle++
 		if err != nil {
 			t.Fatal(err)
@@ -284,7 +284,7 @@ func TestDataUsageUpdatePrefix(t *testing.T) {
 
 	weSleep := func() bool { return false }
 
-	got, err := scanDataFolder(context.Background(), nil, base, dataUsageCache{Info: dataUsageCacheInfo{Name: "bucket"}}, getSize, 0, weSleep)
+	got, err := scanDataFolder(context.Background(), nil, base, false, dataUsageCache{Info: dataUsageCacheInfo{Name: "bucket"}}, getSize, 0, weSleep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,7 +419,7 @@ func TestDataUsageUpdatePrefix(t *testing.T) {
 	}
 	// Changed dir must be picked up in this many cycles.
 	for i := 0; i < dataUsageUpdateDirCycles; i++ {
-		got, err = scanDataFolder(context.Background(), nil, base, got, getSize, 0, weSleep)
+		got, err = scanDataFolder(context.Background(), nil, base, false, got, getSize, 0, weSleep)
 		got.Info.NextCycle++
 		if err != nil {
 			t.Fatal(err)
@@ -568,7 +568,7 @@ func TestDataUsageCacheSerialize(t *testing.T) {
 		return
 	}
 	weSleep := func() bool { return false }
-	want, err := scanDataFolder(context.Background(), nil, base, dataUsageCache{Info: dataUsageCacheInfo{Name: bucket}}, getSize, 0, weSleep)
+	want, err := scanDataFolder(context.Background(), nil, base, false, dataUsageCache{Info: dataUsageCacheInfo{Name: bucket}}, getSize, 0, weSleep)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/erasure-healing-common_test.go
+++ b/cmd/erasure-healing-common_test.go
@@ -233,7 +233,7 @@ func TestListOnlineDisks(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), smallFileThreshold*16)
 	z := obj.(*erasureServerPools)
 
-	erasureDisks, err := z.GetDisks(0, 0)
+	erasureDisks, _, err := z.GetDisks(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestListOnlineDisksSmallObjects(t *testing.T) {
 	data := bytes.Repeat([]byte("a"), smallFileThreshold/2)
 	z := obj.(*erasureServerPools)
 
-	erasureDisks, err := z.GetDisks(0, 0)
+	erasureDisks, _, err := z.GetDisks(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -302,11 +302,12 @@ func (z *erasureServerPools) GetRawData(ctx context.Context, volume, file string
 }
 
 // Return the disks belonging to the poolIdx, and setIdx.
-func (z *erasureServerPools) GetDisks(poolIdx, setIdx int) ([]StorageAPI, error) {
+func (z *erasureServerPools) GetDisks(poolIdx, setIdx int) ([]StorageAPI, bool, error) {
 	if poolIdx < len(z.serverPools) && setIdx < len(z.serverPools[poolIdx].sets) {
-		return z.serverPools[poolIdx].sets[setIdx].getDisks(), nil
+		disks, healing := z.serverPools[poolIdx].sets[setIdx].getOnlineDisksWithHealing(true)
+		return disks, healing, nil
 	}
-	return nil, fmt.Errorf("Matching pool %s, set %s not found", humanize.Ordinal(poolIdx+1), humanize.Ordinal(setIdx+1))
+	return nil, false, fmt.Errorf("Matching pool %s, set %s not found", humanize.Ordinal(poolIdx+1), humanize.Ordinal(setIdx+1))
 }
 
 // Return the count of disks in each pool

--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -381,7 +381,7 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 	}
 
 	// Collect disks we can use.
-	disks, healing := er.getOnlineDisksWithHealing(false)
+	disks, _ := er.getOnlineDisksWithHealing(false)
 	if len(disks) == 0 {
 		scannerLogIf(ctx, errors.New("data-scanner: all drives are offline or being healed, skipping scanner cycle"))
 		return nil
@@ -497,7 +497,6 @@ func (er erasureObjects) nsScanner(ctx context.Context, buckets []BucketInfo, wa
 				if cache.Info.Name == "" {
 					cache.Info.Name = bucket.Name
 				}
-				cache.Info.SkipHealing = healing
 				cache.Info.NextCycle = wantCycle
 				if cache.Info.Name != bucket.Name {
 					cache.Info = dataUsageCacheInfo{

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -287,8 +287,8 @@ type ObjectLayer interface {
 	AbortMultipartUpload(ctx context.Context, bucket, object, uploadID string, opts ObjectOptions) error
 	CompleteMultipartUpload(ctx context.Context, bucket, object, uploadID string, uploadedParts []CompletePart, opts ObjectOptions) (objInfo ObjectInfo, err error)
 
-	GetDisks(poolIdx, setIdx int) ([]StorageAPI, error) // return the disks belonging to pool and set.
-	SetDriveCounts() []int                              // list of erasure stripe size for each pool in order.
+	GetDisks(poolIdx, setIdx int) ([]StorageAPI, bool, error) // return the disks belonging to pool and set.
+	SetDriveCounts() []int                                    // list of erasure stripe size for each pool in order.
 
 	// Healing operations.
 	HealFormat(ctx context.Context, dryRun bool) (madmin.HealResultItem, error)

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -554,14 +554,14 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 
 	poolIdx, setIdx, _ := s.GetDiskLoc()
 
-	disks, err := objAPI.GetDisks(poolIdx, setIdx)
+	disks, healing, err := objAPI.GetDisks(poolIdx, setIdx)
 	if err != nil {
 		return cache, err
 	}
 
 	cache.Info.updates = updates
 
-	dataUsageInfo, err := scanDataFolder(ctx, disks, s.drivePath, cache, func(item scannerItem) (sizeSummary, error) {
+	dataUsageInfo, err := scanDataFolder(ctx, disks, s.drivePath, healing, cache, func(item scannerItem) (sizeSummary, error) {
 		// Look for `xl.meta/xl.json' at the leaf.
 		if !strings.HasSuffix(item.Path, SlashSeparator+xlStorageFormatFile) &&
 			!strings.HasSuffix(item.Path, SlashSeparator+xlStorageFormatFileV1) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
skip healing properly in the scanner when a drive is hotplugged

## Motivation and Context
due to how the state is passed around the SkipHealing
might not be the true state() of the system always, causing
a situation where we might heal from the scanner on the
a same drive which is being. Due to this, competing heals get
triggered that slow each other down.

## How to test this PR?
You need a setup with four drives minimum and hotplug
replace the drive at random; you can see competing 
heals invoked.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
