### PR TITLE
Ensure proper `stale_uploads_cleanup_interval` is used at all times

### DIFF
--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -86,6 +86,8 @@ type erasureSets struct {
 	lastConnectDisksOpTime time.Time
 }
 
+var staleUploadsCleanupIntervalChangedCh = make(chan bool)
+
 func (s *erasureSets) getDiskMap() map[Endpoint]StorageAPI {
 	diskMap := make(map[Endpoint]StorageAPI)
 
@@ -532,10 +534,11 @@ func (s *erasureSets) cleanupStaleUploads(ctx context.Context) {
 				}(set)
 			}
 			wg.Wait()
-
-			// Reset for the next interval
-			timer.Reset(globalAPIConfig.getStaleUploadsCleanupInterval())
+		case <-staleUploadsCleanupIntervalChangedCh:
 		}
+
+		// Reset for the next interval
+		timer.Reset(globalAPIConfig.getStaleUploadsCleanupInterval())
 	}
 }
 

--- a/cmd/erasure-sets.go
+++ b/cmd/erasure-sets.go
@@ -86,7 +86,7 @@ type erasureSets struct {
 	lastConnectDisksOpTime time.Time
 }
 
-var staleUploadsCleanupIntervalChangedCh = make(chan bool)
+var staleUploadsCleanupIntervalChangedCh = make(chan struct{})
 
 func (s *erasureSets) getDiskMap() map[Endpoint]StorageAPI {
 	diskMap := make(map[Endpoint]StorageAPI)

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -194,8 +194,9 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int, legacy bool) {
 		t.staleUploadsCleanupInterval = cfg.StaleUploadsCleanupInterval
 
 		// signal that cleanup interval has changed
-		if staleUploadsCleanupIntervalChangedCh != nil {
-			staleUploadsCleanupIntervalChangedCh <- struct{}{}
+		select {
+		case staleUploadsCleanupIntervalChangedCh <- struct{}{}:
+		default: // in case the channel is blocked...
 		}
 	}
 }

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -183,13 +183,21 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int, legacy bool) {
 	t.transitionWorkers = cfg.TransitionWorkers
 
 	t.staleUploadsExpiry = cfg.StaleUploadsExpiry
-	t.staleUploadsCleanupInterval = cfg.StaleUploadsCleanupInterval
 	t.deleteCleanupInterval = cfg.DeleteCleanupInterval
 	t.enableODirect = cfg.EnableODirect
 	t.gzipObjects = cfg.GzipObjects
 	t.rootAccess = cfg.RootAccess
 	t.syncEvents = cfg.SyncEvents
 	t.objectMaxVersions = cfg.ObjectMaxVersions
+
+	if t.staleUploadsCleanupInterval != cfg.StaleUploadsCleanupInterval {
+		t.staleUploadsCleanupInterval = cfg.StaleUploadsCleanupInterval
+
+		// signal that cleanup interval has changed
+		if staleUploadsCleanupIntervalChangedCh != nil {
+			staleUploadsCleanupIntervalChangedCh <- true
+		}
+	}
 }
 
 func (t *apiConfig) odirectEnabled() bool {

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -195,7 +195,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int, legacy bool) {
 
 		// signal that cleanup interval has changed
 		if staleUploadsCleanupIntervalChangedCh != nil {
-			staleUploadsCleanupIntervalChangedCh <- true
+			staleUploadsCleanupIntervalChangedCh <- struct{}{}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #20450 by resetting the interval when the `stale_uploads_cleanup_interval` is set.