### PR TITLE
Limit S3 Select JSON documents to 10MB

### DIFF
--- a/internal/s3select/json/reader.go
+++ b/internal/s3select/json/reader.go
@@ -26,6 +26,10 @@ import (
 	"github.com/bcicen/jstream"
 )
 
+// Limit single document size to 10MiB, 10x the AWS limit:
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/selecting-content-from-objects.html
+const maxDocumentSize = 10 << 20
+
 // Reader - JSON record reader for S3Select.
 type Reader struct {
 	args       *ReaderArgs
@@ -80,7 +84,7 @@ func (r *Reader) Close() error {
 // NewReader - creates new JSON reader using readCloser.
 func NewReader(readCloser io.ReadCloser, args *ReaderArgs) *Reader {
 	readCloser = &syncReadCloser{rc: readCloser}
-	d := jstream.NewDecoder(readCloser, 0).ObjectAsKVS()
+	d := jstream.NewDecoder(io.LimitReader(readCloser, maxDocumentSize), 0).ObjectAsKVS()
 	return &Reader{
 		args:       args,
 		decoder:    d,

--- a/internal/s3select/select.go
+++ b/internal/s3select/select.go
@@ -442,6 +442,7 @@ func (s3Select *S3Select) Open(rsc io.ReadSeekCloser) error {
 				s3Select.recordReader = json.NewPReader(s3Select.progressReader, &s3Select.Input.JSONArgs)
 			}
 		} else {
+			// Document mode.
 			s3Select.recordReader = json.NewReader(s3Select.progressReader, &s3Select.Input.JSONArgs)
 		}
 


### PR DESCRIPTION
## Description

Closes #20430

Limit allocations from badly formed documents.

## How to test this PR?

See linked PR

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
