### PR TITLE
fix replication of checksum when encryption is enabled

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -1172,6 +1172,14 @@ func (o *ObjectInfo) decryptChecksums(part int, h http.Header) map[string]string
 	if len(data) == 0 {
 		return nil
 	}
+	if part > 0 && !crypto.SSEC.IsEncrypted(o.UserDefined) {
+		// already decrypted in ToObjectInfo for multipart objects
+		for _, pi := range o.Parts {
+			if pi.Number == part {
+				return pi.Checksums
+			}
+		}
+	}
 	if _, encrypted := crypto.IsEncrypted(o.UserDefined); encrypted {
 		decrypted, err := o.metadataDecrypter(h)("object-checksum", data)
 		if err != nil {

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -174,6 +174,7 @@ func (fi FileInfo) ToObjectInfo(bucket, object string, versioned bool) ObjectInf
 		}
 	}
 	objInfo.Checksum = fi.Checksum
+	objInfo.decryptPartsChecksums(nil)
 	objInfo.Inlined = fi.InlineData()
 	// Success.
 	return objInfo

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -248,10 +248,19 @@ func checkPreconditions(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	}
 
 	// Check if the part number is correct.
-	if opts.PartNumber > 1 && opts.PartNumber > len(objInfo.Parts) {
-		// According to S3 we don't need to set any object information here.
-		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidPartNumber), r.URL)
-		return true
+	if opts.PartNumber > 1 {
+		partFound := false
+		for _, pi := range objInfo.Parts {
+			if pi.Number == opts.PartNumber {
+				partFound = true
+				break
+			}
+		}
+		if !partFound {
+			// According to S3 we don't need to set any object information here.
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidPartNumber), r.URL)
+			return true
+		}
 	}
 
 	// If-None-Match : Return the object only if its entity tag (ETag) is different from the

--- a/docs/site-replication/run-replication-with-checksum-header.sh
+++ b/docs/site-replication/run-replication-with-checksum-header.sh
@@ -65,8 +65,8 @@ echo "done"
 
 # Start MinIO instances
 echo -n "Starting MinIO instances ..."
-CI=on MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server --certs-dir /tmp/certs --address ":9001" --console-address ":10000" /tmp/minio1/{1...4}/disk{1...4} /tmp/minio1/{5...8}/disk{1...4} >/tmp/minio1_1.log 2>&1 &
-CI=on MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server --certs-dir /tmp/certs --address ":9002" --console-address ":11000" /tmp/minio2/{1...4}/disk{1...4} /tmp/minio2/{5...8}/disk{1...4} >/tmp/minio2_1.log 2>&1 &
+CI=on MINIO_KMS_SECRET_KEY=minio-default-key:IyqsU3kMFloCNup4BsZtf/rmfHVcTgznO2F25CkEH1g= MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server --certs-dir /tmp/certs --address ":9001" --console-address ":10000" /tmp/minio1/{1...4}/disk{1...4} /tmp/minio1/{5...8}/disk{1...4} >/tmp/minio1_1.log 2>&1 &
+CI=on MINIO_KMS_SECRET_KEY=minio-default-key:IyqsU3kMFloCNup4BsZtf/rmfHVcTgznO2F25CkEH1g= MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server --certs-dir /tmp/certs --address ":9002" --console-address ":11000" /tmp/minio2/{1...4}/disk{1...4} /tmp/minio2/{5...8}/disk{1...4} >/tmp/minio2_1.log 2>&1 &
 echo "done"
 
 if [ ! -f ./mc ]; then
@@ -99,7 +99,7 @@ sleep 30
 echo "Create bucket in source MinIO instance"
 ./mc mb minio1/test-bucket --insecure
 
-# Load objects to source site
+# Load objects to source site with checksum header
 echo "Loading objects to source MinIO instance"
 OBJ_CHKSUM=$(openssl dgst -sha256 -binary </tmp/data/obj | base64)
 aws s3api --endpoint-url=https://localhost:9001 put-object --checksum-algorithm SHA256 --checksum-sha256 "${OBJ_CHKSUM}" --bucket test-bucket --key obj --body /tmp/data/obj --no-verify-ssl --profile enterprise
@@ -173,6 +173,89 @@ if [ "${SRC_OBJ_1_ETAG}" != "${DEST_OBJ_1_ETAG}" ]; then
 fi
 if [ "${SRC_OBJ_2_ETAG}" != "${DEST_OBJ_2_ETAG}" ]; then
 	echo "BUG: Etags dont match for 'mpartobj'. Source: ${SRC_OBJ_2_ETAG}, Destination: ${DEST_OBJ_2_ETAG}"
+	exit_1
+fi
+
+echo "Set default encryption on "
+
+# test if checksum header is replicated for encrypted objects
+# Enable SSE KMS for test-bucket bucket
+./mc encrypt set sse-kms minio-default-key minio1/test-bucket --insecure
+
+# Load objects to source site with checksum header
+echo "Loading objects to source MinIO instance"
+OBJ_CHKSUM=$(openssl dgst -sha256 -binary </tmp/data/obj | base64)
+aws s3api --endpoint-url=https://localhost:9001 put-object --checksum-algorithm SHA256 --checksum-sha256 "${OBJ_CHKSUM}" --bucket test-bucket --key obj2 --body /tmp/data/obj --no-verify-ssl --profile enterprise
+
+split -n 10 /tmp/data/mpartobj
+CREATE_MPART_OUT=$(aws s3api --endpoint-url=https://localhost:9001 create-multipart-upload --bucket test-bucket --key mpartobj2 --checksum-algorithm SHA256 --no-verify-ssl --profile enterprise)
+UPLOAD_ID=$(echo "${CREATE_MPART_OUT}" | jq '.UploadId' | sed 's/"//g')
+
+PARTS=""
+for idx in {1..10}; do
+	F_SUFFIX=$(num_to_alpha "$idx")
+	PART_CHKSUM=$(openssl dgst -sha256 -binary <"xa${F_SUFFIX}" | base64)
+	UPLOAD_PART_OUT=$(aws s3api --endpoint-url=https://localhost:9001 upload-part --checksum-algorithm SHA256 --checksum-sha256 "${PART_CHKSUM}" --bucket test-bucket --key mpartobj2 --part-number "${idx}" --body "xa${F_SUFFIX}" --upload-id "${UPLOAD_ID}" --no-verify-ssl --profile enterprise)
+	PART_ETAG=$(echo "${UPLOAD_PART_OUT}" | jq '.ETag')
+	if [ "${idx}" == 10 ]; then
+		PARTS="${PARTS}{\"ETag\": ${PART_ETAG}, \"ChecksumSHA256\": \"${PART_CHKSUM}\", \"PartNumber\": ${idx}}"
+	else
+		PARTS="${PARTS}{\"ETag\": ${PART_ETAG}, \"ChecksumSHA256\": \"${PART_CHKSUM}\", \"PartNumber\": ${idx}},"
+	fi
+done
+
+echo "{\"Parts\":[${PARTS}]}" >fileparts.json
+jq <fileparts.json
+aws s3api --endpoint-url=https://localhost:9001 complete-multipart-upload --multipart-upload file://fileparts.json --bucket test-bucket --key mpartobj2 --upload-id "${UPLOAD_ID}" --no-verify-ssl --profile enterprise
+sleep 120
+
+# List the objects from replicated site
+echo "Objects from replicated site"
+./mc ls minio2/test-bucket --insecure
+count1=$(./mc ls minio2/test-bucket/obj2 --insecure | wc -l)
+if [ "${count1}" -ne 1 ]; then
+	echo "BUG: object minio1/test-bucket/obj2 not replicated"
+	exit_1
+fi
+count2=$(./mc ls minio2/test-bucket/mpartobj2 --insecure | wc -l)
+if [ "${count2}" -ne 1 ]; then
+	echo "BUG: object minio1/test-bucket/mpartobj2 not replicated"
+	exit_1
+fi
+
+# Stat the objects from source site
+echo "Stat minio1/test-bucket/obj2"
+SRC_OUT_1=$(aws s3api --endpoint-url https://localhost:9001 head-object --bucket test-bucket --key obj2 --checksum-mode ENABLED --no-verify-ssl --profile enterprise)
+SRC_OUT_2=$(aws s3api --endpoint-url https://localhost:9001 head-object --bucket test-bucket --key mpartobj2 --checksum-mode ENABLED --no-verify-ssl --profile enterprise)
+SRC_OBJ_1_CHKSUM=$(echo "${SRC_OUT_1}" | jq '.ChecksumSHA256')
+SRC_OBJ_2_CHKSUM=$(echo "${SRC_OUT_2}" | jq '.ChecksumSHA256')
+SRC_OBJ_1_ETAG=$(echo "${SRC_OUT_1}" | jq '.ETag')
+SRC_OBJ_2_ETAG=$(echo "${SRC_OUT_2}" | jq '.ETag')
+
+# Stat the objects from replicated site
+echo "Stat minio2/test-bucket/obj2"
+DEST_OUT_1=$(aws s3api --endpoint-url https://localhost:9002 head-object --bucket test-bucket --key obj2 --checksum-mode ENABLED --no-verify-ssl --profile enterprise)
+DEST_OUT_2=$(aws s3api --endpoint-url https://localhost:9002 head-object --bucket test-bucket --key mpartobj2 --checksum-mode ENABLED --no-verify-ssl --profile enterprise)
+DEST_OBJ_1_CHKSUM=$(echo "${DEST_OUT_1}" | jq '.ChecksumSHA256')
+DEST_OBJ_2_CHKSUM=$(echo "${DEST_OUT_2}" | jq '.ChecksumSHA256')
+DEST_OBJ_1_ETAG=$(echo "${DEST_OUT_1}" | jq '.ETag')
+DEST_OBJ_2_ETAG=$(echo "${DEST_OUT_2}" | jq '.ETag')
+
+# Check the replication of checksums and etags
+if [ "${SRC_OBJ_1_CHKSUM}" != "${DEST_OBJ_1_CHKSUM}" ]; then
+	echo "BUG: Checksums dont match for 'obj2'. Source: ${SRC_OBJ_1_CHKSUM}, Destination: ${DEST_OBJ_1_CHKSUM}"
+	exit_1
+fi
+if [ "${SRC_OBJ_2_CHKSUM}" != "${DEST_OBJ_2_CHKSUM}" ]; then
+	echo "BUG: Checksums dont match for 'mpartobj2'. Source: ${SRC_OBJ_2_CHKSUM}, Destination: ${DEST_OBJ_2_CHKSUM}"
+	exit_1
+fi
+if [ "${SRC_OBJ_1_ETAG}" != "${DEST_OBJ_1_ETAG}" ]; then
+	echo "BUG: Etags dont match for 'obj2'. Source: ${SRC_OBJ_1_ETAG}, Destination: ${DEST_OBJ_1_ETAG}"
+	exit_1
+fi
+if [ "${SRC_OBJ_2_ETAG}" != "${DEST_OBJ_2_ETAG}" ]; then
+	echo "BUG: Etags dont match for 'mpartobj2'. Source: ${SRC_OBJ_2_ETAG}, Destination: ${DEST_OBJ_2_ETAG}"
 	exit_1
 fi
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
part checksum header was not being sent on upload part while replicating encrypted content

This PR also corrects response for GET calls with part-number and checksum-mode specified
## How to test this PR?
1. Added tests to capture the replication of objects with checksum headers
2.  GET/HEAD requests for part on multipart object uploaded with checksum fails with InvalidPartNumber error for master branch
```
aws s3api head-object  --bucket bucket --endpoint-url http://localhost:9001 --profile minio --key mult --part-number 7 --checksum-mode ENABLED

 aws s3api get-object  --bucket bucket --endpoint-url http://localhost:9001 --profile minio --key mult --part-number 1 --checksum-mode sha256  /tmp/file
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
