### PR TITLE
batch: repl: A missing prefix in the remote source will fail replication

### DIFF
--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -388,7 +388,11 @@ func (r *BatchJobReplicateV1) StartFromSource(ctx context.Context, api ObjectLay
 
 		objInfoCh := make(chan miniogo.ObjectInfo, 1)
 		go func() {
-			for _, prefix := range r.Source.Prefix.F() {
+			prefixes := r.Source.Prefix.F()
+			if len(prefixes) == 0 {
+				prefixes = []string{""}
+			}
+			for _, prefix := range prefixes {
 				prefixObjInfoCh := c.ListObjects(ctx, r.Source.Bucket, miniogo.ListObjectsOptions{
 					Prefix:       strings.TrimSpace(prefix),
 					WithVersions: minioSrc,


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
When the prefix field is not provided in the remote source of a yaml replication job, 
the code fails to do listing and makes replication successful. This commit fixes it.


## Motivation and Context
Fix a use case of replication

## How to test this PR?
```
replicate:
  apiVersion: v1
  source:
    type: minio
    bucket: randombucket
    endpoint: "https://play.min.io"
    path: "on"
    credentials:
      accessKey: Q3AM3UQ867SPQQA43P2F
      secretKey: zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG
  target:
    type: minio
    bucket: testbucket
  flags:
    retry:
      attempts: 10 # number of retries for the job before giving up
      delay: "500ms" # least amount of delay between each retry
```

Put some objects in randombucket in play and run the above batch replication yam file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
