### PR TITLE
allow for canceling pending callers in goroutine, if we are returning

### DIFF
--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -442,7 +442,9 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 
 	// Special context for NetLockers - do not use timeouts.
 	// Also, pass the trace context info if found for debugging
-	netLockCtx := context.Background()
+	netLockCtx, newCancel := context.WithCancel(context.Background())
+	defer newCancel()
+
 	tc, ok := ctx.Value(mcontext.ContextTraceKey).(*mcontext.TraceCtxt)
 	if ok {
 		netLockCtx = context.WithValue(netLockCtx, mcontext.ContextTraceKey, tc)
@@ -529,7 +531,7 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 	// We may have some unused results in ch, release them async.
 	go func() {
 		wg.Wait()
-		xioutil.SafeClose(ch)
+		close(ch)
 		for grantToBeReleased := range ch {
 			if grantToBeReleased.isLocked() {
 				// release abandoned lock


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow for canceling pending callers in goroutine, if we are returning

## Motivation and Context
cancels ongoing goroutines if any that may linger around
until some network error, instead cancel if we are returning
right away. 

## How to test this PR?
Observe a pending slow RLock or Lock would be blocking however 
if the client timedout early, this goroutine would linger around
very long, instead we can cancel and retry.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
