### PR TITLE
prevent IAM cleanup errors

### DIFF
--- a/cmd/iam-object-store.go
+++ b/cmd/iam-object-store.go
@@ -793,7 +793,10 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	for _, item := range listedConfigItems[stsListKey] {
 		userName := path.Dir(item)
 		// loadUser() will delete expired user during the load.
-		iamLogIf(ctx, iamOS.loadUser(ctx, userName, stsUser, stsAccountsFromStore))
+		err := iamOS.loadUser(ctx, userName, stsUser, stsAccountsFromStore)
+		if err != nil && !errors.Is(err, errNoSuchUser) {
+			iamLogIf(ctx, err)
+		}
 		// No need to return errors for failed expiration of STS users
 	}
 
@@ -801,7 +804,10 @@ func (iamOS *IAMObjectStore) loadAllFromObjStore(ctx context.Context, cache *iam
 	// (removed during loadUser() in the loop above) are removed from memory.
 	for _, item := range listedConfigItems[policyDBSTSUsersListKey] {
 		stsName := strings.TrimSuffix(item, ".json")
-		iamLogIf(ctx, iamOS.loadMappedPolicy(ctx, stsName, stsUser, false, stsAccPoliciesFromStore))
+		err := iamOS.loadMappedPolicy(ctx, stsName, stsUser, false, stsAccPoliciesFromStore)
+		if err != nil && !errors.Is(err, errNoSuchPolicy) {
+			iamLogIf(ctx, err)
+		}
 		// No need to return errors for failed expiration of STS users
 	}
 


### PR DESCRIPTION
## Description
The service now raises the following errors when STS credentials are expired:
```
API: SYSTEM.iam
Time: 20:35:26 UTC 10/23/2024
DeploymentID: e4c15d73-33ab-4722-9cb8-f98f3032211f
Error: Specified user does not exist (*errors.errorString)
       6: internal/logger/logger.go:268:logger.LogIf()
       5: cmd/logging.go:29:cmd.iamLogIf()
       4: cmd/iam-object-store.go:782:cmd.(*IAMObjectStore).loadAllFromObjStore()
       3: cmd/iam-store.go:601:cmd.(*IAMStoreSys).LoadIAMCache()
       2: cmd/iam.go:207:cmd.(*IAMSys).Load()
       1: cmd/iam.go:472:cmd.(*IAMSys).periodicRoutines()
```
This PR hides these messages.

## Motivation and Context
Only errors that can cause issues should be logged. Harmless "errors" or expected errors shouldn't be logged.

## How to test this PR?
Start MinIO and run a client that requests STS credentials. After expiration the error will be logged, where after this PR it won't.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
