### PR TITLE
Fixes api label casing and count value for +Inf bucket of prometheus MetricV2 histograms

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1881,7 +1881,7 @@ func getHistogramMetrics(hist *prometheus.HistogramVec, desc MetricDescription, 
 		metrics = append(metrics, MetricV2{
 			Description:    desc,
 			VariableLabels: labels1,
-			Value:          dtoMetric.Counter.GetValue(),
+			Value:          float64(dtoMetric.Histogram.GetSampleCount()),
 		})
 	}
 	return metrics

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1875,7 +1875,11 @@ func getHistogramMetrics(hist *prometheus.HistogramVec, desc MetricDescription, 
 		// add metrics with +Inf label
 		labels1 := make(map[string]string)
 		for _, lp := range dtoMetric.GetLabel() {
-			labels1[*lp.Name] = *lp.Value
+			if *lp.Name == "api" && toLowerAPILabels {
+				labels1[*lp.Name] = strings.ToLower(*lp.Value)
+			} else {
+				labels1[*lp.Name] = *lp.Value
+			}
 		}
 		labels1["le"] = fmt.Sprintf("%.3f", math.Inf(+1))
 		metrics = append(metrics, MetricV2{

--- a/cmd/metrics-v2_test.go
+++ b/cmd/metrics-v2_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestGetHistogramMetrics(t *testing.T) {
+func TestGetHistogramMetrics_BucketCount(t *testing.T) {
 	histBuckets := []float64{0.05, 0.1, 0.25, 0.5, 0.75}
 	labels := []string{"GetObject", "PutObject", "CopyObject", "CompleteMultipartUpload"}
 	ttfbHist := prometheus.NewHistogramVec(
@@ -85,10 +85,66 @@ func TestGetHistogramMetrics(t *testing.T) {
 	metrics := getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), false)
 	// additional labels for +Inf for all histogram metrics
 	if expPoints := len(labels) * (len(histBuckets) + 1); expPoints != len(metrics) {
-		t.Fatalf("Expected %v data points but got %v", expPoints, len(metrics))
+		t.Fatalf("Expected %v data points when toLowerAPILabels=false but got %v", expPoints, len(metrics))
+	}
+
+	metrics = getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), true)
+	// additional labels for +Inf for all histogram metrics
+	if expPoints := len(labels) * (len(histBuckets) + 1); expPoints != len(metrics) {
+		t.Fatalf("Expected %v data points when toLowerAPILabels=true but got %v", expPoints, len(metrics))
+	}
+}
+
+func TestGetHistogramMetrics_Values(t *testing.T) {
+	histBuckets := []float64{0.50, 5.00}
+	labels := []string{"PutObject", "CopyObject"}
+	ttfbHist := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "s3_ttfb_seconds",
+			Help:    "Time taken by requests served by current MinIO server instance",
+			Buckets: histBuckets,
+		},
+		[]string{"api"},
+	)
+	observations := []struct {
+		val   float64
+		label string
+	}{
+		{
+			val:   0.02,
+			label: labels[0],
+		},
+		{
+			val:   0.19,
+			label: labels[1],
+		},
+		{
+			val:   0.31,
+			label: labels[1],
+		},
+		{
+			val:   0.61,
+			label: labels[0],
+		},
+		{
+			val:   6.79,
+			label: labels[1],
+		},
+	}
+	ticker := time.NewTicker(1 * time.Millisecond)
+	defer ticker.Stop()
+	for _, obs := range observations {
+		// Send observations once every 1ms, to simulate delay between
+		// observations. This is to test the channel based
+		// synchronization used internally.
+		select {
+		case <-ticker.C:
+			ttfbHist.With(prometheus.Labels{"api": obs.label}).Observe(obs.val)
+		}
 	}
 
 	// Accumulate regular-cased API label metrics for 'PutObject' for deeper verification
+	metrics := getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), false)
 	capitalPutObjects := make([]MetricV2, 0, len(histBuckets)+1)
 	for _, metric := range metrics {
 		if value := metric.VariableLabels["api"]; value == "PutObject" {
@@ -105,55 +161,59 @@ func TestGetHistogramMetrics(t *testing.T) {
 		le2 := a.VariableLabels["le"]
 		return strings.Compare(le1, le2)
 	})
-	if le := capitalPutObjects[0].VariableLabels["le"]; le != "0.050" {
+	if le := capitalPutObjects[0].VariableLabels["le"]; le != "0.500" {
 		t.Errorf("Expected le='0.050' api=PutObject metrics but got '%v'", le)
 	}
-	if value := capitalPutObjects[0].Value; value != 0 {
-		t.Errorf("Expected le='0.050' api=PutObject value to be 0 but got '%v'", value)
+	if value := capitalPutObjects[0].Value; value != 1 {
+		t.Errorf("Expected le='0.050' api=PutObject value to be 1 but got '%v'", value)
 	}
-	if le := capitalPutObjects[1].VariableLabels["le"]; le != "0.100" {
-		t.Errorf("Expected le='0.100' api=PutObject metrics but got '%v'", le)
+	if le := capitalPutObjects[1].VariableLabels["le"]; le != "5.000" {
+		t.Errorf("Expected le='5.000' api=PutObject metrics but got '%v'", le)
 	}
-	if value := capitalPutObjects[1].Value; value != 1 {
-		t.Errorf("Expected le='0.100' api=PutObject value to be 1 but got '%v'", value)
+	if value := capitalPutObjects[1].Value; value != 2 {
+		t.Errorf("Expected le='5.000' api=PutObject value to be 2 but got '%v'", value)
 	}
-	if le := capitalPutObjects[2].VariableLabels["le"]; le != "0.250" {
-		t.Errorf("Expected le='0.250' api=PutObject metrics but got '%v'", le)
-	}
-	if value := capitalPutObjects[2].Value; value != 3 {
-		t.Errorf("Expected le='0.250' api=PutObject value to be 3 but got '%v'", value)
-	}
-	if le := capitalPutObjects[3].VariableLabels["le"]; le != "0.500" {
-		t.Errorf("Expected le='0.500' api=PutObject metrics but got '%v'", le)
-	}
-	if value := capitalPutObjects[3].Value; value != 4 {
-		t.Errorf("Expected le='0.500' api=PutObject value to be 4 but got '%v'", value)
-	}
-	if le := capitalPutObjects[4].VariableLabels["le"]; le != "0.750" {
-		t.Errorf("Expected le='0.750' api=PutObject metrics but got '%v'", le)
-	}
-	if value := capitalPutObjects[4].Value; value != 4 {
-		t.Errorf("Expected le='0.750' api=PutObject value to be 4 but got '%v'", value)
-	}
-	if le := capitalPutObjects[5].VariableLabels["le"]; le != "+Inf" {
+	if le := capitalPutObjects[2].VariableLabels["le"]; le != "+Inf" {
 		t.Errorf("Expected le='+Inf' api=PutObject metrics but got '%v'", le)
 	}
-	if value := capitalPutObjects[5].Value; value != 4 {
-		t.Errorf("Expected le='+Inf' api=PutObject value to be 4 but got '%v'", value)
+	if value := capitalPutObjects[2].Value; value != 2 {
+		t.Errorf("Expected le='+Inf' api=PutObject value to be 2 but got '%v'", value)
 	}
-	//expectedLabels := []
-	for _, m := range capitalPutObjects {
-		t.Logf("Capital: %+v", m)
-	}
-	//labelNames := slices.Collect(maps.Values(actualLabelNames))
-	//labelValues := slices.Collect(maps.Keys(actualLabelValues))
-	//t.Logf("Label names: %s", labelNames)
-	//t.Logf("Label vals:  %s", labelValues)
 
+	// Accumulate lower-cased API label metrics for 'copyobject' for deeper verification
 	metrics = getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), true)
-	t.Logf("Metrics: %+v", metrics)
-	// additional labels for +Inf for all histogram metrics
-	if expPoints := len(labels) * (len(histBuckets) + 1); expPoints != len(metrics) {
-		t.Fatalf("Expected %v data points but got %v", expPoints, len(metrics))
+	lowerCopyObjects := make([]MetricV2, 0, len(histBuckets)+1)
+	for _, metric := range metrics {
+		if value := metric.VariableLabels["api"]; value == "copyobject" {
+			lowerCopyObjects = append(lowerCopyObjects, metric)
+		}
+	}
+	if expMetricsPerApi := len(histBuckets) + 1; expMetricsPerApi != len(lowerCopyObjects) {
+		t.Fatalf("Expected %d api=copyobject metrics but got %d", expMetricsPerApi, len(lowerCopyObjects))
+	}
+
+	// Deterministic ordering
+	slices.SortFunc(lowerCopyObjects, func(a MetricV2, b MetricV2) int {
+		le1 := a.VariableLabels["le"]
+		le2 := a.VariableLabels["le"]
+		return strings.Compare(le1, le2)
+	})
+	if le := lowerCopyObjects[0].VariableLabels["le"]; le != "0.500" {
+		t.Errorf("Expected le='0.050' api=copyobject metrics but got '%v'", le)
+	}
+	if value := lowerCopyObjects[0].Value; value != 2 {
+		t.Errorf("Expected le='0.050' api=copyobject value to be 2 but got '%v'", value)
+	}
+	if le := lowerCopyObjects[1].VariableLabels["le"]; le != "5.000" {
+		t.Errorf("Expected le='5.000' api=copyobject metrics but got '%v'", le)
+	}
+	if value := lowerCopyObjects[1].Value; value != 2 {
+		t.Errorf("Expected le='5.000' api=copyobject value to be 2 but got '%v'", value)
+	}
+	if le := lowerCopyObjects[2].VariableLabels["le"]; le != "+Inf" {
+		t.Errorf("Expected le='+Inf' api=copyobject metrics but got '%v'", le)
+	}
+	if value := lowerCopyObjects[2].Value; value != 3 {
+		t.Errorf("Expected le='+Inf' api=copyobject value to be 3 but got '%v'", value)
 	}
 }

--- a/cmd/metrics-v2_test.go
+++ b/cmd/metrics-v2_test.go
@@ -151,8 +151,8 @@ func TestGetHistogramMetrics_Values(t *testing.T) {
 			capitalPutObjects = append(capitalPutObjects, metric)
 		}
 	}
-	if expMetricsPerApi := len(histBuckets) + 1; expMetricsPerApi != len(capitalPutObjects) {
-		t.Fatalf("Expected %d api=PutObject metrics but got %d", expMetricsPerApi, len(capitalPutObjects))
+	if expMetricsPerAPI := len(histBuckets) + 1; expMetricsPerAPI != len(capitalPutObjects) {
+		t.Fatalf("Expected %d api=PutObject metrics but got %d", expMetricsPerAPI, len(capitalPutObjects))
 	}
 
 	// Deterministic ordering
@@ -188,8 +188,8 @@ func TestGetHistogramMetrics_Values(t *testing.T) {
 			lowerCopyObjects = append(lowerCopyObjects, metric)
 		}
 	}
-	if expMetricsPerApi := len(histBuckets) + 1; expMetricsPerApi != len(lowerCopyObjects) {
-		t.Fatalf("Expected %d api=copyobject metrics but got %d", expMetricsPerApi, len(lowerCopyObjects))
+	if expMetricsPerAPI := len(histBuckets) + 1; expMetricsPerAPI != len(lowerCopyObjects) {
+		t.Fatalf("Expected %d api=copyobject metrics but got %d", expMetricsPerAPI, len(lowerCopyObjects))
 	}
 
 	// Deterministic ordering

--- a/cmd/metrics-v2_test.go
+++ b/cmd/metrics-v2_test.go
@@ -18,6 +18,8 @@
 package cmd
 
 import (
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,6 +83,75 @@ func TestGetHistogramMetrics(t *testing.T) {
 	}
 
 	metrics := getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), false)
+	// additional labels for +Inf for all histogram metrics
+	if expPoints := len(labels) * (len(histBuckets) + 1); expPoints != len(metrics) {
+		t.Fatalf("Expected %v data points but got %v", expPoints, len(metrics))
+	}
+
+	// Accumulate regular-cased API label metrics for 'PutObject' for deeper verification
+	capitalPutObjects := make([]MetricV2, 0, len(histBuckets)+1)
+	for _, metric := range metrics {
+		if value := metric.VariableLabels["api"]; value == "PutObject" {
+			capitalPutObjects = append(capitalPutObjects, metric)
+		}
+	}
+	if expMetricsPerApi := len(histBuckets) + 1; expMetricsPerApi != len(capitalPutObjects) {
+		t.Fatalf("Expected %d api=PutObject metrics but got %d", expMetricsPerApi, len(capitalPutObjects))
+	}
+
+	// Deterministic ordering
+	slices.SortFunc(capitalPutObjects, func(a MetricV2, b MetricV2) int {
+		le1 := a.VariableLabels["le"]
+		le2 := a.VariableLabels["le"]
+		return strings.Compare(le1, le2)
+	})
+	if le := capitalPutObjects[0].VariableLabels["le"]; le != "0.050" {
+		t.Errorf("Expected le='0.050' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[0].Value; value != 0 {
+		t.Errorf("Expected le='0.050' api=PutObject value to be 0 but got '%v'", value)
+	}
+	if le := capitalPutObjects[1].VariableLabels["le"]; le != "0.100" {
+		t.Errorf("Expected le='0.100' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[1].Value; value != 1 {
+		t.Errorf("Expected le='0.100' api=PutObject value to be 1 but got '%v'", value)
+	}
+	if le := capitalPutObjects[2].VariableLabels["le"]; le != "0.250" {
+		t.Errorf("Expected le='0.250' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[2].Value; value != 3 {
+		t.Errorf("Expected le='0.250' api=PutObject value to be 3 but got '%v'", value)
+	}
+	if le := capitalPutObjects[3].VariableLabels["le"]; le != "0.500" {
+		t.Errorf("Expected le='0.500' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[3].Value; value != 4 {
+		t.Errorf("Expected le='0.500' api=PutObject value to be 4 but got '%v'", value)
+	}
+	if le := capitalPutObjects[4].VariableLabels["le"]; le != "0.750" {
+		t.Errorf("Expected le='0.750' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[4].Value; value != 4 {
+		t.Errorf("Expected le='0.750' api=PutObject value to be 4 but got '%v'", value)
+	}
+	if le := capitalPutObjects[5].VariableLabels["le"]; le != "+Inf" {
+		t.Errorf("Expected le='+Inf' api=PutObject metrics but got '%v'", le)
+	}
+	if value := capitalPutObjects[5].Value; value != 4 {
+		t.Errorf("Expected le='+Inf' api=PutObject value to be 4 but got '%v'", value)
+	}
+	//expectedLabels := []
+	for _, m := range capitalPutObjects {
+		t.Logf("Capital: %+v", m)
+	}
+	//labelNames := slices.Collect(maps.Values(actualLabelNames))
+	//labelValues := slices.Collect(maps.Keys(actualLabelValues))
+	//t.Logf("Label names: %s", labelNames)
+	//t.Logf("Label vals:  %s", labelValues)
+
+	metrics = getHistogramMetrics(ttfbHist, getBucketTTFBDistributionMD(), true)
+	t.Logf("Metrics: %+v", metrics)
 	// additional labels for +Inf for all histogram metrics
 	if expPoints := len(labels) * (len(histBuckets) + 1); expPoints != len(metrics) {
 		t.Fatalf("Expected %v data points but got %v", expPoints, len(metrics))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Addresses two issues with MetricV2 histograms
1.) Fixes casing of the `api` label for the `le='+Inf'` bucket, based on the `toLowerAPILabels` argument

2.) Fixes a separate issue uncovered while writing unit tests where the value of the `+Inf` bucket was always zero instead of the total count.

## Motivation and Context
Correcting these issues should fix an issue that prevented usage of the prometheus `histogram_quantile()` function on minio bucket histograms.

Further detail available in issue [#20655](https://github.com/minio/minio/issues/20655)

## How to test this PR?
* New unit tests were added for verifying `+Inf` bucket value and `api` labels.
* Locally verified from a development build in my existing environment that originally observed the issue:


```
$ curl -H 'Authorization: Bearer ...' -v http://localhost:9000/minio/v2/metrics/bucket
...
# HELP minio_bucket_requests_ttfb_seconds_distribution Distribution of time to first byte across API calls per bucket
# TYPE minio_bucket_requests_ttfb_seconds_distribution gauge
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="+Inf",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="0.050",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="0.100",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="0.250",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="0.500",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="1.000",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="10.000",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="2.500",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="completemultipartupload",bucket="grafana-tempo-traces",le="5.000",server="127.0.0.1:9000"} 1
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="+Inf",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="0.050",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="0.100",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="0.250",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="0.500",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="1.000",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="10.000",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="2.500",server="127.0.0.1:9000"} 2
minio_bucket_requests_ttfb_seconds_distribution{api="copyobject",bucket="grafana-tempo-traces",le="5.000",server="127.0.0.1:9000"} 2
...
```

Two `histogram_quantile()`-based charts in grafana began working after deploying the development build:
![image](https://github.com/user-attachments/assets/7dd0362e-8006-4382-a614-febde78f53ab)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression: described in issue [#20655](https://github.com/minio/minio/issues/20655)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
