### PR TITLE
avoid waiting for quorum health while debugging

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -2586,29 +2586,17 @@ func (z *erasureServerPools) Health(ctx context.Context, opts HealthOptions) Hea
 
 			healthy := erasureSetUpCount[poolIdx][setIdx].online >= poolWriteQuorums[poolIdx]
 			if !healthy {
-				if opts.Startup {
-					storageLogIf(logger.SetReqInfo(ctx, reqInfo),
-						fmt.Errorf("Write quorum was not established on pool: %d, set: %d, expected write quorum: %d",
-							poolIdx, setIdx, poolWriteQuorums[poolIdx]), logger.FatalKind)
-				} else {
-					storageLogIf(logger.SetReqInfo(ctx, reqInfo),
-						fmt.Errorf("Write quorum may be lost on pool: %d, set: %d, expected write quorum: %d",
-							poolIdx, setIdx, poolWriteQuorums[poolIdx]), logger.FatalKind)
-				}
+				storageLogIf(logger.SetReqInfo(ctx, reqInfo),
+					fmt.Errorf("Write quorum could not be established on pool: %d, set: %d, expected write quorum: %d, drives-online: %d",
+						poolIdx, setIdx, poolWriteQuorums[poolIdx], erasureSetUpCount[poolIdx][setIdx].online), logger.FatalKind)
 			}
 			result.Healthy = result.Healthy && healthy
 
 			healthyRead := erasureSetUpCount[poolIdx][setIdx].online >= poolReadQuorums[poolIdx]
 			if !healthyRead {
-				if opts.Startup {
-					storageLogIf(logger.SetReqInfo(ctx, reqInfo),
-						fmt.Errorf("Read quorum was not established on pool: %d, set: %d, expected read quorum: %d",
-							poolIdx, setIdx, poolReadQuorums[poolIdx]))
-				} else {
-					storageLogIf(logger.SetReqInfo(ctx, reqInfo),
-						fmt.Errorf("Read quorum may be lost on pool: %d, set: %d, expected read quorum: %d",
-							poolIdx, setIdx, poolReadQuorums[poolIdx]))
-				}
+				storageLogIf(logger.SetReqInfo(ctx, reqInfo),
+					fmt.Errorf("Read quorum could not be established on pool: %d, set: %d, expected read quorum: %d, drives-online: %d",
+						poolIdx, setIdx, poolReadQuorums[poolIdx], erasureSetUpCount[poolIdx][setIdx].online))
 			}
 			result.HealthyRead = result.HealthyRead && healthyRead
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -189,12 +189,14 @@ func printMinIOVersion(c *cli.Context) {
 	io.Copy(c.App.Writer, versionBanner(c))
 }
 
+var debugNoExit = env.Get("_MINIO_DEBUG_NO_EXIT", "") != ""
+
 // Main main for minio server.
 func Main(args []string) {
 	// Set the minio app name.
 	appName := filepath.Base(args[0])
 
-	if env.Get("_MINIO_DEBUG_NO_EXIT", "") != "" {
+	if debugNoExit {
 		freeze := func(_ int) {
 			// Infinite blocking op
 			<-make(chan struct{})

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -923,6 +923,10 @@ func serverMain(ctx *cli.Context) {
 	bootstrapTrace("waitForQuorum", func() {
 		result := newObject.Health(context.Background(), HealthOptions{Startup: true})
 		for !result.Healthy {
+			if debugNoExit {
+				logger.Info("Not waiting for quorum since we are debugging.. possible cause unhealthy sets (%s)", result)
+				break
+			}
 			d := time.Duration(r.Float64() * float64(time.Second))
 			logger.Info("Waiting for quorum healthcheck to succeed.. possible cause unhealthy sets (%s), retrying in %s", result, d)
 			time.Sleep(d)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
avoid waiting for quorum health while debugging

## Motivation and Context
if _MINIO_DEBUG_NO_EXIT is specified, then allow
for quorum health missing to facilitate debugging.

## How to test this PR?
continuation of #19953 to facilitate debugging

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
