### PR TITLE
implement a safer completeMultipart implementation

### DIFF
--- a/cmd/erasure.go
+++ b/cmd/erasure.go
@@ -90,6 +90,11 @@ func (er erasureObjects) defaultWQuorum() int {
 	return dataCount
 }
 
+// defaultRQuorum read quorum based on setDriveCount and defaultParityCount
+func (er erasureObjects) defaultRQuorum() int {
+	return er.setDriveCount - er.defaultParityCount
+}
+
 func diskErrToDriveState(err error) (state string) {
 	switch {
 	case errors.Is(err, errDiskNotFound) || errors.Is(err, context.DeadlineExceeded):

--- a/cmd/naughty-disk_test.go
+++ b/cmd/naughty-disk_test.go
@@ -208,6 +208,20 @@ func (d *naughtyDisk) RenameData(ctx context.Context, srcVolume, srcPath string,
 	return d.disk.RenameData(ctx, srcVolume, srcPath, fi, dstVolume, dstPath, opts)
 }
 
+func (d *naughtyDisk) RenamePart(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string, meta []byte) error {
+	if err := d.calcError(); err != nil {
+		return err
+	}
+	return d.disk.RenamePart(ctx, srcVolume, srcPath, dstVolume, dstPath, meta)
+}
+
+func (d *naughtyDisk) ReadParts(ctx context.Context, bucket string, partMetaPaths ...string) ([]*ObjectPartInfo, error) {
+	if err := d.calcError(); err != nil {
+		return nil, err
+	}
+	return d.disk.ReadParts(ctx, bucket, partMetaPaths...)
+}
+
 func (d *naughtyDisk) RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error {
 	if err := d.calcError(); err != nil {
 		return err

--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -494,6 +494,16 @@ type RenameFileHandlerParams struct {
 	DstFilePath string `msg:"dp"`
 }
 
+// RenamePartHandlerParams are parameters for RenamePartHandler.
+type RenamePartHandlerParams struct {
+	DiskID      string `msg:"id"`
+	SrcVolume   string `msg:"sv"`
+	SrcFilePath string `msg:"sp"`
+	DstVolume   string `msg:"dv"`
+	DstFilePath string `msg:"dp"`
+	Meta        []byte `msg:"m"`
+}
+
 // ReadAllHandlerParams are parameters for ReadAllHandler.
 type ReadAllHandlerParams struct {
 	DiskID   string `msg:"id"`
@@ -545,6 +555,16 @@ type LocalDiskIDs struct {
 // ListDirResult - ListDir()'s response.
 type ListDirResult struct {
 	Entries []string `msg:"e"`
+}
+
+// ReadPartsReq - send multiple part paths to read from
+type ReadPartsReq struct {
+	Paths []string `msg:"p"`
+}
+
+// ReadPartsResp - is the response for ReadPartsReq
+type ReadPartsResp struct {
+	Infos []*ObjectPartInfo `msg:"is"`
 }
 
 // DeleteBulkReq - send multiple paths in same delete request.

--- a/cmd/storage-datatypes_gen.go
+++ b/cmd/storage-datatypes_gen.go
@@ -4831,6 +4831,332 @@ func (z *ReadMultipleResp) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *ReadPartsReq) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "p":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Paths")
+				return
+			}
+			if cap(z.Paths) >= int(zb0002) {
+				z.Paths = (z.Paths)[:zb0002]
+			} else {
+				z.Paths = make([]string, zb0002)
+			}
+			for za0001 := range z.Paths {
+				z.Paths[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Paths", za0001)
+					return
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *ReadPartsReq) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "p"
+	err = en.Append(0x81, 0xa1, 0x70)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Paths)))
+	if err != nil {
+		err = msgp.WrapError(err, "Paths")
+		return
+	}
+	for za0001 := range z.Paths {
+		err = en.WriteString(z.Paths[za0001])
+		if err != nil {
+			err = msgp.WrapError(err, "Paths", za0001)
+			return
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ReadPartsReq) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "p"
+	o = append(o, 0x81, 0xa1, 0x70)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Paths)))
+	for za0001 := range z.Paths {
+		o = msgp.AppendString(o, z.Paths[za0001])
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ReadPartsReq) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "p":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Paths")
+				return
+			}
+			if cap(z.Paths) >= int(zb0002) {
+				z.Paths = (z.Paths)[:zb0002]
+			} else {
+				z.Paths = make([]string, zb0002)
+			}
+			for za0001 := range z.Paths {
+				z.Paths[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Paths", za0001)
+					return
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ReadPartsReq) Msgsize() (s int) {
+	s = 1 + 2 + msgp.ArrayHeaderSize
+	for za0001 := range z.Paths {
+		s += msgp.StringPrefixSize + len(z.Paths[za0001])
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *ReadPartsResp) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "is":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Infos")
+				return
+			}
+			if cap(z.Infos) >= int(zb0002) {
+				z.Infos = (z.Infos)[:zb0002]
+			} else {
+				z.Infos = make([]*ObjectPartInfo, zb0002)
+			}
+			for za0001 := range z.Infos {
+				if dc.IsNil() {
+					err = dc.ReadNil()
+					if err != nil {
+						err = msgp.WrapError(err, "Infos", za0001)
+						return
+					}
+					z.Infos[za0001] = nil
+				} else {
+					if z.Infos[za0001] == nil {
+						z.Infos[za0001] = new(ObjectPartInfo)
+					}
+					err = z.Infos[za0001].DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "Infos", za0001)
+						return
+					}
+				}
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *ReadPartsResp) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 1
+	// write "is"
+	err = en.Append(0x81, 0xa2, 0x69, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteArrayHeader(uint32(len(z.Infos)))
+	if err != nil {
+		err = msgp.WrapError(err, "Infos")
+		return
+	}
+	for za0001 := range z.Infos {
+		if z.Infos[za0001] == nil {
+			err = en.WriteNil()
+			if err != nil {
+				return
+			}
+		} else {
+			err = z.Infos[za0001].EncodeMsg(en)
+			if err != nil {
+				err = msgp.WrapError(err, "Infos", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *ReadPartsResp) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 1
+	// string "is"
+	o = append(o, 0x81, 0xa2, 0x69, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Infos)))
+	for za0001 := range z.Infos {
+		if z.Infos[za0001] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z.Infos[za0001].MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "Infos", za0001)
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *ReadPartsResp) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "is":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Infos")
+				return
+			}
+			if cap(z.Infos) >= int(zb0002) {
+				z.Infos = (z.Infos)[:zb0002]
+			} else {
+				z.Infos = make([]*ObjectPartInfo, zb0002)
+			}
+			for za0001 := range z.Infos {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.Infos[za0001] = nil
+				} else {
+					if z.Infos[za0001] == nil {
+						z.Infos[za0001] = new(ObjectPartInfo)
+					}
+					bts, err = z.Infos[za0001].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "Infos", za0001)
+						return
+					}
+				}
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *ReadPartsResp) Msgsize() (s int) {
+	s = 1 + 3 + msgp.ArrayHeaderSize
+	for za0001 := range z.Infos {
+		if z.Infos[za0001] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z.Infos[za0001].Msgsize()
+		}
+	}
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *RenameDataHandlerParams) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -5754,6 +6080,234 @@ func (z *RenameOptions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *RenameOptions) Msgsize() (s int) {
 	s = 1 + 12 + 1
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *RenamePartHandlerParams) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "id":
+			z.DiskID, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "DiskID")
+				return
+			}
+		case "sv":
+			z.SrcVolume, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "SrcVolume")
+				return
+			}
+		case "sp":
+			z.SrcFilePath, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "SrcFilePath")
+				return
+			}
+		case "dv":
+			z.DstVolume, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "DstVolume")
+				return
+			}
+		case "dp":
+			z.DstFilePath, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "DstFilePath")
+				return
+			}
+		case "m":
+			z.Meta, err = dc.ReadBytes(z.Meta)
+			if err != nil {
+				err = msgp.WrapError(err, "Meta")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *RenamePartHandlerParams) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 6
+	// write "id"
+	err = en.Append(0x86, 0xa2, 0x69, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.DiskID)
+	if err != nil {
+		err = msgp.WrapError(err, "DiskID")
+		return
+	}
+	// write "sv"
+	err = en.Append(0xa2, 0x73, 0x76)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.SrcVolume)
+	if err != nil {
+		err = msgp.WrapError(err, "SrcVolume")
+		return
+	}
+	// write "sp"
+	err = en.Append(0xa2, 0x73, 0x70)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.SrcFilePath)
+	if err != nil {
+		err = msgp.WrapError(err, "SrcFilePath")
+		return
+	}
+	// write "dv"
+	err = en.Append(0xa2, 0x64, 0x76)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.DstVolume)
+	if err != nil {
+		err = msgp.WrapError(err, "DstVolume")
+		return
+	}
+	// write "dp"
+	err = en.Append(0xa2, 0x64, 0x70)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.DstFilePath)
+	if err != nil {
+		err = msgp.WrapError(err, "DstFilePath")
+		return
+	}
+	// write "m"
+	err = en.Append(0xa1, 0x6d)
+	if err != nil {
+		return
+	}
+	err = en.WriteBytes(z.Meta)
+	if err != nil {
+		err = msgp.WrapError(err, "Meta")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *RenamePartHandlerParams) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 6
+	// string "id"
+	o = append(o, 0x86, 0xa2, 0x69, 0x64)
+	o = msgp.AppendString(o, z.DiskID)
+	// string "sv"
+	o = append(o, 0xa2, 0x73, 0x76)
+	o = msgp.AppendString(o, z.SrcVolume)
+	// string "sp"
+	o = append(o, 0xa2, 0x73, 0x70)
+	o = msgp.AppendString(o, z.SrcFilePath)
+	// string "dv"
+	o = append(o, 0xa2, 0x64, 0x76)
+	o = msgp.AppendString(o, z.DstVolume)
+	// string "dp"
+	o = append(o, 0xa2, 0x64, 0x70)
+	o = msgp.AppendString(o, z.DstFilePath)
+	// string "m"
+	o = append(o, 0xa1, 0x6d)
+	o = msgp.AppendBytes(o, z.Meta)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *RenamePartHandlerParams) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "id":
+			z.DiskID, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DiskID")
+				return
+			}
+		case "sv":
+			z.SrcVolume, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SrcVolume")
+				return
+			}
+		case "sp":
+			z.SrcFilePath, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SrcFilePath")
+				return
+			}
+		case "dv":
+			z.DstVolume, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DstVolume")
+				return
+			}
+		case "dp":
+			z.DstFilePath, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "DstFilePath")
+				return
+			}
+		case "m":
+			z.Meta, bts, err = msgp.ReadBytesBytes(bts, z.Meta)
+			if err != nil {
+				err = msgp.WrapError(err, "Meta")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *RenamePartHandlerParams) Msgsize() (s int) {
+	s = 1 + 3 + msgp.StringPrefixSize + len(z.DiskID) + 3 + msgp.StringPrefixSize + len(z.SrcVolume) + 3 + msgp.StringPrefixSize + len(z.SrcFilePath) + 3 + msgp.StringPrefixSize + len(z.DstVolume) + 3 + msgp.StringPrefixSize + len(z.DstFilePath) + 2 + msgp.BytesPrefixSize + len(z.Meta)
 	return
 }
 

--- a/cmd/storage-datatypes_gen_test.go
+++ b/cmd/storage-datatypes_gen_test.go
@@ -2382,6 +2382,232 @@ func BenchmarkDecodeReadMultipleResp(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalReadPartsReq(t *testing.T) {
+	v := ReadPartsReq{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgReadPartsReq(b *testing.B) {
+	v := ReadPartsReq{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgReadPartsReq(b *testing.B) {
+	v := ReadPartsReq{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalReadPartsReq(b *testing.B) {
+	v := ReadPartsReq{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeReadPartsReq(t *testing.T) {
+	v := ReadPartsReq{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeReadPartsReq Msgsize() is inaccurate")
+	}
+
+	vn := ReadPartsReq{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeReadPartsReq(b *testing.B) {
+	v := ReadPartsReq{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeReadPartsReq(b *testing.B) {
+	v := ReadPartsReq{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalReadPartsResp(t *testing.T) {
+	v := ReadPartsResp{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgReadPartsResp(b *testing.B) {
+	v := ReadPartsResp{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgReadPartsResp(b *testing.B) {
+	v := ReadPartsResp{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalReadPartsResp(b *testing.B) {
+	v := ReadPartsResp{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeReadPartsResp(t *testing.T) {
+	v := ReadPartsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeReadPartsResp Msgsize() is inaccurate")
+	}
+
+	vn := ReadPartsResp{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeReadPartsResp(b *testing.B) {
+	v := ReadPartsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeReadPartsResp(b *testing.B) {
+	v := ReadPartsResp{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalRenameDataHandlerParams(t *testing.T) {
 	v := RenameDataHandlerParams{}
 	bts, err := v.MarshalMsg(nil)
@@ -2932,6 +3158,119 @@ func BenchmarkEncodeRenameOptions(b *testing.B) {
 
 func BenchmarkDecodeRenameOptions(b *testing.B) {
 	v := RenameOptions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalRenamePartHandlerParams(t *testing.T) {
+	v := RenamePartHandlerParams{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgRenamePartHandlerParams(b *testing.B) {
+	v := RenamePartHandlerParams{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgRenamePartHandlerParams(b *testing.B) {
+	v := RenamePartHandlerParams{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalRenamePartHandlerParams(b *testing.B) {
+	v := RenamePartHandlerParams{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeRenamePartHandlerParams(t *testing.T) {
+	v := RenamePartHandlerParams{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeRenamePartHandlerParams Msgsize() is inaccurate")
+	}
+
+	vn := RenamePartHandlerParams{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeRenamePartHandlerParams(b *testing.B) {
+	v := RenamePartHandlerParams{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeRenamePartHandlerParams(b *testing.B) {
+	v := RenamePartHandlerParams{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -95,10 +95,12 @@ type StorageAPI interface {
 	CreateFile(ctx context.Context, origvolume, olume, path string, size int64, reader io.Reader) error
 	ReadFileStream(ctx context.Context, volume, path string, offset, length int64) (io.ReadCloser, error)
 	RenameFile(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string) error
+	RenamePart(ctx context.Context, srcVolume, srcPath, dstVolume, dstPath string, meta []byte) error
 	CheckParts(ctx context.Context, volume string, path string, fi FileInfo) (*CheckPartsResp, error)
 	Delete(ctx context.Context, volume string, path string, opts DeleteOptions) (err error)
 	VerifyFile(ctx context.Context, volume, path string, fi FileInfo) (*CheckPartsResp, error)
 	StatInfoFile(ctx context.Context, volume, path string, glob bool) (stat []StatInfo, err error)
+	ReadParts(ctx context.Context, bucket string, partMetaPaths ...string) ([]*ObjectPartInfo, error)
 	ReadMultiple(ctx context.Context, req ReadMultipleReq, resp chan<- ReadMultipleResp) error
 	CleanAbandonedData(ctx context.Context, volume string, path string) error
 

--- a/cmd/storage-rest-common.go
+++ b/cmd/storage-rest-common.go
@@ -20,7 +20,7 @@ package cmd
 //go:generate msgp -file $GOFILE -unexported
 
 const (
-	storageRESTVersion       = "v62" // Introduce DeleteBulk internode API.
+	storageRESTVersion       = "v63" // Introduce RenamePart and ReadParts API
 	storageRESTVersionPrefix = SlashSeparator + storageRESTVersion
 	storageRESTPrefix        = minioReservedBucketPath + "/storage"
 )
@@ -44,6 +44,7 @@ const (
 	storageRESTMethodReadMultiple   = "/rmpl"
 	storageRESTMethodCleanAbandoned = "/cln"
 	storageRESTMethodDeleteBulk     = "/dblk"
+	storageRESTMethodReadParts      = "/rps"
 )
 
 const (

--- a/cmd/storagemetric_string.go
+++ b/cmd/storagemetric_string.go
@@ -37,12 +37,14 @@ func _() {
 	_ = x[storageMetricDeleteAbandonedParts-26]
 	_ = x[storageMetricDiskInfo-27]
 	_ = x[storageMetricDeleteBulk-28]
-	_ = x[storageMetricLast-29]
+	_ = x[storageMetricRenamePart-29]
+	_ = x[storageMetricReadParts-30]
+	_ = x[storageMetricLast-31]
 }
 
-const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsDiskInfoDeleteBulkLast"
+const _storageMetric_name = "MakeVolBulkMakeVolListVolsStatVolDeleteVolWalkDirListDirReadFileAppendFileCreateFileReadFileStreamRenameFileRenameDataCheckPartsDeleteDeleteVersionsVerifyFileWriteAllDeleteVersionWriteMetadataUpdateMetadataReadVersionReadXLReadAllStatInfoFileReadMultipleDeleteAbandonedPartsDiskInfoDeleteBulkRenamePartReadPartsLast"
 
-var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 282, 292, 296}
+var _storageMetric_index = [...]uint16{0, 11, 18, 26, 33, 42, 49, 56, 64, 74, 84, 98, 108, 118, 128, 134, 148, 158, 166, 179, 192, 206, 217, 223, 230, 242, 254, 274, 282, 292, 302, 311, 315}
 
 func (i storageMetric) String() string {
 	if i >= storageMetric(len(_storageMetric_index)-1) {

--- a/cmd/xl-storage-format-v1.go
+++ b/cmd/xl-storage-format-v1.go
@@ -159,13 +159,14 @@ const (
 // ObjectPartInfo Info of each part kept in the multipart metadata
 // file after CompleteMultipartUpload() is called.
 type ObjectPartInfo struct {
-	ETag       string            `json:"etag,omitempty"`
-	Number     int               `json:"number"`
-	Size       int64             `json:"size"`       // Size of the part on the disk.
-	ActualSize int64             `json:"actualSize"` // Original size of the part without compression or encryption bytes.
-	ModTime    time.Time         `json:"modTime"`    // Date and time at which the part was uploaded.
-	Index      []byte            `json:"index,omitempty" msg:"index,omitempty"`
-	Checksums  map[string]string `json:"crc,omitempty" msg:"crc,omitempty"` // Content Checksums
+	ETag       string            `json:"etag,omitempty" msg:"e"`
+	Number     int               `json:"number" msg:"n"`
+	Size       int64             `json:"size" msg:"s"`        // Size of the part on the disk.
+	ActualSize int64             `json:"actualSize" msg:"as"` // Original size of the part without compression or encryption bytes.
+	ModTime    time.Time         `json:"modTime" msg:"mt"`    // Date and time at which the part was uploaded.
+	Index      []byte            `json:"index,omitempty" msg:"i,omitempty"`
+	Checksums  map[string]string `json:"crc,omitempty" msg:"crc,omitempty"`   // Content Checksums
+	Error      string            `json:"error,omitempty" msg:"err,omitempty"` // only set while reading part meta from drive.
 }
 
 // ChecksumInfo - carries checksums of individual scattered parts per disk.

--- a/cmd/xl-storage-format-v1_gen.go
+++ b/cmd/xl-storage-format-v1_gen.go
@@ -569,37 +569,37 @@ func (z *ObjectPartInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "ETag":
+		case "e":
 			z.ETag, err = dc.ReadString()
 			if err != nil {
 				err = msgp.WrapError(err, "ETag")
 				return
 			}
-		case "Number":
+		case "n":
 			z.Number, err = dc.ReadInt()
 			if err != nil {
 				err = msgp.WrapError(err, "Number")
 				return
 			}
-		case "Size":
+		case "s":
 			z.Size, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "Size")
 				return
 			}
-		case "ActualSize":
+		case "as":
 			z.ActualSize, err = dc.ReadInt64()
 			if err != nil {
 				err = msgp.WrapError(err, "ActualSize")
 				return
 			}
-		case "ModTime":
+		case "mt":
 			z.ModTime, err = dc.ReadTime()
 			if err != nil {
 				err = msgp.WrapError(err, "ModTime")
 				return
 			}
-		case "index":
+		case "i":
 			z.Index, err = dc.ReadBytes(z.Index)
 			if err != nil {
 				err = msgp.WrapError(err, "Index")
@@ -635,6 +635,12 @@ func (z *ObjectPartInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Checksums[za0001] = za0002
 			}
+		case "err":
+			z.Error, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Error")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -649,8 +655,8 @@ func (z *ObjectPartInfo) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(7)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.Index == nil {
 		zb0001Len--
@@ -660,6 +666,10 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
+	if z.Error == "" {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
 	if err != nil {
@@ -668,8 +678,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 	if zb0001Len == 0 {
 		return
 	}
-	// write "ETag"
-	err = en.Append(0xa4, 0x45, 0x54, 0x61, 0x67)
+	// write "e"
+	err = en.Append(0xa1, 0x65)
 	if err != nil {
 		return
 	}
@@ -678,8 +688,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "ETag")
 		return
 	}
-	// write "Number"
-	err = en.Append(0xa6, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72)
+	// write "n"
+	err = en.Append(0xa1, 0x6e)
 	if err != nil {
 		return
 	}
@@ -688,8 +698,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Number")
 		return
 	}
-	// write "Size"
-	err = en.Append(0xa4, 0x53, 0x69, 0x7a, 0x65)
+	// write "s"
+	err = en.Append(0xa1, 0x73)
 	if err != nil {
 		return
 	}
@@ -698,8 +708,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "Size")
 		return
 	}
-	// write "ActualSize"
-	err = en.Append(0xaa, 0x41, 0x63, 0x74, 0x75, 0x61, 0x6c, 0x53, 0x69, 0x7a, 0x65)
+	// write "as"
+	err = en.Append(0xa2, 0x61, 0x73)
 	if err != nil {
 		return
 	}
@@ -708,8 +718,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		err = msgp.WrapError(err, "ActualSize")
 		return
 	}
-	// write "ModTime"
-	err = en.Append(0xa7, 0x4d, 0x6f, 0x64, 0x54, 0x69, 0x6d, 0x65)
+	// write "mt"
+	err = en.Append(0xa2, 0x6d, 0x74)
 	if err != nil {
 		return
 	}
@@ -719,8 +729,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 		return
 	}
 	if (zb0001Mask & 0x20) == 0 { // if not omitted
-		// write "index"
-		err = en.Append(0xa5, 0x69, 0x6e, 0x64, 0x65, 0x78)
+		// write "i"
+		err = en.Append(0xa1, 0x69)
 		if err != nil {
 			return
 		}
@@ -754,6 +764,18 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 	}
+	if (zb0001Mask & 0x80) == 0 { // if not omitted
+		// write "err"
+		err = en.Append(0xa3, 0x65, 0x72, 0x72)
+		if err != nil {
+			return
+		}
+		err = en.WriteString(z.Error)
+		if err != nil {
+			err = msgp.WrapError(err, "Error")
+			return
+		}
+	}
 	return
 }
 
@@ -761,8 +783,8 @@ func (z *ObjectPartInfo) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *ObjectPartInfo) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(7)
-	var zb0001Mask uint8 /* 7 bits */
+	zb0001Len := uint32(8)
+	var zb0001Mask uint8 /* 8 bits */
 	_ = zb0001Mask
 	if z.Index == nil {
 		zb0001Len--
@@ -772,29 +794,33 @@ func (z *ObjectPartInfo) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x40
 	}
+	if z.Error == "" {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
 	if zb0001Len == 0 {
 		return
 	}
-	// string "ETag"
-	o = append(o, 0xa4, 0x45, 0x54, 0x61, 0x67)
+	// string "e"
+	o = append(o, 0xa1, 0x65)
 	o = msgp.AppendString(o, z.ETag)
-	// string "Number"
-	o = append(o, 0xa6, 0x4e, 0x75, 0x6d, 0x62, 0x65, 0x72)
+	// string "n"
+	o = append(o, 0xa1, 0x6e)
 	o = msgp.AppendInt(o, z.Number)
-	// string "Size"
-	o = append(o, 0xa4, 0x53, 0x69, 0x7a, 0x65)
+	// string "s"
+	o = append(o, 0xa1, 0x73)
 	o = msgp.AppendInt64(o, z.Size)
-	// string "ActualSize"
-	o = append(o, 0xaa, 0x41, 0x63, 0x74, 0x75, 0x61, 0x6c, 0x53, 0x69, 0x7a, 0x65)
+	// string "as"
+	o = append(o, 0xa2, 0x61, 0x73)
 	o = msgp.AppendInt64(o, z.ActualSize)
-	// string "ModTime"
-	o = append(o, 0xa7, 0x4d, 0x6f, 0x64, 0x54, 0x69, 0x6d, 0x65)
+	// string "mt"
+	o = append(o, 0xa2, 0x6d, 0x74)
 	o = msgp.AppendTime(o, z.ModTime)
 	if (zb0001Mask & 0x20) == 0 { // if not omitted
-		// string "index"
-		o = append(o, 0xa5, 0x69, 0x6e, 0x64, 0x65, 0x78)
+		// string "i"
+		o = append(o, 0xa1, 0x69)
 		o = msgp.AppendBytes(o, z.Index)
 	}
 	if (zb0001Mask & 0x40) == 0 { // if not omitted
@@ -805,6 +831,11 @@ func (z *ObjectPartInfo) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendString(o, za0001)
 			o = msgp.AppendString(o, za0002)
 		}
+	}
+	if (zb0001Mask & 0x80) == 0 { // if not omitted
+		// string "err"
+		o = append(o, 0xa3, 0x65, 0x72, 0x72)
+		o = msgp.AppendString(o, z.Error)
 	}
 	return
 }
@@ -827,37 +858,37 @@ func (z *ObjectPartInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-		case "ETag":
+		case "e":
 			z.ETag, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ETag")
 				return
 			}
-		case "Number":
+		case "n":
 			z.Number, bts, err = msgp.ReadIntBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Number")
 				return
 			}
-		case "Size":
+		case "s":
 			z.Size, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Size")
 				return
 			}
-		case "ActualSize":
+		case "as":
 			z.ActualSize, bts, err = msgp.ReadInt64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ActualSize")
 				return
 			}
-		case "ModTime":
+		case "mt":
 			z.ModTime, bts, err = msgp.ReadTimeBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ModTime")
 				return
 			}
-		case "index":
+		case "i":
 			z.Index, bts, err = msgp.ReadBytesBytes(bts, z.Index)
 			if err != nil {
 				err = msgp.WrapError(err, "Index")
@@ -893,6 +924,12 @@ func (z *ObjectPartInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Checksums[za0001] = za0002
 			}
+		case "err":
+			z.Error, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Error")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -907,13 +944,14 @@ func (z *ObjectPartInfo) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *ObjectPartInfo) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.ETag) + 7 + msgp.IntSize + 5 + msgp.Int64Size + 11 + msgp.Int64Size + 8 + msgp.TimeSize + 6 + msgp.BytesPrefixSize + len(z.Index) + 4 + msgp.MapHeaderSize
+	s = 1 + 2 + msgp.StringPrefixSize + len(z.ETag) + 2 + msgp.IntSize + 2 + msgp.Int64Size + 3 + msgp.Int64Size + 3 + msgp.TimeSize + 2 + msgp.BytesPrefixSize + len(z.Index) + 4 + msgp.MapHeaderSize
 	if z.Checksums != nil {
 		for za0001, za0002 := range z.Checksums {
 			_ = za0002
 			s += msgp.StringPrefixSize + len(za0001) + msgp.StringPrefixSize + len(za0002)
 		}
 	}
+	s += 4 + msgp.StringPrefixSize + len(z.Error)
 	return
 }
 

--- a/internal/grid/handlers.go
+++ b/internal/grid/handlers.go
@@ -113,6 +113,7 @@ const (
 	HandlerRenameDataInline
 	HandlerRenameData2
 	HandlerCheckParts2
+	HandlerRenamePart
 
 	// Add more above here ^^^
 	// If all handlers are used, the type of Handler can be changed.
@@ -194,6 +195,7 @@ var handlerPrefixes = [handlerLast]string{
 	HandlerRenameDataInline:            storagePrefix,
 	HandlerRenameData2:                 storagePrefix,
 	HandlerCheckParts2:                 storagePrefix,
+	HandlerRenamePart:                  storagePrefix,
 }
 
 const (

--- a/internal/grid/handlers_string.go
+++ b/internal/grid/handlers_string.go
@@ -83,14 +83,15 @@ func _() {
 	_ = x[HandlerRenameDataInline-72]
 	_ = x[HandlerRenameData2-73]
 	_ = x[HandlerCheckParts2-74]
-	_ = x[handlerTest-75]
-	_ = x[handlerTest2-76]
-	_ = x[handlerLast-77]
+	_ = x[HandlerRenamePart-75]
+	_ = x[handlerTest-76]
+	_ = x[handlerTest2-77]
+	_ = x[handlerLast-78]
 }
 
-const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenameDataRenameFileReadAllServerVerifyTraceListenDeleteBucketMetadataLoadBucketMetadataReloadSiteReplicationConfigReloadPoolMetaStopRebalanceLoadRebalanceMetaLoadTransitionTierConfigDeletePolicyLoadPolicyLoadPolicyMappingDeleteServiceAccountLoadServiceAccountDeleteUserLoadUserLoadGroupHealBucketMakeBucketHeadBucketDeleteBucketGetMetricsGetResourceMetricsGetMemInfoGetProcInfoGetOSInfoGetPartitionsGetNetInfoGetCPUsServerInfoGetSysConfigGetSysServicesGetSysErrorsGetAllBucketStatsGetBucketStatsGetSRMetricsGetPeerMetricsGetMetacacheListingUpdateMetacacheListingGetPeerBucketMetricsStorageInfoConsoleLogListDirGetLocksBackgroundHealStatusGetLastDayTierStatsSignalServiceGetBandwidthWriteAllListBucketsRenameDataInlineRenameData2CheckParts2handlerTesthandlerTest2handlerLast"
+const _HandlerID_name = "handlerInvalidLockLockLockRLockLockUnlockLockRUnlockLockRefreshLockForceUnlockWalkDirStatVolDiskInfoNSScannerReadXLReadVersionDeleteFileDeleteVersionUpdateMetadataWriteMetadataCheckPartsRenameDataRenameFileReadAllServerVerifyTraceListenDeleteBucketMetadataLoadBucketMetadataReloadSiteReplicationConfigReloadPoolMetaStopRebalanceLoadRebalanceMetaLoadTransitionTierConfigDeletePolicyLoadPolicyLoadPolicyMappingDeleteServiceAccountLoadServiceAccountDeleteUserLoadUserLoadGroupHealBucketMakeBucketHeadBucketDeleteBucketGetMetricsGetResourceMetricsGetMemInfoGetProcInfoGetOSInfoGetPartitionsGetNetInfoGetCPUsServerInfoGetSysConfigGetSysServicesGetSysErrorsGetAllBucketStatsGetBucketStatsGetSRMetricsGetPeerMetricsGetMetacacheListingUpdateMetacacheListingGetPeerBucketMetricsStorageInfoConsoleLogListDirGetLocksBackgroundHealStatusGetLastDayTierStatsSignalServiceGetBandwidthWriteAllListBucketsRenameDataInlineRenameData2CheckParts2RenameParthandlerTesthandlerTest2handlerLast"
 
-var _HandlerID_index = [...]uint16{0, 14, 22, 31, 41, 52, 63, 78, 85, 92, 100, 109, 115, 126, 136, 149, 163, 176, 186, 196, 206, 213, 225, 230, 236, 256, 274, 301, 315, 328, 345, 369, 381, 391, 408, 428, 446, 456, 464, 473, 483, 493, 503, 515, 525, 543, 553, 564, 573, 586, 596, 603, 613, 625, 639, 651, 668, 682, 694, 708, 727, 749, 769, 780, 790, 797, 805, 825, 844, 857, 869, 877, 888, 904, 915, 926, 937, 949, 960}
+var _HandlerID_index = [...]uint16{0, 14, 22, 31, 41, 52, 63, 78, 85, 92, 100, 109, 115, 126, 136, 149, 163, 176, 186, 196, 206, 213, 225, 230, 236, 256, 274, 301, 315, 328, 345, 369, 381, 391, 408, 428, 446, 456, 464, 473, 483, 493, 503, 515, 525, 543, 553, 564, 573, 586, 596, 603, 613, 625, 639, 651, 668, 682, 694, 708, 727, 749, 769, 780, 790, 797, 805, 825, 844, 857, 869, 877, 888, 904, 915, 926, 936, 947, 959, 970}
 
 func (i HandlerID) String() string {
 	if i >= HandlerID(len(_HandlerID_index)-1) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
implement a safer completeMultipart implementation

## Motivation and Context
- optimize writing part.N.meta by writing both part.N
  and its meta in sequence without network component.

- remove part.N.meta, part.N which were partially success
  ful, in quorum loss situations during renamePart()

- allow for strict read quorum check arbitrated via ETag
  for the given part number, this makes it double safer
  upon final commit.

- return an appropriate error when read quorum is missing,
  instead of returning InvalidPart{}, which is non-retryable
  error. This kind of situation can happen when many
  nodes are going offline in rotation, an example of such
  a restart() behavior is statefulset updates in k8s.

fixes #20091

## How to test this PR?
CI/CD handles this properly, the way to reproduce issue start 4 node MinIO and continuously restart it 

```sh
#!/bin/bash

alias=$1

minio_wait() {
	mc ready $1
	mc ready $1
	mc ready $1
	mc ready $1
}

bounce() {
	docker stop $1
	sleep 1
	docker start $1
	minio_wait $alias
}

while true; do
	bounce tmp-minio1-1
	bounce tmp-minio2-1
	bounce tmp-minio3-1
	bounce tmp-minio4-1
done
```

```go
package main

import (
	"bytes"
	"context"
	"errors"
	"fmt"
	"log"
	"math/rand"
	"os"
	"os/signal"
	"sync"
	"time"

	mclient "github.com/minio/minio-go/v7"
	mcreds "github.com/minio/minio-go/v7/pkg/credentials"
)

const (
	Host      = "localhost:8080"
	AccessKey = "minioadmin"
	SecretKey = "minioadmin"
)

const (
	NWorkers         = 10
	ReqSize          = 1 << 20 * 10
	DisableMultipart = false
)

func main() {
	mc, err := mclient.New(Host, &mclient.Options{
		Creds:  mcreds.NewStaticV4(AccessKey, SecretKey, ""),
		Secure: false,
	})
	if err != nil {
		log.Fatal(err)
	}

	ctx := context.Background()
	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
	defer stop()

	msgs := make(chan string, 100)

	var wg sync.WaitGroup
	for i := 0; i < NWorkers; i++ {
		wg.Add(1)

		// start request worker
		go func(i int) {
			defer wg.Done()
			data := make([]byte, ReqSize)
			if _, err := rand.Read(data); err != nil {
				log.Fatalf("data prep err: %v", err)
			}
			buf := bytes.NewReader(data)
			name := fmt.Sprintf("obj%d", i)

			opts := mclient.PutObjectOptions{
				//PartSize:         (1 << 20) * 100,
				DisableMultipart: DisableMultipart,
				PartSize:         (1 << 20) * 5,
			}
			var err error
			for {
				if ctx.Err() != nil {
					return // cancelled
				}

				// retry certain error types
				for tries := 0; tries < 3; tries++ {
					localCtx, done := context.WithTimeout(ctx, 1500*time.Second)
					_, err = mc.PutObject(localCtx, "testing", name, buf, int64(len(data)), opts)
					done()
					if err == nil {
						break
					}

					if errors.Is(err, context.DeadlineExceeded) {
						msgs <- fmt.Sprintf("Deadline (%d: try #%d): %v", i+1, tries, err)
						continue
					}
					eResp := mclient.ToErrorResponse(err)
					if eResp.StatusCode == 400 && eResp.Code == "InvalidPart" {
						msgs <- fmt.Sprintf("400 InvalidPart: (%d: try #%d, obj: %v): %v", i+1, tries, name, err)
						continue
					}
					if eResp.StatusCode == 404 && eResp.Code == "NoSuchUpload" {
						msgs <- fmt.Sprintf("404 NoSuchUpload: (%d: try #%d): %v", i+1, tries, err)
						continue
					}
					if eResp.StatusCode == 503 && eResp.Code == "SlowDownRead" {
						time.Sleep(2 * time.Second)
						msgs <- fmt.Sprintf("503 SlowDownRead: (%d: try #%d): %v", i+1, tries, err)
						continue
					}
					msgs <- fmt.Sprintf("Error: (%d: try #%d): %v", i+1, tries, err)
					break
				}

				if errors.Is(err, context.Canceled) {
					return
				}
				if errors.Is(err, context.DeadlineExceeded) {
					msgs <- fmt.Sprintf("Deadline (%d): %v: skipping request", i+1, err)
					continue
				}
				if err != nil {
					eResp := mclient.ToErrorResponse(err)
					log.Fatalf("Copy error: %#v", eResp)
				}

				msgs <- fmt.Sprintf("OK (%d)", i+1)
				r := rand.Intn(400) + 50
				time.Sleep(time.Duration(r) * time.Millisecond)
			}

		}(i)
	}

	// sync handle messages from workers
	go func() {
		for {
			select {
			case <-ctx.Done():
				return
			case m := <-msgs:
				fmt.Println(m)
			}
		}
	}()

	wg.Wait()
}
```


```yaml
version: '3.7'

# Settings and configurations that are common for all containers
x-minio-common: &minio-common
  image: y4m4/minio:dev
  command: server --address ":9000" --console-address ":9090" http://minio{1...4}/data{1...2}
  expose:
    - "9000"
    - "9090"
  environment:
    MINIO_ROOT_USER: minioadmin
    MINIO_ROOT_PASSWORD: minioadmin
  # healthcheck:
  #  test: ["CMD", "mc", "ready", "local"]
  #  interval: 5s
  #  timeout: 5s
  #  retries: 5

# starts 4 docker containers running minio server instances.
# using nginx reverse proxy, load balancing, you can access
# it through port 9000.
services:
  minio1:
    <<: *minio-common
    hostname: minio1
    volumes:
      - data1-1:/data1
      - data1-2:/data2

  minio2:
    <<: *minio-common
    hostname: minio2
    volumes:
      - data2-1:/data1
      - data2-2:/data2

  minio3:
    <<: *minio-common
    hostname: minio3
    volumes:
      - data3-1:/data1
      - data3-2:/data2

  minio4:
    <<: *minio-common
    hostname: minio4
    volumes:
      - data4-1:/data1
      - data4-2:/data2

  nginx:
    image: nginx:1.19.2-alpine
    hostname: nginx
    volumes:
      - ./nginx.conf:/etc/nginx/nginx.conf:ro
    ports:
      - "9000:9000"
      - "9090:9090"
    depends_on:
      - minio1
      - minio2
      - minio3
      - minio4

  sidekick:
    command: --health-path=/minio/health/cluster --address :8000 http://minio{1...4}:9000
    image: quay.io/minio/sidekick:v7.0.0
    hostname: sidekick
    expose:
    - "8000"
    ports:
      - "8080:8000"
    depends_on:
      - minio1
      - minio2
      - minio3
      - minio4
      - nginx

## By default this config uses default local driver,
## For custom volumes replace with volume driver configuration.
volumes:
  data1-1:
  data1-2:
  data2-1:
  data2-2:
  data3-1:
  data3-2:
  data4-1:
  data4-2:
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
