### PR TITLE
avoid crash when initializing bucket quota cache

### DIFF
--- a/cmd/server-main.go
+++ b/cmd/server-main.go
@@ -1090,11 +1090,6 @@ func serverMain(ctx *cli.Context) {
 			globalSiteReplicationSys.Init(GlobalContext, newObject)
 		})
 
-		// Initialize quota manager.
-		bootstrapTrace("globalBucketQuotaSys.Init", func() {
-			globalBucketQuotaSys.Init(newObject)
-		})
-
 		// Populate existing buckets to the etcd backend
 		if globalDNSConfig != nil {
 			// Background this operation.

--- a/cmd/veeam-sos-api.go
+++ b/cmd/veeam-sos-api.go
@@ -171,7 +171,7 @@ func veeamSOSAPIGetObject(ctx context.Context, bucket, object string, rs *HTTPRa
 		}
 
 		q, _ := globalBucketQuotaSys.Get(ctx, bucket)
-		binfo, _ := globalBucketQuotaSys.GetBucketUsageInfo(ctx, bucket)
+		binfo := globalBucketQuotaSys.GetBucketUsageInfo(ctx, bucket)
 
 		ci := capacityInfo{
 			Used: int64(binfo.Size),


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
avoid crash when initializing bucket quota cache

## Motivation and Context
avoid a crash such as

```
ERRO: panic: "PUT /xxxxxxxxxx/1.snappy": runtime error: invalid memory address or nil pointer dereference
goroutine 14118 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x5e
github.com/minio/minio/cmd.serverMain.func8.setCriticalErrorHandler.2.1()
        github.com/minio/minio/cmd/generic-handlers.go:568 +0x99
panic({0x299cca0?, 0x65f7900?})
        runtime/panic.go:770 +0x132
github.com/minio/minio/internal/cachevalue.(*Cache[...]).update(0x4e6e0c0, {0x4e55120, 0xc00dd9f470})
        github.com/minio/minio/internal/cachevalue/cache.go:143 +0x84
```

## How to test this PR?
Perform requests to the server before the data structures are all initialized just 
add some delays in the startup sequence, and make sure you have a bucket quota
enabled for the bucket.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
