### PR TITLE
avoid sendFile() for ranges or object lengths < 4MiB

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2067,7 +2067,6 @@ func (s *xlStorage) ReadFileStream(ctx context.Context, volume, path string, off
 			return nil, err
 		}
 	}
-
 	return &sendFileReader{Reader: io.LimitReader(file, length), Closer: file}, nil
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request, I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
avoid sendFile() for ranges or object lengths < 4MiB

## Motivation and Context
SendFile() has a tiny overhead for smaller streams

## How to test this PR?
It is more challenging to test on laptops; the results are
```
* Average: +6.07% (+1077.3 MiB/s) throughput, +6.07% (+269.3) obj/s
```

There is a consistent number here.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
