### PR TITLE
Removing the audit log retry mechanism

### DIFF
--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -562,7 +562,6 @@ func (h *Target) Send(ctx context.Context, entry interface{}) error {
 		return nil
 	}
 
-retry:
 	select {
 	case h.logCh <- entry:
 		h.totalMessages.Add(1)
@@ -573,12 +572,6 @@ retry:
 		}
 		return nil
 	default:
-		nWorkers := h.workers.Load()
-		if nWorkers < h.maxWorkers {
-			// Just sleep to avoid any possible hot-loops.
-			time.Sleep(50 * time.Millisecond)
-			goto retry
-		}
 		h.totalMessages.Add(1)
 		h.failedMessages.Add(1)
 		return errors.New("log buffer full")


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The audit log retry mechanism is causing backpressure when the receiver(aka target) is not able to receive logs fast enough. This causes a buildup, which eventually causes retries to be triggered in the Send function.

The retry mechanism having a sleep timer is sub-optimal, but the cause for minios hard-stop of data ingestion was caused by `minio/cmd/handler-api.go: 535` the above mentioned ratelimiter works on a hard-coded value instead of resource usage, so when the audit logs started retrying, total active requests would build up, and the ratelimiter starts dropping requests. Even if we had enough resources to keep going. 

The audit retry mechanism is not needed anymore since the audit log queues will start spawning more processors at 50% capacity. If we're ever in the situation where the queue is full, a retry won't help. 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
