### PR TITLE
Reduce redundant hash computation

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -220,10 +220,11 @@ func newErasureServerPools(ctx context.Context, endpointServerPools EndpointServ
 }
 
 func (z *erasureServerPools) NewNSLock(bucket string, objects ...string) RWLocker {
-	poolID := hashKey(z.distributionAlgo, "", len(z.serverPools), z.deploymentID)
+	var key string
 	if len(objects) >= 1 {
-		poolID = hashKey(z.distributionAlgo, objects[0], len(z.serverPools), z.deploymentID)
+		key = objects[0]
 	}
+	poolID := hashKey(z.distributionAlgo, key, len(z.serverPools), z.deploymentID)
 	return z.serverPools[poolID].NewNSLock(bucket, objects...)
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

The hashKey function was initially called twice, once with an empty string and once with objects. By setting a default key variable and adjusting it based on the presence of objects, we ensure hashKey is called only once, thus reducing redundant computation.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
