### PR TITLE
allow server startup to come online with READ success

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -2425,7 +2425,6 @@ const (
 type HealthOptions struct {
 	Maintenance    bool
 	DeploymentType string
-	Startup        bool
 }
 
 // HealthResult returns the current state of the system, also

--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -921,14 +921,14 @@ func serverMain(ctx *cli.Context) {
 	}
 
 	bootstrapTrace("waitForQuorum", func() {
-		result := newObject.Health(context.Background(), HealthOptions{Startup: true})
-		for !result.Healthy {
+		result := newObject.Health(context.Background(), HealthOptions{})
+		for !result.HealthyRead {
 			if debugNoExit {
 				logger.Info("Not waiting for quorum since we are debugging.. possible cause unhealthy sets (%s)", result)
 				break
 			}
 			d := time.Duration(r.Float64() * float64(time.Second))
-			logger.Info("Waiting for quorum healthcheck to succeed.. possible cause unhealthy sets (%s), retrying in %s", result, d)
+			logger.Info("Waiting for quorum READ healthcheck to succeed.. possible cause unhealthy sets (%s), retrying in %s", result, d)
 			time.Sleep(d)
 			result = newObject.Health(context.Background(), HealthOptions{})
 		}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow server startup to come online with READ success

## Motivation and Context
READ is sufficient instead of WRITE quorum.

## How to test this PR?
#19953 continuation with relaxed limits

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
