### PR TITLE
Tweak grid for less writes

### DIFF
--- a/internal/grid/grid.go
+++ b/internal/grid/grid.go
@@ -57,7 +57,7 @@ const (
 	biggerBufMax = maxBufferSize
 
 	// If there is a queue, merge up to this many messages.
-	maxMergeMessages = 30
+	maxMergeMessages = 50
 
 	// clientPingInterval will ping the remote handler every 15 seconds.
 	// Clients disconnect when we exceed 2 intervals.
@@ -126,7 +126,8 @@ var PutByteBuffer = func(b []byte) {
 // A successful call returns err == nil, not err == EOF. Because readAllInto is
 // defined to read from src until EOF, it does not treat an EOF from Read
 // as an error to be reported.
-func readAllInto(b []byte, r *wsutil.Reader) ([]byte, error) {
+func readAllInto(b []byte, r *wsutil.Reader, want int64) ([]byte, error) {
+	read := int64(0)
 	for {
 		if len(b) == cap(b) {
 			// Add more capacity (let append pick how much).
@@ -136,9 +137,17 @@ func readAllInto(b []byte, r *wsutil.Reader) ([]byte, error) {
 		b = b[:len(b)+n]
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				if want >= 0 && read+int64(n) != want {
+					return nil, io.ErrUnexpectedEOF
+				}
 				err = nil
 			}
 			return b, err
+		}
+		read += int64(n)
+		if want >= 0 && read == want {
+			// No need to read more...
+			return b, nil
 		}
 	}
 }


### PR DESCRIPTION
## Description

Use `runtime.Gosched()` if we have less than maxMergeMessages and queue is empty. Up maxMergeMessages to 50 to allow more messages to be merged into a single write.

Add length check for early bailout on readAllInto when we know packet length.

## How to test this PR?

Distributed cluster, high load + #20128

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
