### PR TITLE
Fix inconsistently written compressed files.

### DIFF
--- a/docs/debugging/xl-meta/main.go
+++ b/docs/debugging/xl-meta/main.go
@@ -664,7 +664,7 @@ func (x xlMetaInlineData) files(fn func(name string, data []byte)) error {
 
 const (
 	xlHeaderVersion = 3
-	xlMetaVersion   = 2
+	xlMetaVersion   = 3
 )
 
 type xlHeaders struct {


### PR DESCRIPTION
## Description

Before https://github.com/minio/minio/pull/20575 files could pick up indices from unrelated files if no indices were added.

This would result in these files not being consistent across a set.

When loading search for the compression indicators, check if within the problematic date range and clean up any parts that have an index, but shouldn't.

Test validates that the signature matches the one in files stored without an index.

Bumps xlMetaVersion, so this check doesn't have to be made for future versions.

## How to test this PR?

Test included. Requires object where part(s) are < 8MB.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
