### PR TITLE
Add support for audit/logger max retry and retry interval

### DIFF
--- a/internal/logger/audit.go
+++ b/internal/logger/audit.go
@@ -144,7 +144,7 @@ func AuditLog(ctx context.Context, w http.ResponseWriter, r *http.Request, reqCl
 	// Send audit logs only to http targets.
 	for _, t := range auditTgts {
 		if err := t.Send(ctx, entry); err != nil {
-			LogOnceIf(ctx, "logging", fmt.Errorf("Unable to send an audit event to the target `%v`: %v", t, err), "send-audit-event-failure")
+			LogOnceIf(ctx, "logging", fmt.Errorf("Unable to send audit event(s) to the target `%v`: %v", t, err), "send-audit-event-failure")
 		}
 	}
 }

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -132,6 +132,18 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
+			Key:         MaxRetry,
+			Description: `maximum retry count before we start dropping upto batch_size events`,
+			Optional:    true,
+			Type:        "number",
+		},
+		config.HelpKV{
+			Key:         RetryInterval,
+			Description: `maximum retry sleeps between each retries`,
+			Optional:    true,
+			Type:        "duration",
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,

--- a/internal/logger/target/http/http.go
+++ b/internal/logger/target/http/http.go
@@ -79,6 +79,8 @@ type Config struct {
 	BatchSize  int               `json:"batchSize"`
 	QueueSize  int               `json:"queueSize"`
 	QueueDir   string            `json:"queueDir"`
+	MaxRetry   int               `json:"maxRetry"`
+	RetryIntvl time.Duration     `json:"retryInterval"`
 	Proxy      string            `json:"string"`
 	Transport  http.RoundTripper `json:"-"`
 
@@ -227,6 +229,7 @@ func (h *Target) send(ctx context.Context, payload []byte, payloadCount int, pay
 			if xnet.IsNetworkOrHostDown(err, false) {
 				h.status.Store(statusOffline)
 			}
+			h.failedMessages.Add(int64(payloadCount))
 		} else {
 			h.status.Store(statusOnline)
 		}
@@ -257,7 +260,6 @@ func (h *Target) send(ctx context.Context, payload []byte, payloadCount int, pay
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		h.failedMessages.Add(int64(payloadCount))
 		return fmt.Errorf("%s returned '%w', please check your endpoint configuration", h.Endpoint(), err)
 	}
 
@@ -268,10 +270,8 @@ func (h *Target) send(ctx context.Context, payload []byte, payloadCount int, pay
 		// accepted HTTP status codes.
 		return nil
 	} else if resp.StatusCode == http.StatusForbidden {
-		h.failedMessages.Add(int64(payloadCount))
 		return fmt.Errorf("%s returned '%s', please check if your auth token is correctly set", h.Endpoint(), resp.Status)
 	}
-	h.failedMessages.Add(int64(payloadCount))
 	return fmt.Errorf("%s returned '%s', please check your endpoint configuration", h.Endpoint(), resp.Status)
 }
 
@@ -326,9 +326,6 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 		}
 	}()
 
-	var entry interface{}
-	var ok bool
-	var err error
 	lastBatchProcess := time.Now()
 
 	buf := bytebufferpool.Get()
@@ -343,27 +340,25 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 	globalBuffer := logChBuffers[name]
 	logChLock.Unlock()
 
-	newTicker := time.NewTicker(time.Second)
-	isTick := false
 	var count int
-
 	for {
-		isTick = false
-		select {
-		case _ = <-newTicker.C:
-			isTick = true
-		case entry, _ = <-globalBuffer:
-		case entry, ok = <-h.logCh:
-			if !ok {
+		var (
+			ok    bool
+			entry any
+		)
+
+		if count < h.batchSize {
+			select {
+			case entry, _ = <-globalBuffer:
+			case entry, ok = <-h.logCh:
+				if !ok {
+					return
+				}
+			case <-ctx.Done():
 				return
 			}
-		case <-ctx.Done():
-			return
-		}
 
-		if !isTick {
 			h.totalMessages.Add(1)
-
 			if !isDirQueue {
 				if err := enc.Encode(&entry); err != nil {
 					h.config.LogOnceIf(
@@ -374,29 +369,32 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 					h.failedMessages.Add(1)
 					continue
 				}
-				count++
 			} else {
 				entries = append(entries, entry)
-				count++
 			}
-		}
+			count++
 
-		if count != h.batchSize {
-			if len(h.logCh) > 0 || len(globalBuffer) > 0 || count == 0 {
+			if len(h.logCh) > 0 || len(globalBuffer) > 0 {
 				continue
 			}
 
-			if h.batchSize > 1 {
-				// If we are doing batching, we should wait
-				// at least one second before sending.
-				// Even if there is nothing in the queue.
-				if time.Since(lastBatchProcess).Seconds() < 1 {
-					continue
-				}
+			// If we are doing batching, we should wait
+			// at least for a second, before sending.
+			// Even if there is nothing in the queue.
+			if h.batchSize > 1 && time.Since(lastBatchProcess) < time.Second {
+				continue
 			}
-		}
+		} // if we have reached the count send at once or we have crossed last second before batch was processed.
 
 		lastBatchProcess = time.Now()
+
+		var retries int
+		retryIntvl := h.config.RetryIntvl
+		if retryIntvl <= 0 {
+			retryIntvl = 3 * time.Second
+		}
+
+		maxRetries := h.config.MaxRetry
 
 	retry:
 		// If the channel reaches above half capacity
@@ -415,6 +413,7 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 			}
 		}
 
+		var err error
 		if !isDirQueue {
 			err = h.send(ctx, buf.Bytes(), count, h.payloadType, webhookCallTimeout)
 		} else {
@@ -422,18 +421,24 @@ func (h *Target) startQueueProcessor(ctx context.Context, mainWorker bool) {
 		}
 
 		if err != nil {
-			h.config.LogOnceIf(
-				context.Background(),
-				fmt.Errorf("unable to send webhook log entry(s) to '%s' err '%w': %d", name, err, count),
-				name,
-			)
-
 			if errors.Is(err, context.Canceled) {
 				return
 			}
 
-			time.Sleep(3 * time.Second)
-			goto retry
+			h.config.LogOnceIf(
+				context.Background(),
+				fmt.Errorf("unable to send audit/log entry(s) to '%s' err '%w': %d", name, err, count),
+				name,
+			)
+
+			time.Sleep(retryIntvl)
+			if maxRetries == 0 {
+				goto retry
+			}
+			retries++
+			if retries <= maxRetries {
+				goto retry
+			}
 		}
 
 		entries = make([]interface{}, 0)


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Add support for audit/logger max retry and retry interval

## Motivation and Context
The current implementation retries forever until our
log buffer is full, and we start dropping events.

This PR allows you to set a value until we give
up on existing audit/logger batches to proceed to
process the new ones.

Bonus:
 - do not blow up buffers beyond batchSize value
 - do not leak ticker if worker returns

## How to test this PR?
The PR is self-explanatory.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
