### PR TITLE
Satisfy `aws:SecureTransport` policy behind reverse proxy

### DIFF
--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -125,10 +125,15 @@ func getConditionValues(r *http.Request, lc string, cred auth.Credentials) map[s
 		authtype = "POST"
 	}
 
+	secureTransport := r.TLS != nil
+	if forwardedScheme := handlers.GetSourceScheme(r); forwardedScheme != "" {
+		secureTransport = forwardedScheme == "https"
+	}
+
 	args := map[string][]string{
 		"CurrentTime":      {currTime.Format(time.RFC3339)},
 		"EpochTime":        {strconv.FormatInt(currTime.Unix(), 10)},
-		"SecureTransport":  {strconv.FormatBool(r.TLS != nil)},
+		"SecureTransport":  {strconv.FormatBool(secureTransport)},
 		"SourceIp":         {handlers.GetSourceIPRaw(r)},
 		"UserAgent":        {r.UserAgent()},
 		"Referer":          {r.Referer()},


### PR DESCRIPTION
This PR addresses the issue in #20061.

Use the following setup to reproduce this issue:
- Set up NGINX with proper SSL termination on https://minio.example.com that forwards traffic to http://localhost:9000 (for MinIO) and http://localhost:9001 (for console on https://minio.example.com/minio/ui). Make sure the NGINX configuration follows our [guidelines](https://min.io/docs/minio/linux/integrations/setup-nginx-proxy-with-minio.html).
- Created the following policy and assigned it to user `test`.
  ```json
  {
      "Version": "2012-10-17",
      "Statement": [
          {
              "Effect": "Allow",
              "Action": ["s3:*"],
              "Resource": ["arn:aws:s3:::*"]
          },
          {
              "Sid": "Allow SSL communication only",
              "Effect": "Deny",
              "Action": ["s3:*"],
              "Resource": ["arn:aws:s3:::*"],
              "Condition": {
                  "Bool": {
                      "aws:SecureTransport": [ "false" ]
                  }
              }
          }
      ]
  }
  ```
- Register `mc alias set test https://minio.example.com/ test minio123`.

Running `mc ls test` shows `mc: <ERROR> Unable to list folder. Access Denied.`. When removing the second statement it works fine. Because MinIO is using TLS, I would expect it to succeed.

After code inspection, I found the following ([`bucket-policy.go:131`](https://github.com/minio/minio/blob/380233d646b3e02e8c9f389b8bb02d131d5a06c9/cmd/bucket-policy.go#L131)):
```go
"SecureTransport":  {strconv.FormatBool(r.TLS != nil)},
```
MinIO checks if the request (as MinIO receives it) is using TLS, but it's not checking the headers that may have been added by the reverse proxy. This PR checks if the forwarding headers are set and if so, these take precedence.