### PR TITLE
tests: Add loaded grid reconnection test

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -1808,8 +1808,8 @@ func (c *Connection) debugMsg(d debugMsg, args ...any) {
 	for drain {
 		select {
 		case _, ok := <-c.outQueue:
-			if !ok {
-				drain = false
+			if ok {
+				continue
 			}
 		default:
 		}

--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -1093,7 +1093,10 @@ func (c *Connection) handleMessages(ctx context.Context, conn net.Conn) {
 			}
 			block := c.blockMessages.Load()
 			if block != nil && *block != nil {
-				<-*block
+				select {
+				case <-*block:
+				case <-ctx.Done():
+				}
 			}
 
 			if c.incomingBytes != nil {

--- a/internal/grid/connection_test.go
+++ b/internal/grid/connection_test.go
@@ -169,7 +169,7 @@ func TestDisconnect(t *testing.T) {
 
 func TestDisconnectUnderLoad(t *testing.T) {
 	defer testlogger.T.SetLogTB(t)()
-	defer timeout(30 * time.Second)()
+	defer timeout(120 * time.Second)()
 	hosts, listeners, _ := getHosts(2)
 	dialer := &net.Dialer{
 		Timeout: 1 * time.Second,

--- a/internal/grid/connection_test.go
+++ b/internal/grid/connection_test.go
@@ -330,13 +330,13 @@ func disconnectConnections(msg debugMsg, c ...*Connection) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	for _, conn := range c {
-		go func() {
+		go func(c *Connection) {
 			defer wg.Done()
-			conn.debugMsg(msg)
+			c.debugMsg(msg)
 			// There is a small race here...
 			// Technically the connection could be re-established before we wait for the disconnect.
-			conn.waitForDisconnect(ctx)
-		}()
+			c.waitForDisconnect(ctx)
+		}(conn)
 	}
 	wg.Wait()
 }

--- a/internal/grid/connection_test.go
+++ b/internal/grid/connection_test.go
@@ -286,8 +286,8 @@ func TestDisconnectUnderLoad(t *testing.T) {
 	disconnectConnections(debugKillInbound, remoteConn, localConn)
 
 	// Must reconnect
-	errFatal(remoteConn.WaitForConnect(context.Background()))
 	close(nowBlocking)
+	errFatal(remoteConn.WaitForConnect(context.Background()))
 	close(cleanReqs1)
 	respWg.Wait()
 
@@ -316,8 +316,8 @@ func TestDisconnectUnderLoad(t *testing.T) {
 	disconnectConnections(debugKillOutbound, remoteConn, localConn)
 
 	// Must reconnect
-	errFatal(remoteConn.WaitForConnect(context.Background()))
 	close(nowBlocking)
+	errFatal(remoteConn.WaitForConnect(context.Background()))
 	close(cleanReqs2)
 	respWg.Wait()
 }

--- a/internal/grid/grid_test.go
+++ b/internal/grid/grid_test.go
@@ -1260,7 +1260,7 @@ func timeout(after time.Duration) (cancel func()) {
 		case <-cc:
 			return
 		case <-c:
-			buf := make([]byte, 1<<20)
+			buf := make([]byte, 250<<20)
 			stacklen := runtime.Stack(buf, true)
 			fmt.Printf("=== Timeout, assuming deadlock ===\n*** goroutine dump...\n%s\n*** end\n", string(buf[:stacklen]))
 			os.Exit(2)


### PR DESCRIPTION
## Description

Adds regression test to ensure that reconnects are handled without blocking even under heavy load.

Contains no functional fixes, beside test related.

## How to test this PR?

Tested with `go test -run=TestDisconnectUnderLoad -count=50`.


## Types of changes
- [x] Unit tests added/updated
