### PR TITLE
heal/batch: Fix missing redirection to the first node

### DIFF
--- a/cmd/bucket-listobjects-handlers.go
+++ b/cmd/bucket-listobjects-handlers.go
@@ -245,7 +245,7 @@ func parseRequestToken(token string) (subToken string, nodeIndex int) {
 
 func proxyRequestByToken(ctx context.Context, w http.ResponseWriter, r *http.Request, token string) (string, bool) {
 	subToken, nodeIndex := parseRequestToken(token)
-	if nodeIndex > 0 {
+	if nodeIndex >= 0 {
 		return subToken, proxyRequestByNodeIndex(ctx, w, r, nodeIndex)
 	}
 	return subToken, false


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Manual heal can return XMinioHealInvalidClientToken if the manual healing is started in the first node and the next mc call to get the heal status is landed in another node. The reason is that redirection based on the token id is not able to redirect requests to the first node due to a typo in the code.

This also affects batch cancel command, if the batch is being done in the first node, the user will never be able to cancel it due to the same bug.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
