### PR TITLE
 heal: List and heal again for any listing error

### DIFF
--- a/cmd/erasure-healing.go
+++ b/cmd/erasure-healing.go
@@ -629,7 +629,7 @@ func (er *erasureObjects) healObject(ctx context.Context, bucket string, object 
 		}
 
 		for i, v := range result.Before.Drives {
-			if v.Endpoint == disk.String() {
+			if v.Endpoint == disk.Endpoint().String() {
 				result.After.Drives[i].State = madmin.DriveStateOk
 			}
 		}

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -519,9 +519,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 				go healEntry(bucket, *entry)
 			},
 			finished: func(errs []error) {
-				found := false
-				found := countErrs(errs, nil) != len(errs)
-				if found {
+				if countErrs(errs, nil) != len(errs) {
 					retErr = fmt.Errorf("one or more errors reported during listing: %v", errors.Join(errs...))
 				}
 			},

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -520,12 +520,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 			},
 			finished: func(errs []error) {
 				found := false
-				for _, e := range errs {
-					if e != nil {
-						found = true
-						break
-					}
-				}
+				found := countErrs(errs, nil) != len(errs)
 				if found {
 					retErr = fmt.Errorf("one or more errors reported during listing: %v", errs)
 				}

--- a/cmd/global-heal.go
+++ b/cmd/global-heal.go
@@ -522,7 +522,7 @@ func (er *erasureObjects) healErasureSet(ctx context.Context, buckets []string, 
 				found := false
 				found := countErrs(errs, nil) != len(errs)
 				if found {
-					retErr = fmt.Errorf("one or more errors reported during listing: %v", errs)
+					retErr = fmt.Errorf("one or more errors reported during listing: %v", errors.Join(errs...))
 				}
 			},
 		})


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
When a fresh drive healing is finished, add more check for drive listing
errors. If any, re-list and heal again. Although this is a very rare use
case to have listPathRaw() returning nil when minDisks is set to 1, we
still need to handle all possibles use cases to avoid missing healing
any object.

Also check for HealObject result to decide of an object is healed in the
fresh disk since HealObject returns nil if an object is healed in any
disk, and not in the new fresh drive.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
