### PR TITLE
Fix PutObject Trailing checksum

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1960,6 +1960,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	opts.IndexCB = idxCb
+	opts.WantChecksum = hashReader.Checksum()
 
 	if opts.PreserveETag != "" ||
 		r.Header.Get(xhttp.IfMatch) != "" ||

--- a/internal/hash/checksum.go
+++ b/internal/hash/checksum.go
@@ -335,6 +335,10 @@ func (c *Checksum) AppendTo(b []byte, parts []byte) []byte {
 	var tmp [binary.MaxVarintLen32]byte
 	n := binary.PutUvarint(tmp[:], uint64(c.Type))
 	crc := c.Raw
+	if c.Type.Trailing() {
+		// When we serialize we don't care if it was trailing.
+		c.Type ^= ChecksumTrailing
+	}
 	if len(crc) != c.Type.RawByteLen() {
 		return b
 	}

--- a/internal/hash/reader.go
+++ b/internal/hash/reader.go
@@ -366,6 +366,14 @@ func (r *Reader) ContentCRC() map[string]string {
 	return map[string]string{r.contentHash.Type.String(): r.contentHash.Encoded}
 }
 
+// Checksum returns the content checksum if set.
+func (r *Reader) Checksum() *Checksum {
+	if !r.contentHash.Type.IsSet() || !r.contentHash.Valid() {
+		return nil
+	}
+	return &r.contentHash
+}
+
 var _ io.Closer = (*Reader)(nil) // compiler check
 
 // Close and release resources.


### PR DESCRIPTION
## Description

PutObject would verify trailing checksums, but not store them.

Fixes #20455

## How to test this PR?

I have added it to minio-go as functional test, but it will need a bit of cleanup. Will send PR with reference when done.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
