### PR TITLE
try loading temp account if not in cache

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1212,9 +1212,18 @@ func (sys *IAMSys) getServiceAccount(ctx context.Context, accessKey string) (Use
 
 // GetTemporaryAccount - wrapper method to get information about a temporary account
 func (sys *IAMSys) GetTemporaryAccount(ctx context.Context, accessKey string) (auth.Credentials, *policy.Policy, error) {
+	if !sys.Initialized() {
+		return auth.Credentials{}, nil, errServerNotInitialized
+	}
 	tmpAcc, embeddedPolicy, err := sys.getTempAccount(ctx, accessKey)
 	if err != nil {
-		return auth.Credentials{}, nil, err
+		if err == errNoSuchTempAccount {
+			sys.store.LoadUser(ctx, accessKey)
+			tmpAcc, embeddedPolicy, err = sys.getTempAccount(ctx, accessKey)
+		}
+		if err != nil {
+			return auth.Credentials{}, nil, err
+		}
 	}
 	// Hide secret & session keys
 	tmpAcc.Credentials.SecretKey = ""


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context

Attempt loading sts token if missing in cache

## How to test this PR?
create an sts token , then restart the instance - sts token should be displayed.
```
mc admin user sts info sitea JZLAQW4PG3EIDFZ7VAIP
AccessKey: JZLAQW4PG3EIDFZ7VAIP
ParentUser: foobar
Status: on
Name:
Description:
Policy: embedded
Expiration: 5 minutes from now
```

with master branch, 
```
mc admin user sts info sitea JZLAQW4PG3EIDFZ7VAIP
mc: <ERROR> Unable to get information of the specified service account. We encountered an internal error, please try again. (Specified temporary account does not exist).
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
