### PR TITLE
fix replication last hour metric

### DIFF
--- a/cmd/metrics-v3-replication.go
+++ b/cmd/metrics-v3-replication.go
@@ -34,6 +34,7 @@ const (
 	replicationMaxQueuedBytes          = "max_queued_bytes"
 	replicationMaxQueuedCount          = "max_queued_count"
 	replicationMaxDataTransferRate     = "max_data_transfer_rate"
+	replicationRecentBacklogCount      = "recent_backlog_count"
 )
 
 var (
@@ -61,6 +62,8 @@ var (
 		"Maximum number of objects queued for replication since server start")
 	replicationMaxDataTransferRateMD = NewGaugeMD(replicationMaxDataTransferRate,
 		"Maximum replication data transfer rate in bytes/sec seen since server start")
+	replicationRecentBacklogCountMD = NewGaugeMD(replicationRecentBacklogCount,
+		"Total number of objects seen in replication backlog in the last 5 minutes")
 )
 
 // loadClusterReplicationMetrics - `MetricsLoaderFn` for cluster replication metrics
@@ -91,6 +94,7 @@ func loadClusterReplicationMetrics(ctx context.Context, m MetricValues, c *metri
 		m.Set(replicationCurrentDataTransferRate, tots.Curr)
 		m.Set(replicationMaxDataTransferRate, tots.Peak)
 	}
+	m.Set(replicationRecentBacklogCount, float64(qs.MRFStats.LastFailedCount))
 
 	return nil
 }

--- a/cmd/metrics-v3.go
+++ b/cmd/metrics-v3.go
@@ -341,6 +341,7 @@ func newMetricGroups(r *prometheus.Registry) *metricsV3Collection {
 			replicationMaxQueuedBytesMD,
 			replicationMaxQueuedCountMD,
 			replicationMaxDataTransferRateMD,
+			replicationRecentBacklogCountMD,
 		},
 		loadClusterReplicationMetrics,
 	)

--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -275,7 +275,7 @@ Metrics about MinIO site and bucket replication.
 | `minio_replication_max_queued_bytes`              | Maximum number of bytes queued for replication since server start. <br><br>Type: gauge      | `server` |
 | `minio_replication_max_queued_count`              | Maximum number of objects queued for replication since server start. <br><br>Type: gauge    | `server` |
 | `minio_replication_max_data_transfer_rate`        | Maximum replication data transfer rate in bytes/sec since server start. <br><br>Type: gauge | `server` |
-
+| `minio_replication_recent_backlog_count`          | Total number of objects seen in replication backlog in the last 5 minutes <br><br>Type: gauge | `server` |
 #### `/bucket/replication`
 
 | Name                                                                | Description                                                                                                     | Labels                                                |


### PR DESCRIPTION
also adding missing recent_backlog_count metric to v3 metrics

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?
set up replication and take target down - objects uploaded while target down should reflect in the last hour metric upto an hour. With master branch the count was not being reset

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
