### PR TITLE
Fix prefix validation in lifecycle rule

### DIFF
--- a/internal/bucket/lifecycle/rule.go
+++ b/internal/bucket/lifecycle/rule.go
@@ -86,11 +86,11 @@ func (r Rule) validateNoncurrentExpiration() error {
 func (r Rule) validatePrefixAndFilter() error {
 	// In the now deprecated PutBucketLifecycle API, Rule had a mandatory Prefix element and there existed no Filter field.
 	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html
-	// In the newer PutBucketLifecycleConfiguraiton API, Rule has a prefix field that is deprecated, and there exists an optional
+	// In the newer PutBucketLifecycleConfiguration API, Rule has a prefix field that is deprecated, and there exists an optional
 	// Filter field, and within it, an optional Prefix field.
 	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html
 	// A valid rule could be a pre-existing one created using the now deprecated PutBucketLifecycle.
-	// Or, a valid rule could also be either a pre-existing or a new rule that is created using PutBucketLifecycleConfiguraiton.
+	// Or, a valid rule could also be either a pre-existing or a new rule that is created using PutBucketLifecycleConfiguration.
 	// Prefix validation below may check that either Rule.Prefix or Rule.Filter.Prefix exist but not both.
 	// Here, we assume the pre-existing rule created using PutBucketLifecycle API is already valid and won't fail the validation if Rule.Prefix is empty.
 

--- a/internal/bucket/lifecycle/rule.go
+++ b/internal/bucket/lifecycle/rule.go
@@ -84,10 +84,21 @@ func (r Rule) validateNoncurrentExpiration() error {
 }
 
 func (r Rule) validatePrefixAndFilter() error {
-	if !r.Prefix.set && r.Filter.IsEmpty() || r.Prefix.set && !r.Filter.IsEmpty() {
+	// In the now deprecated PutBucketLifecycle API, Rule had a mandatory Prefix element and there existed no Filter field.
+	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html
+	// In the newer PutBucketLifecycleConfiguraiton API, Rule has a prefix field that is deprecated, and there exists an optional
+	// Filter field, and within it, an optional Prefix field.
+	// See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html
+	// A valid rule could be a pre-existing one created using the now deprecated PutBucketLifecycle.
+	// Or, a valid rule could also be either a pre-existing or a new rule that is created using PutBucketLifecycleConfiguraiton.
+	// Prefix validation below may check that either Rule.Prefix or Rule.Filter.Prefix exist but not both.
+	// Here, we assume the pre-existing rule created using PutBucketLifecycle API is already valid and won't fail the validation if Rule.Prefix is empty.
+
+	if r.Prefix.set && !r.Filter.IsEmpty() && r.Filter.Prefix.set {
 		return errXMLNotWellFormed
 	}
-	if !r.Prefix.set {
+
+	if r.Filter.set {
 		return r.Filter.Validate()
 	}
 	return nil


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Attempts to create a lifecycle rule using cURL when the xml has no prefix fails with `errXMLNotWellFormed` error:

```
$ curl -X PUT "http://localhost:9001/bucket-1?lifecycle" -H "Content-Type: application/xml" -H "Content-MD5: is0WM2LlKTzQECbf4PMRrQ==" --data '<LifecycleConfiguration><Rule><Expiration><Days>6</Days></Expiration><ID>Expiration-rule</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>'
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidArgument</Code><Message>The XML you provided was not well-formed or did not validate against our published schema</Message><BucketName>bucket-1</BucketName><Resource>/bucket-1</Resource><RequestId>180B2C661117A385</RequestId><HostId>7987905dee74cdeb212432486a178e511309594cee7cb75f892cd53e35f09ea4</HostId></Error>

```

## Motivation and Context

In the now deprecated `PutBucketLifecycle` API, Rule had a mandatory Prefix element and there existed no Filter field.
(See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html)
In the newer `PutBucketLifecycleConfiguration` API, Rule has a prefix field that is deprecated, and there exists an optional Filter field, and within it, an optional Prefix field.
(See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html)

Existing prefix validation fails if Rule.Prefix does not exist and there are no Filters. This behavior is incorrect since Prefix itself is not mandatory in `PutBucketLifecycleConfiguration` API.

A valid rule could be a pre-existing one created using the now deprecated `PutBucketLifecycle`.
Or, a valid rule could also be either a pre-existing or a new rule that is created using `PutBucketLifecycleConfiguration`.

Prefix validation has been modified to check that either Rule.Prefix or Rule.Filter.Prefix exist but not both.
In doing so, we are assuming that any pre-existing rule created using PutBucketLifecycle API is already valid; so validation won't fail if Rule.Prefix is empty.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
