### PR TITLE
Fix error when validating DN that is not under base DN

### DIFF
--- a/internal/config/identity/ldap/ldap.go
+++ b/internal/config/identity/ldap/ldap.go
@@ -98,7 +98,7 @@ func (l *Config) GetValidatedDNForUsername(username string) (*xldap.DNSearchResu
 	// under a configured base DN in the LDAP directory.
 	validDN, isUnderBaseDN, err := l.GetValidatedUserDN(conn, username)
 	if err == nil && !isUnderBaseDN {
-		return nil, fmt.Errorf("Unable to find user DN: %w", err)
+		return nil, nil
 	}
 	return validDN, err
 }

--- a/internal/config/identity/ldap/ldap.go
+++ b/internal/config/identity/ldap/ldap.go
@@ -98,6 +98,7 @@ func (l *Config) GetValidatedDNForUsername(username string) (*xldap.DNSearchResu
 	// under a configured base DN in the LDAP directory.
 	validDN, isUnderBaseDN, err := l.GetValidatedUserDN(conn, username)
 	if err == nil && !isUnderBaseDN {
+		// Not under any configured base DN, so treat as not found.
 		return nil, nil
 	}
 	return validDN, err


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Validating a user DN that is not under the configured base DN will now return nil instead of internal error.

## Motivation and Context
Currently if a DN is being validated and it is on the LDAP server but not under the base DN it will return an internal error with `Unable to find user DN: %!w(<nil>)`. This changes the behavior so it is consistent with a user that does not exist

## How to test this PR?

1. Configure LDAP server with user_dn_search_base_dn as `ou=swengg,dc=min,dc=io`
2. `mc idp ldap policy attach` to user `uid=bobfisher,ou=people,ou=hwengg,dc=min,dc=io`
Previously this attach would return an internal error, it should now return `mc: <ERROR> Unable to make LDAP policy association. The specified user does not exist. (Specified user does not exist)`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
