### PR TITLE
fix: error in sending to a logger target from healFreshDisk will caus…

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -20,7 +20,6 @@ package logger
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"go/build"
@@ -422,9 +421,7 @@ func sendLog(ctx context.Context, entry log.Entry) {
 	for _, t := range systemTgts {
 		if err := t.Send(ctx, entry); err != nil {
 			if consoleTgt != nil { // Sending to the console never fails
-				b, _ := json.Marshal(entry)
-				entry.Trace.Message = fmt.Sprintf("sendLog: event %s was not sent to Logger target (%v): %v", string(b), t.String(), err.Error())
-				consoleTgt.Send(ctx, entry)
+				consoleTgt.Send(ctx, errToEntry(ctx, "logging", fmt.Errorf("unable to send log event to Logger target (%s): %v", t.String(), err), entry.Level))
 			}
 		}
 	}


### PR DESCRIPTION
…e nil pointer deref

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This happens only when there's an error sending to another configured log target and it falls back to console logging

I'd prefer to put in a more comprehensive fix, this is a quick hotfix 

Stacktrace below for MinIO version `RELEASE.2024-05-10T01-41-38Z` (some line numbers changed)

```
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xd3bbfb]
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: goroutine 25951542778 [running]:
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: github.com/minio/minio/internal/logger.sendLog({0x4e375c0, 0xc202e76e10}, {{0xc113b7fc80, 0x24}, {0x2dd38db, 0x5}, {0x0, 0x0}, {0x1f652765, >
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/internal/logger/logger.go:424 +0x17b
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: github.com/minio/minio/internal/logger.Event({0x4e375c0, 0xc202e76e10}, {0x2dd740a, 0x7}, {0x2e9dd17?, 0x1?}, {0xc159ccdee0?, 0xc137b223c0?,>
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/internal/logger/logger.go:437 +0x174
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: github.com/minio/minio/cmd.healingLogEvent(...)
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/cmd/logging.go:66
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: github.com/minio/minio/cmd.healFreshDisk({0x4e375c0, 0xc001306960}, 0xc0025746c0, {0xc002401a70, 0x1, 0x0, 0x6, 0xb})
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/cmd/background-newdisks-heal-ops.go:415 +0x5d2
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: github.com/minio/minio/cmd.monitorLocalDisksAndHeal.func1({0xc002401a70, 0x1, 0x0, 0x6, 0xb})
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/cmd/background-newdisks-heal-ops.go:528 +0xc7
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: created by github.com/minio/minio/cmd.monitorLocalDisksAndHeal in goroutine 7792
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]:         github.com/minio/minio/cmd/background-newdisks-heal-ops.go:526 +0x2a5
Aug 22 00:42:03 phx02-s12-swds006 minio[221756]: panic: runtime error: invalid memory address or nil pointer dereference
```
## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
