### PR TITLE
fix: gcs tier going offline due to customer HTTPclient

### DIFF
--- a/cmd/warm-backend-gcs.go
+++ b/cmd/warm-backend-gcs.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 
 	"cloud.google.com/go/storage"
 	"github.com/minio/madmin-go/v3"
@@ -118,14 +117,9 @@ func newWarmBackendGCS(conf madmin.TierGCS, tier string) (*warmBackendGCS, error
 		return nil, err
 	}
 
-	clnt := &http.Client{
-		Transport: globalRemoteTargetTransport,
-	}
-
 	client, err := storage.NewClient(context.Background(),
 		option.WithCredentialsJSON(credsJSON),
 		option.WithScopes(storage.ScopeReadWrite),
-		option.WithHTTPClient(clnt),
 		option.WithUserAgent(fmt.Sprintf("gcs-tier-%s", tier)+SlashSeparator+ReleaseTag),
 	)
 	if err != nil {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: gcs tier going offline due to customer HTTP client

## Motivation and Context
specifying customer HTTP client makes the GCS SDK
ignore the passed credentials, instead let the GCS 
SDK manages the transport.

this PR fixes #19922 a regression from #19565

## How to test this PR?
As per #19922

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression from #19565
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
