### PR TITLE
fix errors in metrics code on macos

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1688,7 +1688,7 @@ func getMinioProcMetrics() *MetricsGroupV2 {
 		cacheInterval: 10 * time.Second,
 	}
 	mg.RegisterRead(func(ctx context.Context) (metrics []MetricV2) {
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == globalWindowsOSName || runtime.GOOS == globalMacOSName {
 			return nil
 		}
 

--- a/cmd/metrics-v3-system-cpu.go
+++ b/cmd/metrics-v3-system-cpu.go
@@ -55,15 +55,17 @@ func loadCPUMetrics(ctx context.Context, m MetricValues, c *metricsCache) error 
 	}
 
 	ts := cpuMetrics.TimesStat
-	tot := ts.User + ts.System + ts.Idle + ts.Iowait + ts.Nice + ts.Steal
-	cpuUserVal := math.Round(ts.User/tot*100*100) / 100
-	m.Set(sysCPUUser, cpuUserVal)
-	cpuSystemVal := math.Round(ts.System/tot*100*100) / 100
-	m.Set(sysCPUSystem, cpuSystemVal)
-	cpuNiceVal := math.Round(ts.Nice/tot*100*100) / 100
-	m.Set(sysCPUNice, cpuNiceVal)
-	cpuStealVal := math.Round(ts.Steal/tot*100*100) / 100
-	m.Set(sysCPUSteal, cpuStealVal)
+	if ts != nil {
+		tot := ts.User + ts.System + ts.Idle + ts.Iowait + ts.Nice + ts.Steal
+		cpuUserVal := math.Round(ts.User/tot*100*100) / 100
+		m.Set(sysCPUUser, cpuUserVal)
+		cpuSystemVal := math.Round(ts.System/tot*100*100) / 100
+		m.Set(sysCPUSystem, cpuSystemVal)
+		cpuNiceVal := math.Round(ts.Nice/tot*100*100) / 100
+		m.Set(sysCPUNice, cpuNiceVal)
+		cpuStealVal := math.Round(ts.Steal/tot*100*100) / 100
+		m.Set(sysCPUSteal, cpuStealVal)
+	}
 
 	// metrics-resource.go runs a job to collect resource metrics including their Avg values and
 	// stores them in resourceMetricsMap. We can use it to get the Avg values of CPU idle and IOWait.

--- a/cmd/metrics-v3-system-process.go
+++ b/cmd/metrics-v3-system-process.go
@@ -156,11 +156,13 @@ func loadProcessMetrics(ctx context.Context, m MetricValues, c *metricsCache) er
 		m.Set(processUptimeSeconds, time.Since(globalBootTime).Seconds())
 	}
 
-	p, err := procfs.Self()
-	if err != nil {
-		metricsLogIf(ctx, err)
-	} else {
-		loadProcFSMetrics(ctx, p, m)
+	if runtime.GOOS != globalWindowsOSName && runtime.GOOS != globalMacOSName {
+		p, err := procfs.Self()
+		if err != nil {
+			metricsLogIf(ctx, err)
+		} else {
+			loadProcFSMetrics(ctx, p, m)
+		}
 	}
 
 	if globalIsDistErasure && globalLockServer != nil {


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

- do not load proc fs metrics in case of macos
- null-check TimeStat before accessing

## Motivation and Context

https://github.com/minio/minio/issues/19901

## How to test this PR?

- Run minio server on a macos machine
- Scrape prometheus metrics endpoints (both v2 and v3)
- Verify that there are no error logs on the server

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
