### PR TITLE
[fix] S3Select: Add some missing input validation

### DIFF
--- a/internal/s3select/csv/args.go
+++ b/internal/s3select/csv/args.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	none = "none"
-	use  = "use"
+	none   = "none"
+	use    = "use"
+	ignore = "ignore"
 
 	defaultRecordDelimiter      = "\n"
 	defaultFieldDelimiter       = ","
@@ -92,11 +93,22 @@ func (args *ReaderArgs) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (er
 				}
 				switch tagName {
 				case "FileHeaderInfo":
-					args.FileHeaderInfo = strings.ToLower(s)
+					s = strings.ToLower(s)
+					if len(s) != 0 {
+						if s != none && s != use && s != ignore {
+							return errors.New("unsupported FileHeaderInfo")
+						}
+						args.FileHeaderInfo = s
+					}
+
 				case "RecordDelimiter":
-					args.RecordDelimiter = s
+					if len(s) != 0 {
+						args.RecordDelimiter = s
+					}
 				case "FieldDelimiter":
-					args.FieldDelimiter = s
+					if len(s) != 0 {
+						args.FieldDelimiter = s
+					}
 				case "QuoteCharacter":
 					if utf8.RuneCountInString(s) > 1 {
 						return fmt.Errorf("unsupported QuoteCharacter '%v'", s)
@@ -112,7 +124,9 @@ func (args *ReaderArgs) UnmarshalXML(d *xml.Decoder, start xml.StartElement) (er
 						return fmt.Errorf("unsupported QuoteEscapeCharacter '%v'", s)
 					}
 				case "Comments":
-					args.CommentCharacter = s
+					if len(s) != 0 {
+						args.CommentCharacter = s
+					}
 				default:
 					return errors.New("unrecognized option")
 				}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Prevents server panic when some CSV parameters are empty.

## Motivation and Context

Based on an emailed report. When the object is accessible via anonymous download, it could be used to crash the server without any credentials.

## How to test this PR?

```
# run minio on localhost
docker run -p 9000:9000 -p 9001:9001 minio/minio server /data --console-address ":9001"
# setup the admin account
mc config host add localtest http://127.0.0.1:9000/ minioadmin minioadmin
# upload any file
echo 1 > /tmp/testfile
mc cp /tmp/testfile localadmin/test

# send SQL with empty field delimeter
mc sql -e "SELECT _1 FROM s3object" --csv-input "fd=" localtest/test/testfile
# check the server
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
