### PR TITLE
add missing STS accounts loading

### DIFF
--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -802,7 +802,11 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	// Store the newly populated map in the iam cache. This takes care of
 	// removing stale entries from the existing map.
 	cache.iamSTSAccountsMap = stsAccountsFromStore
-	cache.iamSTSPolicyMap = stsAccPoliciesFromStore
+
+	stsAccPoliciesFromStore.Range(func(k string, v MappedPolicy) bool {
+		cache.iamSTSPolicyMap.Store(k, v)
+		return true
+	})
 
 	return nil
 }

--- a/cmd/iam-store.go
+++ b/cmd/iam-store.go
@@ -2865,6 +2865,10 @@ func (store *IAMStoreSys) LoadUser(ctx context.Context, accessKey string) error 
 		cache.iamUsersMap[k] = v
 	}
 
+	for k, v := range newCache.iamSTSAccountsMap {
+		cache.iamSTSAccountsMap[k] = v
+	}
+
 	newCache.iamSTSPolicyMap.Range(func(k string, v MappedPolicy) bool {
 		cache.iamSTSPolicyMap.Store(k, v)
 		return true

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -179,7 +179,7 @@ func (sys *IAMSys) initStore(objAPI ObjectLayer, etcdClient *etcd.Client) {
 
 	if etcdClient == nil {
 		var group *singleflight.Group
-		if env.Get("_MINIO_IAM_SINGLE_FLIGHT", config.EnableOff) == config.EnableOn {
+		if env.Get("_MINIO_IAM_SINGLE_FLIGHT", config.EnableOn) == config.EnableOn {
 			group = &singleflight.Group{}
 		}
 		sys.store = &IAMStoreSys{

--- a/docs/sts/assume-role.go
+++ b/docs/sts/assume-role.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7"
 	cr "github.com/minio/minio-go/v7/pkg/credentials"
 )
@@ -112,6 +113,11 @@ func main() {
 		Secure: stsEndpointURL.Scheme == "https",
 	}
 
+	mopts := &madmin.Options{
+		Creds:  li,
+		Secure: stsEndpointURL.Scheme == "https",
+	}
+
 	v, err := li.Get()
 	if err != nil {
 		log.Fatalf("Error retrieving STS credentials: %v", err)
@@ -123,6 +129,18 @@ func main() {
 		fmt.Println("SecretAccessKey:", v.SecretAccessKey)
 		fmt.Println("SessionToken:", v.SessionToken)
 		return
+	}
+
+	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
+	// New returns an MinIO Admin client object.
+	madmClnt, err := madmin.NewWithOptions(stsEndpointURL.Host, mopts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = madmClnt.ServiceRestart(context.Background())
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	// Use generated credentials to authenticate with MinIO server


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add missing STS accounts loading

## Motivation and Context
PR #20268 missed loading STS accounts map properly

## How to test this PR?
you can use 
```go
package main

import (
	"context"
	"flag"
	"fmt"
	"io"
	"log"
	"net/url"
	"os"
	"time"

	"github.com/minio/madmin-go/v3"
	"github.com/minio/minio-go/v7"
	cr "github.com/minio/minio-go/v7/pkg/credentials"
)

var (
	// Minio endpoint (for STS API)
	stsEndpoint string

	// User account credentials
	minioUsername string
	minioPassword string

	// Display credentials flag
	displayCreds bool

	// Credential expiry duration
	expiryDuration time.Duration

	// Bucket to list
	bucketToList string

	// Session policy file (FIXME: add support in minio-go)
	sessionPolicyFile string
)

func init() {
	flag.StringVar(&stsEndpoint, "sts-ep", "http://localhost:9000", "STS endpoint")
	flag.StringVar(&minioUsername, "u", "", "MinIO Username")
	flag.StringVar(&minioPassword, "p", "", "MinIO Password")
	flag.BoolVar(&displayCreds, "d", false, "Only show generated credentials")
	flag.DurationVar(&expiryDuration, "e", 0, "Request a duration of validity for the generated credential")
	flag.StringVar(&bucketToList, "b", "", "Bucket to list (defaults to username)")
	flag.StringVar(&sessionPolicyFile, "s", "", "File containing session policy to apply to the STS request")
}

func main() {
	flag.Parse()
	if minioUsername == "" || minioPassword == "" {
		flag.PrintDefaults()
		return
	}

	// The credentials package in minio-go provides an interface to call the
	// STS API.

	// Initialize credential options
	var stsOpts cr.STSAssumeRoleOptions
	stsOpts.AccessKey = minioUsername
	stsOpts.SecretKey = minioPassword

	if sessionPolicyFile != "" {
		var policy string
		if f, err := os.Open(sessionPolicyFile); err != nil {
			log.Fatalf("Unable to open session policy file: %v", err)
		} else {
			defer f.Close()
			bs, err := io.ReadAll(f)
			if err != nil {
				log.Fatalf("Error reading session policy file: %v", err)
			}
			policy = string(bs)
		}
		stsOpts.Policy = policy
	}
	if expiryDuration != 0 {
		stsOpts.DurationSeconds = int(expiryDuration.Seconds())
	}
	li, err := cr.NewSTSAssumeRole(stsEndpoint, stsOpts)
	if err != nil {
		log.Fatalf("Error initializing STS Identity: %v", err)
	}

	stsEndpointURL, err := url.Parse(stsEndpoint)
	if err != nil {
		log.Fatalf("Error parsing sts endpoint: %v", err)
	}

	opts := &minio.Options{
		Creds:  li,
		Secure: stsEndpointURL.Scheme == "https",
	}

	mopts := &madmin.Options{
		Creds:  li,
		Secure: stsEndpointURL.Scheme == "https",
	}

	v, err := li.Get()
	if err != nil {
		log.Fatalf("Error retrieving STS credentials: %v", err)
	}

	if displayCreds {
		fmt.Println("Only displaying credentials:")
		fmt.Println("AccessKeyID:", v.AccessKeyID)
		fmt.Println("SecretAccessKey:", v.SecretAccessKey)
		fmt.Println("SessionToken:", v.SessionToken)
		return
	}

	// API requests are secure (HTTPS) if secure=true and insecure (HTTP) otherwise.
	// New returns an MinIO Admin client object.
	madmClnt, err := madmin.NewWithOptions(stsEndpointURL.Host, mopts)
	if err != nil {
		log.Fatalln(err)
	}

	err = madmClnt.ServiceRestart(context.Background())
	if err != nil {
		log.Fatalln(err)
	}

	// Use generated credentials to authenticate with MinIO server
	minioClient, err := minio.New(stsEndpointURL.Host, opts)
	if err != nil {
		log.Fatalf("Error initializing client: %v", err)
	}

	// Use minIO Client object normally like the regular client.
	if bucketToList == "" {
		bucketToList = minioUsername
	}
	fmt.Printf("Calling list objects on bucket named `%s` with temp creds:\n===\n", bucketToList)
	objCh := minioClient.ListObjects(context.Background(), bucketToList, minio.ListObjectsOptions{})
	for obj := range objCh {
		if obj.Err != nil {
			log.Fatalf("Listing error: %v", obj.Err)
		}
		fmt.Printf("Key: %s\nSize: %d\nLast Modified: %s\n===\n", obj.Key, obj.Size, obj.LastModified)
	}
}
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
