### PR TITLE
Remove `expires` field from list objects metadata

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -593,9 +593,6 @@ func generateListVersionsResponse(ctx context.Context, bucket, prefix, marker, v
 			for k, v := range cleanReservedKeys(object.UserDefined) {
 				content.UserMetadata.Set(k, v)
 			}
-			if !object.Expires.IsZero() {
-				content.UserMetadata.Set("expires", object.Expires.Format(http.TimeFormat))
-			}
 			content.Internal = &ObjectInternalInfo{
 				K: object.DataBlocks,
 				M: object.ParityBlocks,
@@ -729,9 +726,6 @@ func generateListObjectsV2Response(ctx context.Context, bucket, prefix, token, n
 				}
 				for k, v := range cleanReservedKeys(object.UserDefined) {
 					content.UserMetadata.Set(k, v)
-				}
-				if !object.Expires.IsZero() {
-					content.UserMetadata.Set("expires", object.Expires.Format(http.TimeFormat))
 				}
 				content.Internal = &ObjectInternalInfo{
 					K: object.DataBlocks,


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This field was always 0 regardless of whether the object had an expiry so we are basically removing dead code.

## Motivation and Context

If was found that the fix in #20584 is actually not right because the expires value is never non-zero in list-objects-with-metadata call. The right fix is to remove this dead code.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
