### PR TITLE
do not list dangling objects with unmatched ECs

### DIFF
--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -267,13 +267,20 @@ func (x xlMetaV2VersionHeader) String() string {
 // matchesNotStrict returns whether x and o have both have non-zero version,
 // their versions match and their type match.
 // If they have zero version, modtime must match.
-func (x xlMetaV2VersionHeader) matchesNotStrict(o xlMetaV2VersionHeader) bool {
+func (x xlMetaV2VersionHeader) matchesNotStrict(o xlMetaV2VersionHeader) (ok bool) {
+	ok = x.VersionID == o.VersionID && x.Type == o.Type && x.matchesEC(o)
 	if x.VersionID == [16]byte{} {
-		return x.VersionID == o.VersionID &&
-			x.Type == o.Type && o.ModTime == x.ModTime
+		ok = ok && o.ModTime == x.ModTime
 	}
-	return x.VersionID == o.VersionID &&
-		x.Type == o.Type
+	return ok
+}
+
+func (x xlMetaV2VersionHeader) matchesEC(o xlMetaV2VersionHeader) bool {
+	fmt.Println(x.hasEC(), o.hasEC())
+	if x.hasEC() && o.hasEC() {
+		return x.EcN == o.EcN && x.EcM == o.EcM
+	} // if no EC header this is an older object
+	return true
 }
 
 // hasEC will return true if the version has erasure coding information.
@@ -1967,6 +1974,11 @@ func mergeXLV2Versions(quorum int, strict bool, requestedVersions int, versions 
 							continue
 						}
 						if !strict {
+							// we must match EC, when we are not strict.
+							if !a.header.matchesEC(ver.header) {
+								continue
+							}
+
 							a.header.Signature = [4]byte{}
 						}
 						x[a.header]++

--- a/cmd/xl-storage-format-v2.go
+++ b/cmd/xl-storage-format-v2.go
@@ -276,7 +276,6 @@ func (x xlMetaV2VersionHeader) matchesNotStrict(o xlMetaV2VersionHeader) (ok boo
 }
 
 func (x xlMetaV2VersionHeader) matchesEC(o xlMetaV2VersionHeader) bool {
-	fmt.Println(x.hasEC(), o.hasEC())
 	if x.hasEC() && o.hasEC() {
 		return x.EcN == o.EcN && x.EcM == o.EcM
 	} // if no EC header this is an older object


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
do not list dangling objects with unmatched ECs

## Motivation and Context
This mostly applies to all new objects, this simply 
ignores these objects and no application would have 
to deal with getting 503s on them.

## How to test this PR?
You need an inspect file that satisfies this 
situation.

```
~ mc cp inspect-data.zip.age play/testbucket/
```

Without this PR we simply list contents that are 
unreadable and HEAD returns 503 on them. It is 
simply better to not list them at all and the application
won't notice any ghost objects on the namespace.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
