### PR TITLE
site-repl: Fix ILM document replication in some cases

### DIFF
--- a/internal/bucket/lifecycle/filter.go
+++ b/internal/bucket/lifecycle/filter.go
@@ -49,6 +49,10 @@ type Filter struct {
 // MarshalXML - produces the xml representation of the Filter struct
 // only one of Prefix, And and Tag should be present in the output.
 func (f Filter) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if !f.set {
+		return nil
+	}
+
 	if err := e.EncodeToken(start); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
S3 spec does not accept an ILM XML document containing both <Filter> and <Prefix> 
XML tags, even if both are empty. That is why we added 'set' field in some lifecycle
 structures, to decide when and when not to show a tag, however we forgot to 
disallow marsheling of Filter when 'set' is set to false.

This will fix ILM document replication in a site replication configuration in some cases.

## Motivation and Context
Fix lifecycle site replicaton

## How to test this PR?
1. Create two clusters and set up a site replication
2. Create a bucket and set the following ILM document rule
```
{
"Rules": [
{
"Expiration": {
"Days": 1
},
"Prefix": "",
"ID": "MinIO test replication ILM-expire Rule 1",
"Status": "Enabled",
"NoncurrentVersionExpiration": {
"NoncurrentDays": 1
}
}
]
}
```
3. Check if the ILM document is replicated

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
