### PR TITLE
tests: Fix setting max openfds as memory limit

### DIFF
--- a/cmd/server-rlimit.go
+++ b/cmd/server-rlimit.go
@@ -82,11 +82,7 @@ func setMaxResources(ctx serverCtxt) (err error) {
 	}
 
 	if ctx.MemLimit > 0 {
-		maxLimit = ctx.MemLimit
-	}
-
-	if maxLimit > 0 {
-		debug.SetMemoryLimit(int64(maxLimit))
+		debug.SetMemoryLimit(int64(ctx.MemLimit))
 	}
 
 	// Do not use RLIMIT_AS as that is not useful and at times on systems < 4Gi


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The code was inadvertenly passing max openfds to debug.SetMemoryLimit(), 
fixing this accelerate go test in my machine.

This is only a testing bug, since the server context has always a valid MaxMem, 
so the buggy code was never called in users environments.


## Motivation and Context
Fix testing slowness

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
