### PR TITLE
enhance getActualSize() to return valid values for most situations

### DIFF
--- a/cmd/encryption-v1.go
+++ b/cmd/encryption-v1.go
@@ -743,8 +743,9 @@ func (d *DecryptBlocksReader) Read(p []byte) (int, error) {
 // but has an invalid size.
 func (o ObjectInfo) DecryptedSize() (int64, error) {
 	if _, ok := crypto.IsEncrypted(o.UserDefined); !ok {
-		return 0, errors.New("Cannot compute decrypted size of an unencrypted object")
+		return -1, errors.New("Cannot compute decrypted size of an unencrypted object")
 	}
+
 	if !o.isMultipart() {
 		size, err := sio.DecryptedSize(uint64(o.Size))
 		if err != nil {
@@ -757,7 +758,7 @@ func (o ObjectInfo) DecryptedSize() (int64, error) {
 	for _, part := range o.Parts {
 		partSize, err := sio.DecryptedSize(uint64(part.Size))
 		if err != nil {
-			return 0, errObjectTampered
+			return -1, errObjectTampered
 		}
 		size += int64(partSize)
 	}

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1301,7 +1301,9 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 
 	// Save the consolidated actual size.
 	if opts.ReplicationRequest {
-		fi.Metadata[ReservedMetadataPrefix+"actual-size"] = opts.UserDefined["X-Minio-Internal-Actual-Object-Size"]
+		if v := opts.UserDefined[ReservedMetadataPrefix+"Actual-Object-Size"]; v != "" {
+			fi.Metadata[ReservedMetadataPrefix+"actual-size"] = v
+		}
 	} else {
 		fi.Metadata[ReservedMetadataPrefix+"actual-size"] = strconv.FormatInt(objectActualSize, 10)
 	}

--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -257,7 +257,7 @@ func (e *metaCacheEntry) fileInfo(bucket string) (FileInfo, error) {
 				ModTime:  timeSentinel1970,
 			}, nil
 		}
-		return e.cached.ToFileInfo(bucket, e.name, "", false, false)
+		return e.cached.ToFileInfo(bucket, e.name, "", false, true)
 	}
 	return getFileInfo(e.metadata, bucket, e.name, "", fileInfoOpts{})
 }
@@ -300,7 +300,7 @@ func (e *metaCacheEntry) fileInfoVersions(bucket string) (FileInfoVersions, erro
 		}, nil
 	}
 	// Too small gains to reuse cache here.
-	return getFileInfoVersions(e.metadata, bucket, e.name, false, true)
+	return getFileInfoVersions(e.metadata, bucket, e.name, true)
 }
 
 // metaCacheEntries is a slice of metacache entries.

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -482,7 +482,6 @@ func completeMultipartOpts(ctx context.Context, r *http.Request, bucket, object 
 	}
 	opts.MTime = mtime
 	opts.UserDefined = make(map[string]string)
-	opts.UserDefined[ReservedMetadataPrefix+"Actual-Object-Size"] = r.Header.Get(xhttp.MinIOReplicationActualObjectSize)
 	// Transfer SSEC key in opts.EncryptFn
 	if crypto.SSEC.IsRequested(r.Header) {
 		key, err := ParseSSECustomerRequest(r)
@@ -495,6 +494,7 @@ func completeMultipartOpts(ctx context.Context, r *http.Request, bucket, object 
 	}
 	if _, ok := r.Header[xhttp.MinIOSourceReplicationRequest]; ok {
 		opts.ReplicationRequest = true
+		opts.UserDefined[ReservedMetadataPrefix+"Actual-Object-Size"] = r.Header.Get(xhttp.MinIOReplicationActualObjectSize)
 	}
 	if r.Header.Get(ReplicationSsecChecksumHeader) != "" {
 		opts.UserDefined[ReplicationSsecChecksumHeader] = r.Header.Get(ReplicationSsecChecksumHeader)

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -609,7 +609,6 @@ func TestGetActualSize(t *testing.T) {
 			objInfo: ObjectInfo{
 				UserDefined: map[string]string{
 					"X-Minio-Internal-compression": "klauspost/compress/s2",
-					"X-Minio-Internal-actual-size": "100000001",
 					"content-type":                 "application/octet-stream",
 					"etag":                         "b3ff3ef3789147152fbfbc50efba4bfd-2",
 				},
@@ -623,6 +622,7 @@ func TestGetActualSize(t *testing.T) {
 						ActualSize: 32891137,
 					},
 				},
+				Size: 100000001,
 			},
 			result: 100000001,
 		},
@@ -635,6 +635,7 @@ func TestGetActualSize(t *testing.T) {
 					"etag":                         "b3ff3ef3789147152fbfbc50efba4bfd-2",
 				},
 				Parts: []ObjectPartInfo{},
+				Size:  841,
 			},
 			result: 841,
 		},
@@ -646,6 +647,7 @@ func TestGetActualSize(t *testing.T) {
 					"etag":                         "b3ff3ef3789147152fbfbc50efba4bfd-2",
 				},
 				Parts: []ObjectPartInfo{},
+				Size:  100,
 			},
 			result: -1,
 		},

--- a/cmd/xl-storage-format-utils.go
+++ b/cmd/xl-storage-format-utils.go
@@ -30,8 +30,8 @@ import (
 // if inclFreeVersions is true all the versions are in fivs.Versions, free and non-free versions alike.
 //
 // Note: Only the scanner requires fivs.Versions to have exclusively non-free versions. This is used while enforcing NewerNoncurrentVersions lifecycle element.
-func getFileInfoVersions(xlMetaBuf []byte, volume, path string, allParts, inclFreeVersions bool) (FileInfoVersions, error) {
-	fivs, err := getAllFileInfoVersions(xlMetaBuf, volume, path, allParts)
+func getFileInfoVersions(xlMetaBuf []byte, volume, path string, inclFreeVersions bool) (FileInfoVersions, error) {
+	fivs, err := getAllFileInfoVersions(xlMetaBuf, volume, path, true)
 	if err != nil {
 		return fivs, err
 	}
@@ -106,7 +106,6 @@ func getAllFileInfoVersions(xlMetaBuf []byte, volume, path string, allParts bool
 type fileInfoOpts struct {
 	InclFreeVersions bool
 	Data             bool
-	AllParts         bool
 }
 
 func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, opts fileInfoOpts) (FileInfo, error) {
@@ -117,7 +116,7 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, opts fileInfo
 		return FileInfo{}, e
 	} else if buf != nil {
 		inData = data
-		fi, err = buf.ToFileInfo(volume, path, versionID, opts.AllParts)
+		fi, err = buf.ToFileInfo(volume, path, versionID, true)
 		if len(buf) != 0 && errors.Is(err, errFileNotFound) {
 			// This special case is needed to handle len(xlMeta.versions) == 0
 			return FileInfo{
@@ -146,7 +145,7 @@ func getFileInfo(xlMetaBuf []byte, volume, path, versionID string, opts fileInfo
 			}, nil
 		}
 		inData = xlMeta.data
-		fi, err = xlMeta.ToFileInfo(volume, path, versionID, opts.InclFreeVersions, opts.AllParts)
+		fi, err = xlMeta.ToFileInfo(volume, path, versionID, opts.InclFreeVersions, true)
 	}
 	if !opts.Data || err != nil {
 		return fi, err

--- a/cmd/xl-storage-format-utils_test.go
+++ b/cmd/xl-storage-format-utils_test.go
@@ -178,7 +178,7 @@ func TestGetFileInfoVersions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to serialize xlmeta %v", err)
 	}
-	fivs, err := getFileInfoVersions(buf, basefi.Volume, basefi.Name, true, false)
+	fivs, err := getFileInfoVersions(buf, basefi.Volume, basefi.Name, false)
 	if err != nil {
 		t.Fatalf("getFileInfoVersions failed: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestGetFileInfoVersions(t *testing.T) {
 	// versions are stored in xl-meta sorted in descending order of their ModTime
 	slices.Reverse(allVersionIDs)
 
-	fivs, err = getFileInfoVersions(buf, basefi.Volume, basefi.Name, true, true)
+	fivs, err = getFileInfoVersions(buf, basefi.Volume, basefi.Name, true)
 	if err != nil {
 		t.Fatalf("getFileInfoVersions failed: %v", err)
 	}

--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -590,7 +590,7 @@ func (s *xlStorage) NSScanner(ctx context.Context, cache dataUsageCache, updates
 		// Remove filename which is the meta file.
 		item.transformMetaDir()
 
-		fivs, err := getFileInfoVersions(buf, item.bucket, item.objectPath(), false, false)
+		fivs, err := getFileInfoVersions(buf, item.bucket, item.objectPath(), false)
 		metaDataPoolPut(buf)
 		if err != nil {
 			res["err"] = err.Error()
@@ -1671,7 +1671,6 @@ func (s *xlStorage) ReadVersion(ctx context.Context, origvolume, volume, path, v
 	fi, err = getFileInfo(buf, volume, path, versionID, fileInfoOpts{
 		Data:             opts.ReadData,
 		InclFreeVersions: opts.InclFreeVersions,
-		AllParts:         true,
 	})
 	if err != nil {
 		return fi, err

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -271,7 +271,7 @@ func TestXLStorageReadVersion(t *testing.T) {
 	}
 
 	xlMeta, _ := os.ReadFile("testdata/xl.meta")
-	fi, _ := getFileInfo(xlMeta, "exists", "as-file", "", fileInfoOpts{Data: false, AllParts: true})
+	fi, _ := getFileInfo(xlMeta, "exists", "as-file", "", fileInfoOpts{Data: false})
 
 	// Create files for the test cases.
 	if err = xlStorage.MakeVol(context.Background(), "exists"); err != nil {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
enhance getActualSize() to return valid values for most situations

## Motivation and Context
Bonus: remove allParts boolean function argument since 
we were sending 'true' in all cases and it's not necessary.

## How to test this PR?
This requires a setup with 

- Setup 2 clusters, the first one with minio.RELEASE.2024-02-12T21-02-27Z 
  and the second one with minio.RELEASE.2024-05-10T01-41-38Z

- Create bucket with versioning and enable encryption on both clusters
  setup one-way bucket replication

- Upload a bigger object to the source cluster (to initiate multipart)

- When listing the target, it fails with
```
mc: <ERROR> Unable to list folder. The requested object was modified and may be compromised
```

This PR fixes this situation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression 468a9fae83e965ecefa1c1fdc2fc57b84ece95b0
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
