### PR TITLE
readParts: Return error when quorum unavailable

### DIFF
--- a/.github/workflows/replication.yaml
+++ b/.github/workflows/replication.yaml
@@ -70,3 +70,9 @@ jobs:
           sudo sysctl net.ipv6.conf.all.disable_ipv6=0
           sudo sysctl net.ipv6.conf.default.disable_ipv6=0
           make test-versioning
+
+      - name: Test Multipart upload with failures
+        run: |
+          sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+          sudo sysctl net.ipv6.conf.default.disable_ipv6=0
+          make test-multipart

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ test-site-replication-minio: install-race ## verify automatic site replication
 	@echo "Running tests for automatic site replication of SSE-C objects with compression enabled for site"
 	@(env bash $(PWD)/docs/site-replication/run-ssec-object-replication-with-compression.sh)
 
+test-multipart: install-race ## test multipart
+	@echo "Test multipart behavior when part files are missing"
+	@(env bash $(PWD)/buildscripts/multipart-quorum-test.sh)
+
 verify: install-race ## verify minio various setups
 	@echo "Verifying build with race"
 	@(env bash $(PWD)/buildscripts/verify-build.sh)

--- a/buildscripts/multipart-quorum-test.sh
+++ b/buildscripts/multipart-quorum-test.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set -E
+set -o pipefail
+set -x
+
+WORK_DIR="$PWD/.verify-$RANDOM"
+MINIO_CONFIG_DIR="$WORK_DIR/.minio"
+MINIO=("$PWD/minio" --config-dir "$MINIO_CONFIG_DIR" server)
+
+if [ ! -x "$PWD/minio" ]; then
+	echo "minio executable binary not found in current directory"
+	exit 1
+fi
+
+if [ ! -x "$PWD/minio" ]; then
+	echo "minio executable binary not found in current directory"
+	exit 1
+fi
+
+trap 'catch $LINENO' ERR
+
+# shellcheck disable=SC2120
+catch() {
+	if [ $# -ne 0 ]; then
+		echo "error on line $1"
+	fi
+
+	echo "Cleaning up instances of MinIO"
+	pkill minio
+	pkill -9 minio
+	purge "$WORK_DIR"
+}
+
+catch
+
+function start_minio_10drive() {
+	start_port=$1
+
+	export MINIO_ROOT_USER=minio
+	export MINIO_ROOT_PASSWORD=minio123
+	export MC_HOST_minio="http://minio:minio123@127.0.0.1:${start_port}/"
+	unset MINIO_KMS_AUTO_ENCRYPTION # do not auto-encrypt objects
+	export MINIO_CI_CD=1
+
+	mkdir ${WORK_DIR}
+	C_PWD=${PWD}
+	if [ ! -x "$PWD/mc" ]; then
+		MC_BUILD_DIR="mc-$RANDOM"
+		if ! git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
+			echo "failed to download https://github.com/minio/mc"
+			purge "${MC_BUILD_DIR}"
+			exit 1
+		fi
+
+		(cd "${MC_BUILD_DIR}" && go build -o "$C_PWD/mc")
+
+		# remove mc source.
+		purge "${MC_BUILD_DIR}"
+	fi
+
+	"${MINIO[@]}" --address ":$start_port" "${WORK_DIR}/disk{1...10}" >"${WORK_DIR}/server1.log" 2>&1 &
+	pid=$!
+	disown $pid
+	sleep 5
+
+	if ! ps -p ${pid} 1>&2 >/dev/null; then
+		echo "server1 log:"
+		cat "${WORK_DIR}/server1.log"
+		echo "FAILED"
+		purge "$WORK_DIR"
+		exit 1
+	fi
+
+	"${PWD}/mc" mb --with-versioning minio/bucket
+
+	# install aws cli
+	curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+	unzip awscliv2.zip
+	sudo ./aws/install
+
+	export AWS_ACCESS_KEY_ID=minio
+	export AWS_SECRET_ACCESS_KEY=minio123
+	aws --endpoint-url http://localhost:"$start_port" s3api create-multipart-upload --bucket bucket --key obj-1 >upload-id.json
+	uploadId=$(jq -r '.UploadId' upload-id.json)
+
+	truncate -S 5MiB file-5mib
+	for i in {1..2}; do
+		aws --endpoint-url http://localhost:"$start_port" s3api upload-part \
+			--upload-id "$uploadId" --bucket bucket --key obj-1 \
+			--part-number "$i" --body file-5mib
+	done
+	for i in {1..6}; do
+		find ${WORK_DIR}/disk${i}/.minio.sys/multipart/ -type f -name "part.1" -delete
+	done
+	cat <<EOF >parts.json
+{
+    "Parts": [
+        {
+            "PartNumber": 1,
+            "ETag": "\"5f363e0e58a95f06cbe9bbc662c5dfb6\""
+        },
+        {
+            "PartNumber": 2,
+            "ETag": "\"5f363e0e58a95f06cbe9bbc662c5dfb6\""
+        }
+    ]
+}
+EOF
+
+	aws --endpoint-url http://localhost:"$start_port" s3api complete-multipart-upload --upload-id "$uploadId" --bucket bucket --key obj-1 --multipart-upload file://./parts.json 2>error.out
+	if ! grep "An error occurred (InvalidPart) when calling the CompleteMultipartUpload operation" error.out; then
+		echo "Failed to receive InvalidPart error"
+		exit 1
+	fi
+}
+
+function purge() {
+	rm -rf "$1"
+}
+
+function main() {
+	start_port=$(shuf -i 10000-65000 -n 1)
+	start_minio_10drive ${start_port}
+}
+
+(main "$@")
+rv=$?
+exit "$rv"

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1047,7 +1047,7 @@ func readParts(ctx context.Context, disks []StorageAPI, bucket string, partMetaP
 	return partInfosInQuorum, nil
 }
 
-func objPartToPartErr(part *ObjectPartInfo) error {
+func objPartToPartErr(part ObjectPartInfo) error {
 	if strings.Contains(part.Error, "file not found") {
 		return InvalidPart{PartNumber: part.Number}
 	}

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -985,27 +985,25 @@ func readParts(ctx context.Context, disks []StorageAPI, bucket string, partMetaP
 	}
 
 	partInfosInQuorum := make([]ObjectPartInfo, len(partMetaPaths))
-	partMetaQuorumMap := make(map[string]int, len(partNumbers))
 	for pidx := range partMetaPaths {
+		// partMetaQuorumMap uses
+		//  - path/to/part.N as key to collate errors from failed drives.
+		//  - part ETag to collate part metadata
+		partMetaQuorumMap := make(map[string]int, len(partNumbers))
 		var pinfos []*ObjectPartInfo
 		for idx := range disks {
-			if len(objectPartInfos[idx]) == 0 {
+			if len(objectPartInfos[idx]) != len(partMetaPaths) {
 				partMetaQuorumMap[partMetaPaths[pidx]]++
 				continue
 			}
 
 			pinfo := objectPartInfos[idx][pidx]
-			if pinfo == nil {
-				partMetaQuorumMap[partMetaPaths[pidx]]++
-				continue
-			}
-
-			if pinfo.ETag == "" {
-				partMetaQuorumMap[partMetaPaths[pidx]]++
-			} else {
+			if pinfo != nil && pinfo.ETag != "" {
 				pinfos = append(pinfos, pinfo)
 				partMetaQuorumMap[pinfo.ETag]++
+				continue
 			}
+			partMetaQuorumMap[partMetaPaths[pidx]]++
 		}
 
 		var maxQuorum int
@@ -1018,50 +1016,48 @@ func readParts(ctx context.Context, disks []StorageAPI, bucket string, partMetaP
 				maxPartMeta = etag
 			}
 		}
-
-		var pinfo *ObjectPartInfo
-		for _, pinfo = range pinfos {
-			if pinfo != nil && maxETag != "" && pinfo.ETag == maxETag {
+		// found is a representative ObjectPartInfo which either has the maximally occurring ETag or an error.
+		var found *ObjectPartInfo
+		for _, pinfo := range pinfos {
+			if pinfo == nil {
+				continue
+			}
+			if maxETag != "" && pinfo.ETag == maxETag {
+				found = pinfo
 				break
 			}
-			if maxPartMeta != "" && path.Base(maxPartMeta) == fmt.Sprintf("part.%d.meta", pinfo.Number) {
+			if pinfo.ETag == "" && maxPartMeta != "" && path.Base(maxPartMeta) == fmt.Sprintf("part.%d.meta", pinfo.Number) {
+				found = pinfo
 				break
 			}
 		}
 
-		if pinfo != nil && pinfo.ETag != "" && partMetaQuorumMap[maxETag] >= readQuorum {
-			partInfosInQuorum[pidx] = *pinfo
+		if found != nil && found.ETag != "" && partMetaQuorumMap[maxETag] >= readQuorum {
+			partInfosInQuorum[pidx] = *found
 			continue
 		}
-
-		if partMetaQuorumMap[maxPartMeta] == len(disks) {
-			if pinfo != nil && pinfo.Error != "" {
-				partInfosInQuorum[pidx] = ObjectPartInfo{Error: pinfo.Error}
-			} else {
-				partInfosInQuorum[pidx] = ObjectPartInfo{
-					Error: InvalidPart{
-						PartNumber: partNumbers[pidx],
-					}.Error(),
-				}
-			}
-		} else {
-			partInfosInQuorum[pidx] = ObjectPartInfo{Error: errErasureReadQuorum.Error()}
+		partInfosInQuorum[pidx] = ObjectPartInfo{
+			Number: partNumbers[pidx],
+			Error: InvalidPart{
+				PartNumber: partNumbers[pidx],
+			}.Error(),
 		}
+
 	}
 	return partInfosInQuorum, nil
 }
 
-func errStrToPartErr(errStr string) error {
-	if strings.Contains(errStr, "file not found") {
-		return InvalidPart{}
+func objPartToPartErr(part *ObjectPartInfo) error {
+	if strings.Contains(part.Error, "file not found") {
+		return InvalidPart{PartNumber: part.Number}
 	}
-	if strings.Contains(errStr, "Specified part could not be found") {
-		return InvalidPart{}
+	if strings.Contains(part.Error, "Specified part could not be found") {
+		return InvalidPart{PartNumber: part.Number}
 	}
-	if strings.Contains(errStr, errErasureReadQuorum.Error()) {
+	if strings.Contains(part.Error, errErasureReadQuorum.Error()) {
 		return errErasureReadQuorum
 	}
-	return errors.New(errStr)
+	return errors.New(part.Error)
 }
 
 // CompleteMultipartUpload - completes an ongoing multipart
@@ -1196,7 +1192,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 
 	for idx, part := range partInfoFiles {
 		if part.Error != "" {
-			err = errStrToPartErr(part.Error)
+			err = objPartToPartErr(part)
 			bugLogIf(ctx, err)
 			return oi, err
 		}


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
readParts requires that both part.N and part.N.meta files to be present. This change addresses an issue with how an error to return to the upper layers were picked from a majority of drives where an UploadPart operation had failed.

## Motivation and Context
A complete multipart upload may incorrectly succeed when one or more UploadPart calls failed with partial writes on minority drives, i.e part.N missing but part.N.meta present.

## How to test this PR?
1. Upload a multipart object 
2. Remove one or more parts from the backend drives
3. Issue Complete Multipart API call. This call should fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
