### PR TITLE
Tier update: return a better error when incorrect credentials or other error encountered

### DIFF
--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -216,9 +216,9 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
-		case errors.Is(err, errTierSetupFailed):
+		case errors.Is(err, errTierInvalidConfig):
 			apiErr = APIError{
-				Code:           "XMinioAdminTierSetupFailed",
+				Code:           "XMinioAdminTierInvalidConfig",
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}

--- a/cmd/admin-handler-utils.go
+++ b/cmd/admin-handler-utils.go
@@ -216,6 +216,12 @@ func toAdminAPIErr(ctx context.Context, err error) APIError {
 				Description:    err.Error(),
 				HTTPStatusCode: http.StatusBadRequest,
 			}
+		case errors.Is(err, errTierSetupFailed):
+			apiErr = APIError{
+				Code:           "XMinioAdminTierSetupFailed",
+				Description:    err.Error(),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
 		default:
 			apiErr = errorCodes.ToAPIErrWithErr(toAdminAPIErrCode(ctx, err), err)
 		}

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -65,9 +65,9 @@ var (
 		StatusCode: http.StatusBadRequest,
 	}
 
-	errTierSetupFailed = AdminError{
-		Code:       "XMinioAdminTierSetupFailed",
-		Message:    "Failed to setup remote tier, check credentials",
+	errTierInvalidConfig = AdminError{
+		Code:       "XMinioAdminTierInvalidConfig",
+		Message:    "Unable to setup remote tier, check tier configuration",
 		StatusCode: http.StatusBadRequest,
 	}
 )

--- a/cmd/tier.go
+++ b/cmd/tier.go
@@ -64,6 +64,12 @@ var (
 		Message:    "Specified remote backend is not empty",
 		StatusCode: http.StatusBadRequest,
 	}
+
+	errTierSetupFailed = AdminError{
+		Code:       "XMinioAdminTierSetupFailed",
+		Message:    "Failed to setup remote tier, check credentials",
+		StatusCode: http.StatusBadRequest,
+	}
 )
 
 const (

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -144,7 +144,7 @@ func newWarmBackend(ctx context.Context, tier madmin.TierConfig, probe bool) (d 
 		return nil, errTierTypeUnsupported
 	}
 	if err != nil {
-		return nil, errTierTypeUnsupported
+		return nil, errTierSetupFailed
 	}
 
 	if probe {

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -144,7 +144,8 @@ func newWarmBackend(ctx context.Context, tier madmin.TierConfig, probe bool) (d 
 		return nil, errTierTypeUnsupported
 	}
 	if err != nil {
-		return nil, errTierSetupFailed
+		tierLogIf(ctx, errors.Join(err, errTierInvalidConfig))
+		return nil, errTierInvalidConfig
 	}
 
 	if probe {

--- a/cmd/warm-backend.go
+++ b/cmd/warm-backend.go
@@ -144,7 +144,7 @@ func newWarmBackend(ctx context.Context, tier madmin.TierConfig, probe bool) (d 
 		return nil, errTierTypeUnsupported
 	}
 	if err != nil {
-		tierLogIf(ctx, errors.Join(err, errTierInvalidConfig))
+		tierLogIf(ctx, err)
 		return nil, errTierInvalidConfig
 	}
 


### PR DESCRIPTION
…p fails for tier

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

We currently return `Specified tier type is unsupported` when actually the tier might be supported, just the credentials are wrong or some other problem has occurred. This adds another error type with the message `Failed to setup remote tier, check credentials` so that mc returns this:

```
❯ ./mc ilm tier update ...wrong creds...
mc: <ERROR> Unable to edit remote tier. Failed to setup remote tier, check credentials.
```

We could even expand this to be even more specific or return actual error, if anyone thinks it should be done?

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
