### PR TITLE
convert PostPolicy API into a multipart transaction

### DIFF
--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -41,6 +41,7 @@ import (
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/v3/mimedb"
 	"github.com/minio/pkg/v3/sync/errgroup"
+	"github.com/minio/sio"
 )
 
 func (er erasureObjects) getUploadIDDir(bucket, object, uploadID string) string {
@@ -590,19 +591,6 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 		return pi, toObjectErr(err, bucket, object, uploadID)
 	}
 
-	// Write lock for this part ID, only hold it if we are planning to read from the
-	// streamto avoid any concurrent updates.
-	//
-	// Must be held throughout this call.
-	partIDLock := er.NewNSLock(bucket, pathJoin(object, uploadID, strconv.Itoa(partID)))
-	plkctx, err := partIDLock.GetLock(ctx, globalOperationTimeout)
-	if err != nil {
-		return PartInfo{}, err
-	}
-
-	ctx = plkctx.Context()
-	defer partIDLock.Unlock(plkctx)
-
 	onlineDisks := er.getDisks()
 	writeQuorum := fi.WriteQuorum(er.defaultWQuorum())
 
@@ -716,11 +704,26 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 		index = opts.IndexCB()
 	}
 
+	var actualSize int64
+	_, encrypted := crypto.IsEncrypted(fi.Metadata)
+	compressed := fi.IsCompressed()
+	switch {
+	case compressed:
+		actualSize = data.ActualSize()
+	case encrypted:
+		decSize, err := sio.DecryptedSize(uint64(n))
+		if err == nil {
+			actualSize = int64(decSize)
+		}
+	default:
+		actualSize = n
+	}
+
 	partInfo := ObjectPartInfo{
 		Number:     partID,
 		ETag:       md5hex,
 		Size:       n,
-		ActualSize: data.ActualSize(),
+		ActualSize: actualSize,
 		ModTime:    UTCNow(),
 		Index:      index,
 		Checksums:  r.ContentCRC(),
@@ -730,6 +733,19 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	if err != nil {
 		return pi, toObjectErr(err, minioMetaMultipartBucket, partPath)
 	}
+
+	// Write lock for this part ID, only hold it if we are planning to read from the
+	// stream avoid any concurrent updates.
+	//
+	// Must be held throughout this call.
+	partIDLock := er.NewNSLock(bucket, pathJoin(object, uploadID, strconv.Itoa(partID)))
+	plkctx, err := partIDLock.GetLock(ctx, globalOperationTimeout)
+	if err != nil {
+		return PartInfo{}, err
+	}
+
+	ctx = plkctx.Context()
+	defer partIDLock.Unlock(plkctx)
 
 	onlineDisks, err = er.renamePart(ctx, onlineDisks, minioMetaTmpBucket, tmpPartPath, minioMetaMultipartBucket, partPath, partFI, writeQuorum)
 	if err != nil {
@@ -1154,7 +1170,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 	// However, in case of encryption, the persisted part ETags don't match
 	// what we have sent to the client during PutObjectPart. The reason is
 	// that ETags are encrypted. Hence, the client will send a list of complete
-	// part ETags of which non can match the ETag of any part. For example
+	// part ETags of which may not match the ETag of any part. For example
 	//   ETag (client):          30902184f4e62dd8f98f0aaff810c626
 	//   ETag (server-internal): 20000f00ce5dc16e3f3b124f586ae1d88e9caa1c598415c2759bbb50e84a59f630902184f4e62dd8f98f0aaff810c626
 	//

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/tags"
+	"github.com/minio/minio/internal/crypto"
 	"github.com/minio/minio/internal/hash"
 
 	"github.com/minio/minio/internal/bucket/replication"
@@ -133,6 +134,8 @@ type ObjectOptions struct {
 
 	MetadataChg           bool                  // is true if it is a metadata update operation.
 	EvalRetentionBypassFn EvalRetentionBypassFn // only set for enforcing retention bypass on DeleteObject.
+	ObjectEncryptionKey   crypto.ObjectKey      // object encryption key
+	CryptoKind            crypto.Type           // kind of crypto request
 
 	FastGetObjInfo bool // Only for S3 Head/Get Object calls for now
 	NoAuditLog     bool // Only set for decom, rebalance, to avoid double audits.
@@ -279,6 +282,7 @@ type ObjectLayer interface {
 	DeleteObjects(ctx context.Context, bucket string, objects []ObjectToDelete, opts ObjectOptions) ([]DeletedObject, []error)
 	TransitionObject(ctx context.Context, bucket, object string, opts ObjectOptions) error
 	RestoreTransitionedObject(ctx context.Context, bucket, object string, opts ObjectOptions) error
+	PostUploadObject(ctx context.Context, bucket, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error)
 
 	// Multipart operations.
 	ListMultipartUploads(ctx context.Context, bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, err error)


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
convert PostPolicy API into a multipart transaction

## Motivation and Context
recently, we encountered a situation where a client was uploading
over an unreliable connection could potentially hold locks on
the server while the body is yet to be read in a multi-pooled
setup, causing a significant amount of time holding active
locks on the server until we reach an EOF on the body.

Causing cascading occurrences of 499s, and 503s and triggering
various timeouts render server to manage these lengthy locks, 
although this does not incur any significant load, it is a sort 
of a DDOS behavior from an unreliable client.

Bonus: make PutObjectPart() per part, write lock granular, and
only to be held at the renamePart() instead of holding it before 
we read the client stream.

This PR uses multipart's transactional nature and uniqueness 
to avoid lock contention on the same object name() until we 
fully commit the data to the namespace.

Also ends up fixing https://github.com/minio/minio/issues/20319

## How to test this PR?
CI/CD should cover it, but here are the tests.

#### Plain-text test

```
#!/bin/bash

pkill minio
rm -rf /tmp/xl*

minio server /tmp/xl{1...4} &
mc ready myminio
mc mb myminio/testbucket -p

curl -v http://localhost:9000/testbucket/ -F policy=eyJleHBpcmF0aW9uIjoiMjAyNC0wOS0xN1QyMjowNDo1NC4zMDFaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwidGVzdGJ1Y2tldCJdLFsic3RhcnRzLXdpdGgiLCIka2V5IiwicHJlZml4LyJdLFsiZXEiLCIkeC1hbXotZGF0ZSIsIjIwMjQwOTEwVDIyMDQ1NFoiXSxbImVxIiwiJHgtYW16LWFsZ29yaXRobSIsIkFXUzQtSE1BQy1TSEEyNTYiXSxbImVxIiwiJHgtYW16LWNyZWRlbnRpYWwiLCJtaW5pb2FkbWluLzIwMjQwOTEwL3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=minioadmin/20240910/us-east-1/s3/aws4_request -F x-amz-date=20240910T220454Z -F x-amz-signature=3c0be8533b665d94fd7a59f8ac455029f15b447a54aa4bd9d844c24ee926f05c -F bucket=testbucket -F key=prefix/hosts -F file=@/etc/hosts

mc ls myminio/testbucket/prefix/
mc cat myminio/testbucket/prefix/hosts | md5sum
mc stat myminio/testbucket/prefix/hosts
```

#### With SSE-KMS

```
#!/bin/bash

pkill minio
export MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=

rm -rf /tmp/xl*

minio server /tmp/xl{1...4} &
mc ready myminio
mc mb myminio/testbucket -p

mc encrypt set sse-kms my-minio-key myminio/testbucket

mc mb myminio/testbucket -p
curl -v http://localhost:9000/testbucket/ -F policy=eyJleHBpcmF0aW9uIjoiMjAyNC0wOS0xN1QyMjowNDo1NC4zMDFaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwidGVzdGJ1Y2tldCJdLFsic3RhcnRzLXdpdGgiLCIka2V5IiwicHJlZml4LyJdLFsiZXEiLCIkeC1hbXotZGF0ZSIsIjIwMjQwOTEwVDIyMDQ1NFoiXSxbImVxIiwiJHgtYW16LWFsZ29yaXRobSIsIkFXUzQtSE1BQy1TSEEyNTYiXSxbImVxIiwiJHgtYW16LWNyZWRlbnRpYWwiLCJtaW5pb2FkbWluLzIwMjQwOTEwL3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=minioadmin/20240910/us-east-1/s3/aws4_request -F x-amz-date=20240910T220454Z -F x-amz-signature=3c0be8533b665d94fd7a59f8ac455029f15b447a54aa4bd9d844c24ee926f05c -F bucket=testbucket -F key=prefix/hosts -F file=@/etc/hosts

mc ls myminio/testbucket/prefix/
mc cat myminio/testbucket/prefix/hosts | md5sum
mc stat myminio/testbucket/prefix/hosts
```

#### With SSE-S3

```
#!/bin/bash

pkill minio
export MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=

rm -rf /tmp/xl*

minio server /tmp/xl{1...4} &
mc ready myminio
mc mb myminio/testbucket -p

mc encrypt set sse-s3 myminio/testbucket

curl -v http://localhost:9000/testbucket/ -F policy=eyJleHBpcmF0aW9uIjoiMjAyNC0wOS0xN1QyMjowNDo1NC4zMDFaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwidGVzdGJ1Y2tldCJdLFsic3RhcnRzLXdpdGgiLCIka2V5IiwicHJlZml4LyJdLFsiZXEiLCIkeC1hbXotZGF0ZSIsIjIwMjQwOTEwVDIyMDQ1NFoiXSxbImVxIiwiJHgtYW16LWFsZ29yaXRobSIsIkFXUzQtSE1BQy1TSEEyNTYiXSxbImVxIiwiJHgtYW16LWNyZWRlbnRpYWwiLCJtaW5pb2FkbWluLzIwMjQwOTEwL3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=minioadmin/20240910/us-east-1/s3/aws4_request -F x-amz-date=20240910T220454Z -F x-amz-signature=3c0be8533b665d94fd7a59f8ac455029f15b447a54aa4bd9d844c24ee926f05c -F bucket=testbucket -F key=prefix/hosts -F file=@/etc/hosts

mc ls myminio/testbucket/prefix/
mc cat myminio/testbucket/prefix/hosts | md5sum
mc stat myminio/testbucket/prefix/hosts
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
