### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -314,7 +314,7 @@ func TestCeilFrac(t *testing.T) {
 
 // Test if isErrIgnored works correctly.
 func TestIsErrIgnored(t *testing.T) {
-	errIgnored := fmt.Errorf("ignored error")
+	errIgnored := errors.New("ignored error")
 	testCases := []struct {
 		err     error
 		ignored bool


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters