### PR TITLE
verify part.N exists before reading part.N.meta

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1106,7 +1106,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 	readQuorum := fi.ReadQuorum(er.defaultRQuorum())
 
 	// Read Part info for all parts
-	partPath := pathJoin(uploadIDPath, fi.DataDir) + "/"
+	partPath := pathJoin(uploadIDPath, fi.DataDir) + SlashSeparator
 	partMetaPaths := make([]string, len(parts))
 	partNumbers := make([]int, len(parts))
 	for idx, part := range parts {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
verify part.N exists before reading part.N.meta

## Motivation and Context
if part.N doesn't exist, we do not have to complete the 
multipart transaction, it simply means that we have some 
partial upload situation at hand.

## How to test this PR?
You need a specific scenario where some drives become
either unreachable or unavailable for a short period
of time while we finish the 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
