### PR TITLE
Letting password enable auth bypass caPublicKey (only if passauth is …

### DIFF
--- a/cmd/sftp-server.go
+++ b/cmd/sftp-server.go
@@ -161,11 +161,13 @@ internalAuth:
 		return nil, errNoSuchUser
 	}
 
-	if caPublicKey != nil {
+	if caPublicKey != nil && pass == nil {
+
 		err := validateKey(c, key)
 		if err != nil {
 			return nil, errAuthentication
 		}
+
 	} else {
 
 		// Temporary credentials are not allowed.


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes a bug where password auth is disabled if caPublicKey is enabled.


## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression 
#19650
 #19833
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
