### PR TITLE
Add support for lower versions of git, such as git1.8.x

### DIFF
--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -88,25 +88,25 @@ func commitID() string {
 }
 
 func commitTime() time.Time {
-	// git log --format=%cD -n1
+	// git log --format=%at -n1
 	var (
-		commitUnix []byte
-		err        error
+		commitUnix    int64
+		commitUnixStr []byte
+		err           error
 	)
 	cmdName := "git"
-	cmdArgs := []string{"log", "--format=%cI", "-n1"}
-	if commitUnix, err = exec.Command(cmdName, cmdArgs...).Output(); err != nil {
+	cmdArgs := []string{"log", "--format=%at", "-n1"}
+
+	if commitUnixStr, err = exec.Command(cmdName, cmdArgs...).Output(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error generating git commit-time: ", err)
+		os.Exit(1)
+	}
+	if commitUnix, err = strconv.ParseInt(strings.TrimSpace(string(commitUnixStr)), 10, 64); err != nil {
 		fmt.Fprintln(os.Stderr, "Error generating git commit-time: ", err)
 		os.Exit(1)
 	}
 
-	t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(commitUnix)))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error generating git commit-time: ", err)
-		os.Exit(1)
-	}
-
-	return t.UTC()
+	return time.Unix(commitUnix, 0).UTC()
 }
 
 func main() {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Replace --format=%cI with --format=%at

```bash
git log --format=%cI  ==> git log --format=%at
```

## Motivation and Context

Allow machines that can only use lower versions of git to compile minio.

## How to test this PR?

```bash
go run buildscripts/gen-ldflags.go
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
