### PR TITLE
Add the policy name to the audit logs tags when doing policy-based API calls. Add retention settings to tags

### DIFF
--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1809,6 +1809,10 @@ func (api objectAPIHandlers) PutBucketObjectLockConfigHandler(w http.ResponseWri
 		return
 	}
 
+	// Audit log tags.
+	reqInfo := logger.GetReqInfo(ctx)
+	reqInfo.SetTags("retention", config.String())
+
 	configData, err := xml.Marshal(config)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2899,6 +2899,8 @@ func (api objectAPIHandlers) PutObjectRetentionHandler(w http.ResponseWriter, r 
 		writeErrorResponse(ctx, w, apiErr, r.URL)
 		return
 	}
+	reqInfo := logger.GetReqInfo(ctx)
+	reqInfo.SetTags("retention", objRetention.String())
 
 	opts, err := getOpts(ctx, r, bucket, object)
 	if err != nil {

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -368,6 +368,10 @@ type ObjectRetention struct {
 	RetainUntilDate RetentionDate `xml:"RetainUntilDate,omitempty"`
 }
 
+func (o ObjectRetention) String() string {
+	return fmt.Sprintf("Mode: %s, RetainUntilDate: %s", o.Mode, o.RetainUntilDate.Time)
+}
+
 // Maximum 4KiB size per object retention config.
 const maxObjectRetentionSize = 1 << 12
 

--- a/internal/bucket/object/lock/lock.go
+++ b/internal/bucket/object/lock/lock.go
@@ -237,6 +237,25 @@ type Config struct {
 	} `xml:"Rule,omitempty"`
 }
 
+// String returns the human readable format of object lock configuration, used in audit logs.
+func (config Config) String() string {
+	parts := []string{
+		fmt.Sprintf("Enabled: %v", config.Enabled()),
+	}
+	if config.Rule != nil {
+		if config.Rule.DefaultRetention.Mode != "" {
+			parts = append(parts, fmt.Sprintf("Mode: %s", config.Rule.DefaultRetention.Mode))
+		}
+		if config.Rule.DefaultRetention.Days != nil {
+			parts = append(parts, fmt.Sprintf("Days: %d", *config.Rule.DefaultRetention.Days))
+		}
+		if config.Rule.DefaultRetention.Years != nil {
+			parts = append(parts, fmt.Sprintf("Years: %d", *config.Rule.DefaultRetention.Years))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
 // Enabled returns true if config.ObjectLockEnabled is set to Enabled
 func (config *Config) Enabled() bool {
 	return config.ObjectLockEnabled == Enabled

--- a/internal/bucket/object/lock/lock_test.go
+++ b/internal/bucket/object/lock/lock_test.go
@@ -611,3 +611,72 @@ func TestFilterObjectLockMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestToString(t *testing.T) {
+	days := uint64(30)
+	daysPtr := &days
+	years := uint64(2)
+	yearsPtr := &years
+
+	tests := []struct {
+		name string
+		c    Config
+		want string
+	}{
+		{
+			name: "happy case",
+			c: Config{
+				ObjectLockEnabled: "Enabled",
+			},
+			want: "Enabled: true",
+		},
+		{
+			name: "with default retention days",
+			c: Config{
+				ObjectLockEnabled: "Enabled",
+				Rule: &struct {
+					DefaultRetention DefaultRetention `xml:"DefaultRetention"`
+				}{
+					DefaultRetention: DefaultRetention{
+						Mode: RetGovernance,
+						Days: daysPtr,
+					},
+				},
+			},
+			want: "Enabled: true, Mode: GOVERNANCE, Days: 30",
+		},
+		{
+			name: "with default retention years",
+			c: Config{
+				ObjectLockEnabled: "Enabled",
+				Rule: &struct {
+					DefaultRetention DefaultRetention `xml:"DefaultRetention"`
+				}{
+					DefaultRetention: DefaultRetention{
+						Mode:  RetCompliance,
+						Years: yearsPtr,
+					},
+				},
+			},
+			want: "Enabled: true, Mode: COMPLIANCE, Years: 2",
+		},
+		{
+			name: "disabled case",
+			c: Config{
+				ObjectLockEnabled: "Disabled",
+			},
+			want: "Enabled: false",
+		},
+		{
+			name: "empty case",
+			c:    Config{},
+			want: "Enabled: false",
+		},
+	}
+	for _, tt := range tests {
+		got := tt.c.String()
+		if got != tt.want {
+			t.Errorf("test: %s, got: '%v', want: '%v'", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Based on customer request in subnet ticket 12167, two things:

- When creating audit logs for API calls that deal with policies, audit logs should include the policy name(s).
- When setting retention on a bucket, the days/years should be in the audit log too.

This PR creates audit JSON like this: 

SetPolicyForUserOrGroup 
`"tags":{"policyName":"consoleAdmin,readwrite"...`

When multiple policies are handled, it just presents them as a CSV list under the same tag "policyName".

And for retention API call:

`"retention":"Enabled: true, Mode: GOVERNANCE, Days: 1, Years: 0"}`


## Motivation and Context

customer request

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
