### PR TITLE
Always pull the latest mint image when running tests

### DIFF
--- a/.github/workflows/run-mint.sh
+++ b/.github/workflows/run-mint.sh
@@ -15,6 +15,9 @@ docker volume rm $(docker volume ls -f dangling=true) || true
 ## change working directory
 cd .github/workflows/mint
 
+## always pull latest
+docker pull docker.io/minio/mint:edge
+
 docker-compose -f minio-${MODE}.yaml up -d
 sleep 1m
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

I'm not sure how this refreshed previously, but without this, it's unclear which mint image is being used and whether it is the latest, since there is no SHA of the image in the test log output.

If the image is already available then this call completes quickly. 

## Motivation and Context

Ensure tests are always correct

## How to test this PR?

Let's see it run in GH

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
