### PR TITLE
use unixNanoTime instead of time.Time in lockRequestorInfo

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -848,9 +848,10 @@ func (a adminAPIHandlers) DataUsageInfoHandler(w http.ResponseWriter, r *http.Re
 }
 
 func lriToLockEntry(l lockRequesterInfo, now time.Time, resource, server string) *madmin.LockEntry {
+	t := time.Unix(0, l.Timestamp)
 	entry := &madmin.LockEntry{
-		Timestamp:  l.Timestamp,
-		Elapsed:    now.Sub(l.Timestamp),
+		Timestamp:  t,
+		Elapsed:    now.Sub(t),
 		Resource:   resource,
 		ServerList: []string{server},
 		Source:     l.Source,

--- a/cmd/admin-handlers_test.go
+++ b/cmd/admin-handlers_test.go
@@ -463,6 +463,7 @@ func TestTopLockEntries(t *testing.T) {
 			Owner:      lri.Owner,
 			ID:         lri.UID,
 			Quorum:     lri.Quorum,
+			Timestamp:  time.Unix(0, lri.Timestamp),
 		})
 	}
 

--- a/cmd/local-locker_gen.go
+++ b/cmd/local-locker_gen.go
@@ -204,13 +204,13 @@ func (z *lockRequesterInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "Timestamp":
-			z.Timestamp, err = dc.ReadTime()
+			z.Timestamp, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Timestamp")
 				return
 			}
 		case "TimeLastRefresh":
-			z.TimeLastRefresh, err = dc.ReadTime()
+			z.TimeLastRefresh, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "TimeLastRefresh")
 				return
@@ -288,7 +288,7 @@ func (z *lockRequesterInfo) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteTime(z.Timestamp)
+	err = en.WriteInt64(z.Timestamp)
 	if err != nil {
 		err = msgp.WrapError(err, "Timestamp")
 		return
@@ -298,7 +298,7 @@ func (z *lockRequesterInfo) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteTime(z.TimeLastRefresh)
+	err = en.WriteInt64(z.TimeLastRefresh)
 	if err != nil {
 		err = msgp.WrapError(err, "TimeLastRefresh")
 		return
@@ -361,10 +361,10 @@ func (z *lockRequesterInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendString(o, z.UID)
 	// string "Timestamp"
 	o = append(o, 0xa9, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70)
-	o = msgp.AppendTime(o, z.Timestamp)
+	o = msgp.AppendInt64(o, z.Timestamp)
 	// string "TimeLastRefresh"
 	o = append(o, 0xaf, 0x54, 0x69, 0x6d, 0x65, 0x4c, 0x61, 0x73, 0x74, 0x52, 0x65, 0x66, 0x72, 0x65, 0x73, 0x68)
-	o = msgp.AppendTime(o, z.TimeLastRefresh)
+	o = msgp.AppendInt64(o, z.TimeLastRefresh)
 	// string "Source"
 	o = append(o, 0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
 	o = msgp.AppendString(o, z.Source)
@@ -417,13 +417,13 @@ func (z *lockRequesterInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "Timestamp":
-			z.Timestamp, bts, err = msgp.ReadTimeBytes(bts)
+			z.Timestamp, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Timestamp")
 				return
 			}
 		case "TimeLastRefresh":
-			z.TimeLastRefresh, bts, err = msgp.ReadTimeBytes(bts)
+			z.TimeLastRefresh, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "TimeLastRefresh")
 				return
@@ -466,7 +466,7 @@ func (z *lockRequesterInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *lockRequesterInfo) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 7 + msgp.BoolSize + 4 + msgp.StringPrefixSize + len(z.UID) + 10 + msgp.TimeSize + 16 + msgp.TimeSize + 7 + msgp.StringPrefixSize + len(z.Source) + 6 + msgp.BoolSize + 6 + msgp.StringPrefixSize + len(z.Owner) + 7 + msgp.IntSize
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.Name) + 7 + msgp.BoolSize + 4 + msgp.StringPrefixSize + len(z.UID) + 10 + msgp.Int64Size + 16 + msgp.Int64Size + 7 + msgp.StringPrefixSize + len(z.Source) + 6 + msgp.BoolSize + 6 + msgp.StringPrefixSize + len(z.Owner) + 7 + msgp.IntSize
 	return
 }
 

--- a/cmd/lock-rest-server-common_test.go
+++ b/cmd/lock-rest-server-common_test.go
@@ -63,15 +63,15 @@ func TestLockRpcServerRemoveEntry(t *testing.T) {
 		Owner:           "owner",
 		Writer:          true,
 		UID:             "0123-4567",
-		Timestamp:       UTCNow(),
-		TimeLastRefresh: UTCNow(),
+		Timestamp:       UTCNow().UnixNano(),
+		TimeLastRefresh: UTCNow().UnixNano(),
 	}
 	lockRequesterInfo2 := lockRequesterInfo{
 		Owner:           "owner",
 		Writer:          true,
 		UID:             "89ab-cdef",
-		Timestamp:       UTCNow(),
-		TimeLastRefresh: UTCNow(),
+		Timestamp:       UTCNow().UnixNano(),
+		TimeLastRefresh: UTCNow().UnixNano(),
 	}
 
 	locker.ll.lockMap["name"] = []lockRequesterInfo{

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -34,6 +34,7 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/google/uuid"
 	"github.com/klauspost/compress/s2"
@@ -244,6 +245,24 @@ func pathsJoinPrefix(prefix string, elem ...string) (paths []string) {
 		paths[i] = pathJoin(prefix, e)
 	}
 	return paths
+}
+
+// string concat alternative to s1 + s2 with low overhead.
+func concat(ss ...string) string {
+	length := len(ss)
+	if length == 0 {
+		return ""
+	}
+	// create & allocate the memory in advance.
+	n := 0
+	for i := 0; i < length; i++ {
+		n += len(ss[i])
+	}
+	b := make([]byte, 0, n)
+	for i := 0; i < length; i++ {
+		b = append(b, ss[i]...)
+	}
+	return unsafe.String(unsafe.SliceData(b), n)
 }
 
 // pathJoin - like path.Join() but retains trailing SlashSeparator of the last element

--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -433,7 +433,7 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 		UID:       id,
 		Resources: names,
 		Source:    source,
-		Quorum:    quorum,
+		Quorum:    &quorum,
 	}
 
 	// Combined timeout for the lock attempt.

--- a/internal/dsync/lock-args.go
+++ b/internal/dsync/lock-args.go
@@ -27,16 +27,16 @@ type LockArgs struct {
 	// Resources contains single or multiple entries to be locked/unlocked.
 	Resources []string
 
-	// Source contains the line number, function and file name of the code
-	// on the client node that requested the lock.
-	Source string
-
 	// Owner represents unique ID for this instance, an owner who originally requested
 	// the locked resource, useful primarily in figuring out stale locks.
 	Owner string
 
+	// Source contains the line number, function and file name of the code
+	// on the client node that requested the lock.
+	Source string `msgp:"omitempty"`
+
 	// Quorum represents the expected quorum for this lock type.
-	Quorum int
+	Quorum *int `msgp:"omitempty"`
 }
 
 // ResponseCode is the response code for a locking request.

--- a/internal/dsync/lock-args_gen.go
+++ b/internal/dsync/lock-args_gen.go
@@ -49,23 +49,35 @@ func (z *LockArgs) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-		case "Source":
-			z.Source, err = dc.ReadString()
-			if err != nil {
-				err = msgp.WrapError(err, "Source")
-				return
-			}
 		case "Owner":
 			z.Owner, err = dc.ReadString()
 			if err != nil {
 				err = msgp.WrapError(err, "Owner")
 				return
 			}
-		case "Quorum":
-			z.Quorum, err = dc.ReadInt()
+		case "Source":
+			z.Source, err = dc.ReadString()
 			if err != nil {
-				err = msgp.WrapError(err, "Quorum")
+				err = msgp.WrapError(err, "Source")
 				return
+			}
+		case "Quorum":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "Quorum")
+					return
+				}
+				z.Quorum = nil
+			} else {
+				if z.Quorum == nil {
+					z.Quorum = new(int)
+				}
+				*z.Quorum, err = dc.ReadInt()
+				if err != nil {
+					err = msgp.WrapError(err, "Quorum")
+					return
+				}
 			}
 		default:
 			err = dc.Skip()
@@ -108,16 +120,6 @@ func (z *LockArgs) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
-	// write "Source"
-	err = en.Append(0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
-	if err != nil {
-		return
-	}
-	err = en.WriteString(z.Source)
-	if err != nil {
-		err = msgp.WrapError(err, "Source")
-		return
-	}
 	// write "Owner"
 	err = en.Append(0xa5, 0x4f, 0x77, 0x6e, 0x65, 0x72)
 	if err != nil {
@@ -128,15 +130,32 @@ func (z *LockArgs) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Owner")
 		return
 	}
+	// write "Source"
+	err = en.Append(0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.Source)
+	if err != nil {
+		err = msgp.WrapError(err, "Source")
+		return
+	}
 	// write "Quorum"
 	err = en.Append(0xa6, 0x51, 0x75, 0x6f, 0x72, 0x75, 0x6d)
 	if err != nil {
 		return
 	}
-	err = en.WriteInt(z.Quorum)
-	if err != nil {
-		err = msgp.WrapError(err, "Quorum")
-		return
+	if z.Quorum == nil {
+		err = en.WriteNil()
+		if err != nil {
+			return
+		}
+	} else {
+		err = en.WriteInt(*z.Quorum)
+		if err != nil {
+			err = msgp.WrapError(err, "Quorum")
+			return
+		}
 	}
 	return
 }
@@ -154,15 +173,19 @@ func (z *LockArgs) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0001 := range z.Resources {
 		o = msgp.AppendString(o, z.Resources[za0001])
 	}
-	// string "Source"
-	o = append(o, 0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
-	o = msgp.AppendString(o, z.Source)
 	// string "Owner"
 	o = append(o, 0xa5, 0x4f, 0x77, 0x6e, 0x65, 0x72)
 	o = msgp.AppendString(o, z.Owner)
+	// string "Source"
+	o = append(o, 0xa6, 0x53, 0x6f, 0x75, 0x72, 0x63, 0x65)
+	o = msgp.AppendString(o, z.Source)
 	// string "Quorum"
 	o = append(o, 0xa6, 0x51, 0x75, 0x6f, 0x72, 0x75, 0x6d)
-	o = msgp.AppendInt(o, z.Quorum)
+	if z.Quorum == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o = msgp.AppendInt(o, *z.Quorum)
+	}
 	return
 }
 
@@ -209,23 +232,34 @@ func (z *LockArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-		case "Source":
-			z.Source, bts, err = msgp.ReadStringBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Source")
-				return
-			}
 		case "Owner":
 			z.Owner, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Owner")
 				return
 			}
-		case "Quorum":
-			z.Quorum, bts, err = msgp.ReadIntBytes(bts)
+		case "Source":
+			z.Source, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "Quorum")
+				err = msgp.WrapError(err, "Source")
 				return
+			}
+		case "Quorum":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.Quorum = nil
+			} else {
+				if z.Quorum == nil {
+					z.Quorum = new(int)
+				}
+				*z.Quorum, bts, err = msgp.ReadIntBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Quorum")
+					return
+				}
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -245,7 +279,12 @@ func (z *LockArgs) Msgsize() (s int) {
 	for za0001 := range z.Resources {
 		s += msgp.StringPrefixSize + len(z.Resources[za0001])
 	}
-	s += 7 + msgp.StringPrefixSize + len(z.Source) + 6 + msgp.StringPrefixSize + len(z.Owner) + 7 + msgp.IntSize
+	s += 6 + msgp.StringPrefixSize + len(z.Owner) + 7 + msgp.StringPrefixSize + len(z.Source) + 7
+	if z.Quorum == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.IntSize
+	}
 	return
 }
 


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
use unixNanoTime instead of time.Time in lockRequestorInfo

## Motivation and Context
Bonus: Skip Source and Quorum fields in lockArgs that are 
never sent during Unlock() phase.

## How to test this PR?
This is mainly a data structure optimization to reduce
the size of the message from a few bytes, while these are 
It is probably a bit over the top in general scenarios; there
are precise situations where the amount of locks and unlocks
held at high concurrency can become a problem for map
based lockers when their inherent runtime memory adds
latency. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
