### PR TITLE
parseObjectAttributes should handle multiple header values when X-Amz…

### DIFF
--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -225,9 +225,11 @@ func getAndValidateAttributesOpts(ctx context.Context, w http.ResponseWriter, r 
 
 func parseObjectAttributes(h http.Header) (attributes map[string]struct{}) {
 	attributes = make(map[string]struct{})
-	for _, v := range strings.Split(strings.TrimSpace(h.Get(xhttp.AmzObjectAttributes)), ",") {
-		if v != "" {
-			attributes[v] = struct{}{}
+	for _, headerVal := range h.Values(xhttp.AmzObjectAttributes) {
+		for _, v := range strings.Split(strings.TrimSpace(headerVal), ",") {
+			if v != "" {
+				attributes[v] = struct{}{}
+			}
 		}
 	}
 

--- a/cmd/object-api-options_test.go
+++ b/cmd/object-api-options_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	xhttp "github.com/minio/minio/internal/http"
+)
+
+// TestGetAndValidateAttributesOpts is currently minimal and covers a subset of getAndValidateAttributesOpts(),
+// it is intended to be expanded when the function is worked on in the future.
+func TestGetAndValidateAttributesOpts(t *testing.T) {
+	globalBucketVersioningSys = &BucketVersioningSys{}
+	bucket := minioMetaBucket
+	ctx := context.Background()
+	testCases := []struct {
+		name            string
+		headers         http.Header
+		wantObjectAttrs map[string]struct{}
+	}{
+		{
+			name:            "empty header",
+			headers:         http.Header{},
+			wantObjectAttrs: map[string]struct{}{},
+		},
+		{
+			name: "single header line",
+			headers: http.Header{
+				xhttp.AmzObjectAttributes: []string{"test1,test2"},
+			},
+			wantObjectAttrs: map[string]struct{}{
+				"test1": {}, "test2": {},
+			},
+		},
+		{
+			name: "multiple header lines with some duplicates",
+			headers: http.Header{
+				xhttp.AmzObjectAttributes: []string{"test1,test2", "test3,test4", "test4,test3"},
+			},
+			wantObjectAttrs: map[string]struct{}{
+				"test1": {}, "test2": {}, "test3": {}, "test4": {},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header = testCase.headers
+
+			opts, _ := getAndValidateAttributesOpts(ctx, rec, req, bucket, "testobject")
+
+			if !reflect.DeepEqual(opts.ObjectAttributes, testCase.wantObjectAttrs) {
+				t.Errorf("want opts %v, got %v", testCase.wantObjectAttrs, opts.ObjectAttributes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…-Object-Attributes is given more than once

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Detailed description in https://github.com/minio/minio/issues/20267, essentially headers where the key is repeated as follows:

```
X-Amz-Object-Attributes: ETag
X-Amz-Object-Attributes: Checksum
X-Amz-Object-Attributes: ObjectParts
X-Amz-Object-Attributes: StorageClass
X-Amz-Object-Attributes: ObjectSize
```

## Motivation and Context



## How to test this PR?

There are tests in functional-tests.go in minio-go, as well as automated test in this PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
