### PR TITLE
Correct bucket metrics name

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -685,6 +685,16 @@ func getUsageLastScanActivityMD() MetricDescription {
 	}
 }
 
+func getBucketUsageLastScanActivityMD() MetricDescription {
+	return MetricDescription{
+		Namespace: bucketMetricNamespace,
+		Subsystem: usageSubsystem,
+		Name:      lastActivityTime,
+		Help:      "Time elapsed (in nano seconds) since last scan activity",
+		Type:      gaugeMetric,
+	}
+}
+
 func getBucketUsageQuotaTotalBytesMD() MetricDescription {
 	return MetricDescription{
 		Namespace: bucketMetricNamespace,
@@ -3243,7 +3253,7 @@ func getBucketUsageMetrics(opts MetricsGroupOpts) *MetricsGroupV2 {
 		}
 
 		metrics = append(metrics, MetricV2{
-			Description: getUsageLastScanActivityMD(),
+			Description: getBucketUsageLastScanActivityMD(),
 			Value:       float64(time.Since(dataUsageInfo.LastUpdate)),
 		})
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Earlier both cluster and bucket metrics used to be named as `minio_usage_last_activity_nano_seconds`. Bucket level now named as `minio_bucket_usage_last_activity_nano_seconds`

## Motivation and Context


## How to test this PR?

```
$ mc admin prometheus metrics m1 | grep nano
# HELP minio_usage_last_activity_nano_seconds Time elapsed (in nano seconds) since last scan activity
# TYPE minio_usage_last_activity_nano_seconds gauge
minio_usage_last_activity_nano_seconds{server="127.0.0.1:9000"} 1.90503344421943e+15

$ mc admin prometheus metrics m1 bucket | grep nano
# HELP minio_bucket_usage_last_activity_nano_seconds Time elapsed (in nano seconds) since last scan activity
# TYPE minio_bucket_usage_last_activity_nano_seconds gauge
minio_bucket_usage_last_activity_nano_seconds{server="127.0.0.1:9000"} 1.905040476000981e+15
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
