### PR TITLE
do not list buckets without local quorum

### DIFF
--- a/cmd/storage-datatypes.go
+++ b/cmd/storage-datatypes.go
@@ -101,8 +101,6 @@ type VolsInfo []VolInfo
 // VolInfo - represents volume stat information.
 // The above means that any added/deleted fields are incompatible.
 //
-// The above means that any added/deleted fields are incompatible.
-//
 //msgp:tuple VolInfo
 type VolInfo struct {
 	// Name of the volume.
@@ -110,6 +108,9 @@ type VolInfo struct {
 
 	// Date and time when the volume was created.
 	Created time.Time
+
+	// total VolInfo counts
+	count int
 }
 
 // FilesInfo represent a list of files, additionally

--- a/cmd/xl-storage_test.go
+++ b/cmd/xl-storage_test.go
@@ -759,7 +759,7 @@ func TestXLStorageListVols(t *testing.T) {
 	if volInfos, err = xlStorage.ListVols(context.Background()); err != nil {
 		t.Fatalf("expected: <nil>, got: %s", err)
 	} else if len(volInfos) != 1 {
-		t.Fatalf("expected: one entry, got: %s", volInfos)
+		t.Fatalf("expected: one entry, got: %v", volInfos)
 	}
 
 	// TestXLStorage non-empty list vols.


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
do not list buckets without local quorum

## Motivation and Context
ListBuckets() would result in listing buckets
without a quorum, this PR fixes the behavior.

## How to test this PR?
```
minio server /tmp/xl{1,2,3,4}
mc mb myminio/testbucket
mc ls myminio/
... testbucket/
rm -rf /tmp/xl{1,2,3}
mc ls myminio (must be empty)
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
