### PR TITLE
Fix ILM expire workers exiting

### DIFF
--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -352,7 +352,7 @@ func (es *expiryState) Worker(input <-chan expiryOp) {
 				traceFn := globalLifecycleSys.trace(oi)
 				if !oi.TransitionedObject.FreeVersion {
 					// nothing to be done
-					return
+					continue
 				}
 
 				ignoreNotFoundErr := func(err error) error {
@@ -367,7 +367,7 @@ func (es *expiryState) Worker(input <-chan expiryOp) {
 				if ignoreNotFoundErr(err) != nil {
 					transitionLogIf(es.ctx, err)
 					traceFn(ILMFreeVersionDelete, nil, err)
-					return
+					continue
 				}
 
 				// Remove this free version


### PR DESCRIPTION
## Description

Under 2 conditions ILM expire workers would exit, eventually causing all workers to terminate.

## How to test this PR?

This requires either changing the object, or having the remote call fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
