### PR TITLE
bring o-direct back from the weeds for READs

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -38,7 +38,6 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/minio-go/v7/pkg/tags"
-	"github.com/minio/minio/internal/bpool"
 	"github.com/minio/minio/internal/cachevalue"
 	"github.com/minio/minio/internal/config/storageclass"
 	xioutil "github.com/minio/minio/internal/ioutil"
@@ -84,32 +83,6 @@ func newErasureServerPools(ctx context.Context, endpointServerPools EndpointServ
 			distributionAlgo: formatErasureVersionV3DistributionAlgoV3,
 		}
 	)
-
-	// Maximum number of reusable buffers per node at any given point in time.
-	n := uint64(1024) // single node single/multiple drives set this to 1024 entries
-
-	if globalIsDistErasure {
-		n = 2048
-	}
-
-	// Avoid allocating more than half of the available memory
-	if maxN := availableMemory() / (blockSizeV2 * 2); n > maxN {
-		n = maxN
-	}
-
-	if globalIsCICD || strconv.IntSize == 32 {
-		n = 256 // 256MiB for CI/CD environments is sufficient or on 32bit platforms.
-	}
-
-	// Initialize byte pool once for all sets, bpool size is set to
-	// setCount * setDriveCount with each memory upto blockSizeV2.
-	buffers := bpool.NewBytePoolCap(n, blockSizeV2, blockSizeV2*2)
-	if n >= 16384 {
-		// pre-populate buffers only n >= 16384 which is (32Gi/2Mi)
-		// for all setups smaller than this avoid pre-alloc.
-		buffers.Populate()
-	}
-	globalBytePoolCap.Store(buffers)
 
 	var localDrives []StorageAPI
 	local := endpointServerPools.FirstLocal()

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -180,6 +180,13 @@ func (d *naughtyDisk) ReadFile(ctx context.Context, volume string, path string, 
 	return d.disk.ReadFile(ctx, volume, path, offset, buf, verifier)
 }
 
+func (d *naughtyDisk) ReadFileStreamTo(ctx context.Context, volume, path string, offset, length int64, writer io.Writer) error {
+	if err := d.calcError(); err != nil {
+		return err
+	}
+	return d.disk.ReadFileStreamTo(ctx, volume, path, offset, length, writer)
+}
+
 func (d *naughtyDisk) ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error) {
 	if err := d.calcError(); err != nil {
 		return nil, err

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -93,6 +93,7 @@ type StorageAPI interface {
 	ReadFile(ctx context.Context, volume string, path string, offset int64, buf []byte, verifier *BitrotVerifier) (n int64, err error)
 	AppendFile(ctx context.Context, volume string, path string, buf []byte) (err error)
 	CreateFile(ctx context.Context, origvolume, olume, path string, size int64, reader io.Reader) error
+	ReadFileStreamTo(ctx context.Context, volume, path string, offset, length int64, writer io.Writer) error
 	ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error)
 	RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error
 	CheckParts(ctx context.Context, volume string, path string, fi FileInfo) (*CheckPartsResp, error)

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -621,7 +621,15 @@ func (client *storageRESTClient) ReadAll(ctx context.Context, volume string, pat
 	return *gridBytes, nil
 }
 
+// ReadFileStreamTo - writes to writer from the contents at path.
+func (client *storageRESTClient) ReadFileStreamTo(ctx context.Context, volume, path string, offset, length int64, writer io.Writer) error {
+	// This function must not be called over the network, only implemented for local disks.
+	// ReadFileStream client remote handler uses ReadFileStreamTo to read from file locally.
+	return errInvalidArgument
+}
+
 // ReadFileStream - returns a reader for the requested file.
+
 func (client *storageRESTClient) ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error) {
 	values := make(url.Values)
 	values.Set(storageRESTVolume, volume)

--- a/cmd/test-utils_test.go
+++ b/cmd/test-utils_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/s3utils"
 	"github.com/minio/minio-go/v7/pkg/signer"
 	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/bpool"
 	"github.com/minio/minio/internal/config"
 	"github.com/minio/minio/internal/crypto"
 	"github.com/minio/minio/internal/hash"
@@ -84,6 +85,10 @@ func TestMain(m *testing.M) {
 	}
 
 	globalNodeAuthToken, _ = authenticateNode(auth.DefaultAccessKey, auth.DefaultSecretKey)
+
+	// Initialize byte pool once for all sets, bpool size is set to
+	// setCount * setDriveCount with each memory upto blockSizeV2.
+	globalBytePoolCap.Store(bpool.NewBytePoolCap(256, blockSizeV2, blockSizeV2*2))
 
 	// disable ENVs which interfere with tests.
 	for _, env := range []string{

--- a/internal/disk/directio_darwin.go
+++ b/internal/disk/directio_darwin.go
@@ -35,8 +35,7 @@ func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, er
 }
 
 // DisableDirectIO - disables directio mode.
-func DisableDirectIO(f *os.File) error {
-	fd := f.Fd()
+func DisableDirectIO(fd uintptr) error {
 	_, err := unix.FcntlInt(fd, unix.F_NOCACHE, 0)
 	return err
 }

--- a/internal/disk/directio_unix.go
+++ b/internal/disk/directio_unix.go
@@ -37,8 +37,7 @@ func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, er
 }
 
 // DisableDirectIO - disables directio mode.
-func DisableDirectIO(f *os.File) error {
-	fd := f.Fd()
+func DisableDirectIO(fd uintptr) error {
 	flag, err := unix.FcntlInt(fd, unix.F_GETFL, 0)
 	if err != nil {
 		return err

--- a/internal/disk/directio_unsupported.go
+++ b/internal/disk/directio_unsupported.go
@@ -57,7 +57,7 @@ func OpenFileDirectIO(filePath string, flag int, perm os.FileMode) (*os.File, er
 }
 
 // DisableDirectIO is a no-op
-func DisableDirectIO(f *os.File) error {
+func DisableDirectIO(fd uintptr) error {
 	return nil
 }
 

--- a/internal/ioutil/ioutil_test.go
+++ b/internal/ioutil/ioutil_test.go
@@ -205,7 +205,7 @@ func TestCopyAligned(t *testing.T) {
 	bufp := ODirectPoolSmall.Get().(*[]byte)
 	defer ODirectPoolSmall.Put(bufp)
 
-	written, err := CopyAligned(f, io.LimitReader(r, 5), *bufp, r.Size(), f)
+	written, err := CopyAligned(f, io.LimitReader(r, 5), *bufp, r.Size(), f.Fd())
 	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("Expected io.ErrUnexpectedEOF, but got %v", err)
 	}
@@ -216,7 +216,7 @@ func TestCopyAligned(t *testing.T) {
 	f.Seek(0, io.SeekStart)
 	r.Seek(0, io.SeekStart)
 
-	written, err = CopyAligned(f, r, *bufp, r.Size(), f)
+	written, err = CopyAligned(f, r, *bufp, r.Size(), f.Fd())
 	if !errors.Is(err, nil) {
 		t.Errorf("Expected nil, but got %v", err)
 	}


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
bring o-direct back from the weeds for READs

## Motivation and Context
This time, the O_DIRECT reader is a better implementation, bypassing 
down the WRITER that allows us to avoid an extra reader representation 
and buffering.

## How to test this PR?
CI/CD tests, and mint cover it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
