### PR TITLE
Helm: Allow users to set storageClass from global parameters

### DIFF
--- a/helm/minio/templates/_helpers.tpl
+++ b/helm/minio/templates/_helpers.tpl
@@ -93,6 +93,27 @@ Return the appropriate apiVersion for console ingress.
 {{- end -}}
 
 {{/*
+Return the appropriate storageClassName.
+{{ include "minio.persistence.storageClass" ( dict "persistence" .Values.path.to.the.persistence "global" .Values.global) }}
+*/}}
+{{- define "minio.persistence.storageClass" -}}
+  {{- $storageClass := .persistence.storageClass -}}
+  {{- if .global -}}
+      {{- if .global.storageClass -}}
+          {{- $storageClass = .global.storageClass -}}
+      {{- end -}}
+  {{- end -}}
+
+  {{- if $storageClass -}}
+    {{- if (eq "-" $storageClass) -}}
+        {{- printf "storageClassName: \"\"" -}}
+    {{- else }}
+        {{- printf "storageClassName: %s" $storageClass -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Determine secret name.
 */}}
 {{- define "minio.secretName" -}}

--- a/helm/minio/templates/pvc.yaml
+++ b/helm/minio/templates/pvc.yaml
@@ -18,15 +18,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- if .Values.persistence.storageClass }}
-  {{- if (eq "-" .Values.persistence.storageClass) }}
-  storageClassName: ""
-  {{- else }}
-  storageClassName: "{{ .Values.persistence.storageClass }}"
-  {{- end }}
-  {{- end }}
   {{- if .Values.persistence.volumeName }}
   volumeName: "{{ .Values.persistence.volumeName }}"
   {{- end }}
+  {{- include "minio.persistence.storageClass" ( dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -241,7 +241,7 @@ spec:
         resources:
           requests:
             storage: {{ $psize }}
-        {{- include "minio.persistence.storageClass" ( dict "persistence" .Values.persistence "global" $.Values.global) | nindent 8 }}
+        {{- include "minio.persistence.storageClass" ( dict "persistence" $.Values.persistence "global" $.Values.global) | nindent 8 }}
     {{- end }}
     {{- else }}
     - apiVersion: v1

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -9,7 +9,6 @@
 {{ $subPath := .Values.persistence.subPath }}
 {{ $penabled := .Values.persistence.enabled }}
 {{ $accessMode := .Values.persistence.accessMode }}
-{{ $storageClass := .Values.persistence.storageClass }}
 {{ $psize := .Values.persistence.size }}
 apiVersion: v1
 kind: Service
@@ -239,12 +238,10 @@ spec:
         {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
-        {{- if $storageClass }}
-        storageClassName: {{ $storageClass }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $psize }}
+        {{- include "minio.persistence.storageClass" ( dict "persistence" .Values.persistence "global" $.Values.global) | nindent 8 }}
     {{- end }}
     {{- else }}
     - apiVersion: v1
@@ -256,12 +253,10 @@ spec:
         {{- end }}
       spec:
         accessModes: [ {{ $accessMode | quote }} ]
-        {{- if $storageClass }}
-        storageClassName: {{ $storageClass }}
-        {{- end }}
         resources:
           requests:
             storage: {{ $psize }}
+        {{- include "minio.persistence.storageClass" ( dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -1,3 +1,11 @@
+## Global parameters
+## These will override the parameters, including dependencies, configured to use the global value
+##
+global:
+  ## Global StorageClass for Persistent Volume(s)
+  ##
+  storageClass: ""
+
 ## Provide a name in place of minio for `app:` labels
 ##
 nameOverride: ""


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This allows users to set the storageClass from global parameters.

## Motivation and Context
Global parameters are useful, especially when building a chart with many dependency charts. I would like to set the storageClass parameter in the parent chart once and see it's set on the subcharts, without needing to set that value explicitly on each chart's values.

## How to test this PR?
```sh
cat > .values.yaml <<EOF
global:
  storageClass: "global"

persistence:
  storageClass: "local"
EOF
helm template helm/minio -s templates/statefulset.yaml -f .values.yaml
```

## Types of changes
- [ ] Optimization (provides speedup with no functional changes)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
