### PR TITLE
Add admin info timeouts

### DIFF
--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -1099,6 +1099,8 @@ func (sys *NotificationSys) ServerInfo(ctx context.Context, metrics bool) []madm
 		wg.Add(1)
 		go func(client *peerRESTClient, idx int) {
 			defer wg.Done()
+			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
 			info, err := client.ServerInfo(ctx, metrics)
 			if err != nil {
 				info.Endpoint = client.host.String()


### PR DESCRIPTION
## Description

Since a lot of operations load from storage, do remote calls, add a 10 second timeout to each operation.

## Motivation and Context

This should make `mc admin info` return values even under extreme conditions.

## How to test this PR?

To be tested under extreme load conditions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
