### PR TITLE
helm: add ability to set ingress pathType

### DIFF
--- a/helm/minio/templates/console-ingress.yaml
+++ b/helm/minio/templates/console-ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := printf "%s-console" (include "minio.fullname" .) -}}
 {{- $servicePort := .Values.consoleService.port -}}
 {{- $ingressPath := .Values.consoleIngress.path -}}
+{{- $ingressPathType := .Values.consoleIngress.pathType -}}
 apiVersion: {{ template "minio.consoleIngress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -37,7 +38,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/helm/minio/templates/ingress.yaml
+++ b/helm/minio/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "minio.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: {{ template "minio.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -37,7 +38,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: Prefix
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -213,6 +213,7 @@ ingress:
     # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     # nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0
   path: /
+  pathType: Prefix
   hosts:
     - minio-example.local
   tls: []
@@ -256,6 +257,7 @@ consoleIngress:
     # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     # nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0
   path: /
+  pathType: Prefix
   hosts:
     - console.minio-example.local
   tls: []


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This PR introduces the ability to set `pathType` for both `ingress` and `ingressConsole`.

## Motivation and Context

This is needed when using `use-regex` nginx ingress annotation. To avoid this kind of validation error, `pathType` needs to be set to `ImplementationSpecific`.

```
admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /console(/|$)(.*) cannot be used with pathType Prefix
```

## How to test this PR?

Set `ingress.pathType` and/or `consoleIngress.pathType` helm values.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
