### PR TITLE
Add cpuio profiling potential crash workaround

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -411,7 +411,12 @@ func startProfiler(profilerType string) (minioProfiler, error) {
 			return nil, err
 		}
 		stop := fgprof.Start(f, fgprof.FormatPprof)
+		startedAt := time.Now()
 		prof.stopFn = func() ([]byte, error) {
+			if elapsed := time.Since(startedAt); elapsed < 100*time.Millisecond {
+				// Light hack around https://github.com/felixge/fgprof/pull/34
+				time.Sleep(100*time.Millisecond - elapsed)
+			}
 			err := stop()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description

Using admin cpuio traces could potentially crash the server (or handler more likely) due to upstream divide by 0: https://github.com/felixge/fgprof/pull/34

Ensure the profile always runs 100ms before stopping, so sample count isn't 0 (default sample rate ~10ms/sample, but allow for cpu starvation)

## How to test this PR?

Not seen in real-world, but could potentially be triggered with quick start and abort.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
