### PR TITLE
decom: avoid skipping single delete markers for replication

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -845,7 +845,7 @@ func (z *erasureServerPools) decommissionPool(ctx context.Context, idx int, pool
 				// to decommission, just skip it, this also includes
 				// any other versions that have already expired.
 				remainingVersions := len(fivs.Versions) - expired
-				if version.Deleted && remainingVersions == 1 {
+				if version.Deleted && remainingVersions == 1 && rcfg == nil {
 					decommissioned++
 					stopFn(version.Size, errors.New("DELETE marked object with no other non-current versions will be skipped"))
 					continue


### PR DESCRIPTION
Fixes #20819

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
It is possible delete marker was received on old pool as decom
move in progress, this PR allows decom retry to ensure these
delete markers are moved to new pool so that decommission can
be completed.

Fixes https://github.com/minio/minio/issues/20819

## Motivation and Context


## How to test this PR?
see #20819

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
