### PR TITLE
Allow healing tiered data at EcN=EcM and EcM lost shards

### DIFF
--- a/cmd/erasure-healing-common.go
+++ b/cmd/erasure-healing-common.go
@@ -442,7 +442,7 @@ func disksWithAllParts(ctx context.Context, onlineDisks []StorageAPI, partsMetad
 	}
 
 	for i, onlineDisk := range onlineDisks {
-		if metaErrs[i] == nil && !hasPartErr(dataErrsByDisk[i]) {
+		if metaErrs[i] == nil && (!hasPartErr(dataErrsByDisk[i]) || partsMetadata[i].IsRemote() || partsMetadata[i].Deleted) {
 			// All parts verified, mark it as all data available.
 			availableDisks[i] = onlineDisk
 		} else {

--- a/cmd/erasure-metadata.go
+++ b/cmd/erasure-metadata.go
@@ -514,8 +514,10 @@ func listObjectParities(partsMetadata []FileInfo, errs []error) (parities []int)
 		if metadata.Deleted || metadata.Size == 0 {
 			parities[index] = totalShards / 2
 		} else if metadata.TransitionStatus == lifecycle.TransitionComplete {
-			// For tiered objects, read quorum is N/2+1 to ensure simple majority on xl.meta. It is not equal to EcM because the data integrity is entrusted with the warm tier.
-			parities[index] = totalShards - (totalShards/2 + 1)
+			// For tiered objects, read quorum is N/2+1 to ensure simple majority on xl.meta.
+			// It is not equal to EcM because the data integrity is entrusted with the warm tier.
+			// However, we never go below EcM, in case of a EcM=EcN setup.
+			parities[index] = max(totalShards-(totalShards/2+1), metadata.Erasure.ParityBlocks)
 		} else {
 			parities[index] = metadata.Erasure.ParityBlocks
 		}


### PR DESCRIPTION
## Description

Tiered objects requires >50% majority to heal, but in cases where EcN=EcM=lost shard count, this is actually more strict than read quorum.

Don't set parity to less than EcM.

It also seems like part "errors" weren't ignored on tiered objects. So we ignore part errors on tiered objects (and delete markers as bonus).

Fixes #20559

## How to test this PR?

Tested on 4 drive setup, deleting up to 2 shards.

Output from `mc admin heal -r -json ...`

```
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx21","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":215040}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx22","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":225280}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx23","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":235520}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx24","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":245760}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx25","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":256000}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx26","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":266240}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx27","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":276480}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx28","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":286720}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx29","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":296960}
{"status":"success","type":"object","name":"testbucket/adir/testfile_241028_idx30","before":{"color":"red","offline":0,"online":2,"missing":2,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"missing"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"after":{"color":"green","offline":0,"online":4,"missing":0,"corrupted":0,"drives":[{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d1","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d2","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d3","state":"ok"},{"uuid":"","endpoint":"https://127.0.0.1:9001/data/distxl/s1/d4","state":"ok"}]},"size":307200}
{"status":"success","type":"summary","objects_scanned":10,"objects_healed":10,"items_scanned":11,"items_healed":10,"size":2611200,"duration":1}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
