### PR TITLE
Fix browser UI animation

### DIFF
--- a/internal/config/browser/browser.go
+++ b/internal/config/browser/browser.go
@@ -51,7 +51,7 @@ var (
 	DefaultKVS = config.KVS{
 		config.KV{
 			Key:   browserCSPPolicy,
-			Value: "default-src 'self' 'unsafe-eval' 'unsafe-inline';",
+			Value: "default-src 'self' 'unsafe-eval' 'unsafe-inline'; script-src 'self' https://unpkg.com;  connect-src 'self' https://unpkg.com;",
 		},
 		config.KV{
 			Key:   browserHSTSSeconds,


### PR DESCRIPTION
Browse UI is not showing the animation because the default content-security-policy do not trust the file https://unpkg.com/detect-gpu@5.0.38/dist/benchmarks/d-apple.json needed by the GPU library to identify if the web browser can play it.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
