### PR TITLE
Docs: link to prom collector repo for info on debug metrics

### DIFF
--- a/docs/metrics/v3.md
+++ b/docs/metrics/v3.md
@@ -193,7 +193,7 @@ Metrics about an entire MinIO cluster.
 
 ### Debug metrics
 
-Standard Go runtime metrics.
+Standard Go runtime metrics from the [Prometheus Go Client base collector](https://github.com/prometheus/client_golang).
 
 | Path        | Description         |
 |-------------|---------------------|


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add link to `https://github.com/prometheus/client_golang` for additional information about `/debug/go` runtime metrics. Suggestions for a better link very much appreciated. 

## Motivation and Context

The list of v3 metrics doesn't show all the possible Go runtime metrics the `/debug/go` endpoint returns. This is reasonable, as they come from a 3rd party source and keeping an up-to-date list in the MinIO docs is not practical. But it is still useful to point readers somewhere to find additional information.

On the docs side, it looks like this:

![Revised text in list of metrics Debug section: Standard Go runtime metrics from the Prometheus Go Client base collector.](https://github.com/user-attachments/assets/354c86f9-1f71-4dec-93fb-ac71c4aefe7b)

## How to test this PR?

Docs-only change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
