### PR TITLE
Fix SkipReader performance with small initial read

### DIFF
--- a/buildscripts/race.sh
+++ b/buildscripts/race.sh
@@ -6,5 +6,5 @@ export GORACE="history_size=7"
 export MINIO_API_REQUESTS_MAX=10000
 
 for d in $(go list ./...); do
-	CGO_ENABLED=1 go test -v -race --timeout 100m "$d"
+	CGO_ENABLED=1 go test -v -race -short --timeout 100m "$d"
 done

--- a/cmd/dummy-data-generator_test.go
+++ b/cmd/dummy-data-generator_test.go
@@ -61,10 +61,9 @@ func NewDummyDataGen(totalLength, skipOffset int64) io.ReadSeeker {
 	}
 
 	skipOffset %= int64(len(alphabets))
-	as := make([]byte, 2*len(alphabets))
-	copy(as, alphabets)
-	copy(as[len(alphabets):], alphabets)
-	b := as[skipOffset : skipOffset+int64(len(alphabets))]
+	const multiply = 100
+	as := bytes.Repeat(alphabets, multiply)
+	b := as[skipOffset : skipOffset+int64(len(alphabets)*(multiply-1))]
 	return &DummyDataGen{
 		length: totalLength,
 		b:      b,

--- a/cmd/object_api_suite_test.go
+++ b/cmd/object_api_suite_test.go
@@ -559,13 +559,9 @@ func execExtended(t *testing.T, fn func(t *testing.T, init func(), bucketOptions
 	t.Run("default", func(t *testing.T) {
 		fn(t, nil, MakeBucketOptions{})
 	})
-	t.Run("defaultVerioned", func(t *testing.T) {
+	t.Run("default+versioned", func(t *testing.T) {
 		fn(t, nil, MakeBucketOptions{VersioningEnabled: true})
 	})
-
-	if testing.Short() {
-		return
-	}
 
 	t.Run("compressed", func(t *testing.T) {
 		fn(t, func() {
@@ -573,7 +569,7 @@ func execExtended(t *testing.T, fn func(t *testing.T, init func(), bucketOptions
 			enableCompression(t, false, []string{"*"}, []string{"*"})
 		}, MakeBucketOptions{})
 	})
-	t.Run("compressedVerioned", func(t *testing.T) {
+	t.Run("compressed+versioned", func(t *testing.T) {
 		fn(t, func() {
 			resetCompressEncryption()
 			enableCompression(t, false, []string{"*"}, []string{"*"})
@@ -588,7 +584,7 @@ func execExtended(t *testing.T, fn func(t *testing.T, init func(), bucketOptions
 			enableEncryption(t)
 		}, MakeBucketOptions{})
 	})
-	t.Run("encryptedVerioned", func(t *testing.T) {
+	t.Run("encrypted+versioned", func(t *testing.T) {
 		fn(t, func() {
 			resetCompressEncryption()
 			enableEncryption(t)
@@ -603,7 +599,7 @@ func execExtended(t *testing.T, fn func(t *testing.T, init func(), bucketOptions
 			enableCompression(t, true, []string{"*"}, []string{"*"})
 		}, MakeBucketOptions{})
 	})
-	t.Run("compressed+encryptedVerioned", func(t *testing.T) {
+	t.Run("compressed+encrypted+versioned", func(t *testing.T) {
 		fn(t, func() {
 			resetCompressEncryption()
 			enableCompression(t, true, []string{"*"}, []string{"*"})


### PR DESCRIPTION
## Description

If `SkipReader` is called with a small initial buffer it may be doing a huge number if Reads to skip the requested number of bytes. If a small buffer is provided grab a 32K buffer and use that. May only be a practical issue in tests - cannot tell.

Fixes slow execution of `testAPIGetObjectWithMPHandler`.

Bonuses:

* Use `-short` with `-race` test.
* Do all suite test types with `-short`.
* Enable compressed+encrypted in `testAPIGetObjectWithMPHandler`.
* Disable big file tests in `testAPIGetObjectWithMPHandler` when using `-short`.

## How to test this PR?

Run tests.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
- [x] Unit tests added/updated
