### PR TITLE
fix: set audit/logger webhook retry interval to maximum 1m

### DIFF
--- a/internal/logger/config.go
+++ b/internal/logger/config.go
@@ -494,6 +494,9 @@ func lookupLoggerWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 		if err != nil {
 			return cfg, err
 		}
+		if retryInterval > time.Minute {
+			return cfg, fmt.Errorf("maximum allowed value for retry interval is '1m': %s", retryIntervalCfgVal)
+		}
 		cfg.HTTP[k] = http.Config{
 			Enabled:    true,
 			Endpoint:   url,
@@ -570,6 +573,9 @@ func lookupAuditWebhookConfig(scfg config.Config, cfg Config) (Config, error) {
 		retryInterval, err := time.ParseDuration(retryIntervalCfgVal)
 		if err != nil {
 			return cfg, err
+		}
+		if retryInterval > time.Minute {
+			return cfg, fmt.Errorf("maximum allowed value for retry interval is '1m': %s", retryIntervalCfgVal)
 		}
 		cfg.AuditWebhook[k] = http.Config{
 			Enabled:    true,

--- a/internal/logger/help.go
+++ b/internal/logger/help.go
@@ -77,6 +77,18 @@ var (
 			Type:        "string",
 		},
 		config.HelpKV{
+			Key:         MaxRetry,
+			Description: `maximum retry count before we start dropping logged event(s)`,
+			Optional:    true,
+			Type:        "number",
+		},
+		config.HelpKV{
+			Key:         RetryInterval,
+			Description: `sleep between each retries, allowed maximum value is '1m' e.g. '10s'`,
+			Optional:    true,
+			Type:        "duration",
+		},
+		config.HelpKV{
 			Key:         config.Comment,
 			Description: config.DefaultComment,
 			Optional:    true,
@@ -133,13 +145,13 @@ var (
 		},
 		config.HelpKV{
 			Key:         MaxRetry,
-			Description: `maximum retry count before we start dropping upto batch_size events`,
+			Description: `maximum retry count before we start dropping audit event(s)`,
 			Optional:    true,
 			Type:        "number",
 		},
 		config.HelpKV{
 			Key:         RetryInterval,
-			Description: `maximum retry sleeps between each retries`,
+			Description: `sleep between each retries, allowed maximum value is '1m' e.g. '10s'`,
 			Optional:    true,
 			Type:        "duration",
 		},


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
fix: set audit/logger webhook retry interval to maximum 1m

## Motivation and Context
Just keep sane maximums, as we discussed internally.

## How to test this PR?
Following settings would fail

```
mc admin config set alias/ audit_webhook ... retry_interval=2m
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
