### PR TITLE
Log an error when calculating the binary checksum failed

### DIFF
--- a/cmd/bootstrap-peer-server.go
+++ b/cmd/bootstrap-peer-server.go
@@ -184,10 +184,13 @@ var binaryChecksum = getBinaryChecksum()
 func getBinaryChecksum() string {
 	mw := md5.New()
 	b, err := os.Open(os.Args[0])
-	if err == nil {
-		defer b.Close()
-		io.Copy(mw, b)
+	if err != nil {
+		logger.Error("Calculating checksum failed: %s", err)
+		return "00000000000000000000000000000000"
 	}
+
+	defer b.Close()
+	io.Copy(mw, b)
 	return hex.EncodeToString(mw.Sum(nil))
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
There are cases where the checksum `d41d8cd98f00b204e9800998ecf8427e` is returned. This is the MD5 hash of an empty file, but that's not obvious. This PR will return checksum `00000000000000000000000000000000` that is more obvious an error and will log the actual error.

## Motivation and Context
A MinIO installation reported that there was a checksum difference between some nodes, where it reported `d41d8cd98f00b204e9800998ecf8427e` that was probably caused that the binary file couldn't be opened.

## How to test this PR?
Build MinIO (using `go build .`), change the mode to 111 (`chmod 111 minio`) and then run `./minio server /tmp/minio1 --address ":9000"` and it should report `ERRO: Calculating checksum failed: open ./minio: permission denied`.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)