### PR TITLE
Allow creating a delete marker in a suspended prefix

### DIFF
--- a/cmd/batch-expire.go
+++ b/cmd/batch-expire.go
@@ -339,8 +339,8 @@ func (r BatchJobExpire) Notify(ctx context.Context, body io.Reader) error {
 // Expire expires object versions which have already matched supplied filter conditions
 func (r *BatchJobExpire) Expire(ctx context.Context, api ObjectLayer, vc *versioning.Versioning, objsToDel []ObjectToDelete) []error {
 	opts := ObjectOptions{
-		PrefixEnabledFn:  vc.PrefixEnabled,
-		VersionSuspended: vc.Suspended(),
+		PrefixEnabledFn:   vc.PrefixEnabled,
+		PrefixSuspendedFn: vc.PrefixSuspended,
 	}
 
 	allErrs := make([]error, 0, len(objsToDel))

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -532,7 +532,7 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 		opts := ObjectOptions{
 			VersionID:        object.VersionID,
 			Versioned:        vc.PrefixEnabled(object.ObjectName),
-			VersionSuspended: vc.Suspended(),
+			VersionSuspended: vc.PrefixSuspended(object.ObjectName),
 		}
 
 		if replicateDeletes || object.VersionID != "" && hasLockEnabled || !globalTierConfigMgr.Empty() {
@@ -603,8 +603,8 @@ func (api objectAPIHandlers) DeleteMultipleObjectsHandler(w http.ResponseWriter,
 
 	deleteList := toNames(objectsToDelete)
 	dObjects, errs := deleteObjectsFn(ctx, bucket, deleteList, ObjectOptions{
-		PrefixEnabledFn:  vc.PrefixEnabled,
-		VersionSuspended: vc.Suspended(),
+		PrefixEnabledFn:   vc.PrefixEnabled,
+		PrefixSuspendedFn: vc.PrefixSuspended,
 	})
 
 	// Are all objects saying bucket not found?

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1651,6 +1651,9 @@ func (er erasureObjects) DeleteObjects(ctx context.Context, bucket string, objec
 		if objects[i].VersionID == "" {
 			// MinIO extension to bucket version configuration
 			suspended := opts.VersionSuspended
+			if opts.PrefixSuspendedFn != nil {
+				suspended = opts.PrefixSuspendedFn(objects[i].ObjectName)
+			}
 			versioned := opts.Versioned
 			if opts.PrefixEnabledFn != nil {
 				versioned = opts.PrefixEnabledFn(objects[i].ObjectName)

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -117,7 +117,8 @@ type ObjectOptions struct {
 
 	DataMovement bool // indicates an going decommisionning or rebalacing
 
-	PrefixEnabledFn func(prefix string) bool // function which returns true if versioning is enabled on prefix
+	PrefixEnabledFn   func(prefix string) bool // function which returns true if versioning is enabled on prefix
+	PrefixSuspendedFn func(prefix string) bool // function which returns true if versioning is suspended on prefix
 
 	// IndexCB will return any index created but the compression.
 	// Object must have been read at this point.

--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -287,11 +287,7 @@ func delOpts(ctx context.Context, r *http.Request, bucket, object string) (opts 
 
 	opts.DeletePrefix = deletePrefix
 	opts.Versioned = globalBucketVersioningSys.PrefixEnabled(bucket, object)
-	// Objects matching prefixes should not leave delete markers,
-	// dramatically reduces namespace pollution while keeping the
-	// benefits of replication, make sure to apply version suspension
-	// only at bucket level instead.
-	opts.VersionSuspended = globalBucketVersioningSys.Suspended(bucket)
+	opts.VersionSuspended = globalBucketVersioningSys.PrefixSuspended(bucket, object)
 	// For directory objects, delete `null` version permanently.
 	if isDirObject(object) && opts.VersionID == "" {
 		opts.VersionID = nullVersionID

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -387,8 +387,8 @@ func deleteObjectVersions(ctx context.Context, o ObjectLayer, bucket string, toD
 		}
 		vc, _ := globalBucketVersioningSys.Get(bucket)
 		deletedObjs, errs := o.DeleteObjects(ctx, bucket, toDel, ObjectOptions{
-			PrefixEnabledFn:  vc.PrefixEnabled,
-			VersionSuspended: vc.Suspended(),
+			PrefixEnabledFn:   vc.PrefixEnabled,
+			PrefixSuspendedFn: vc.PrefixSuspended,
 		})
 
 		for i, dobj := range deletedObjs {

--- a/docs/bucket/replication/test_del_marker_proxying.sh
+++ b/docs/bucket/replication/test_del_marker_proxying.sh
@@ -65,6 +65,7 @@ while true; do
 	RESULT=$({ ./mc stat sitea/bucket/obj$loop_count; } 2>&1)
 	if [[ ${RESULT} != *"Object does not exist"* ]]; then
 		echo "BUG: stat should fail. succeeded."
+		echo "BUG:   found: |${RESULT}|"
 		exit_1
 	fi
 	loop_count=$((loop_count + 1))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fix delete marker creation when only a prefix is supended.

Both DeleteObject and DeleteObjects handlers are affected here

## Motivation and Context


## How to test this PR?
Create a versioned bucket then,
```
mc mb myminio/testbucket --with-versioning
mc cp go.mod myminio/testbucket/
mc version enable myminio/testbucket --excluded-prefixes "*"
mc rm myminio/testbucket/go.mod
mc rm myminio/testbucket/go.mod
```
go.mod is still visible

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
