### PR TITLE
Use a timeout when acquiring RLocks to objects.

### DIFF
--- a/internal/dsync/drwmutex.go
+++ b/internal/dsync/drwmutex.go
@@ -429,11 +429,12 @@ func lock(ctx context.Context, ds *Dsync, locks *[]string, id, source string, is
 	var wg sync.WaitGroup
 
 	args := LockArgs{
-		Owner:     owner,
-		UID:       id,
-		Resources: names,
-		Source:    source,
-		Quorum:    &quorum,
+		Owner:         owner,
+		UID:           id,
+		Resources:     names,
+		Source:        source,
+		Quorum:        &quorum,
+		TimeoutMillis: ds.Timeouts.Acquire.Milliseconds(),
 	}
 
 	// Combined timeout for the lock attempt.

--- a/internal/dsync/drwmutex_test.go
+++ b/internal/dsync/drwmutex_test.go
@@ -259,6 +259,10 @@ func TestSlowLockServer(t *testing.T) {
 		},
 	}
 
+	for _, srv := range lockServers {
+		srv.reset()
+	}
+
 	const resourceName = "xyz"
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -299,7 +303,7 @@ func TestSlowLockServer(t *testing.T) {
 func asserNumLocks(t *testing.T, n int) {
 	for _, srv := range lockServers {
 		if len(srv.lockMap) != n {
-			t.Fatalf("lockServer should have %d resource locks", n)
+			t.Fatalf("lockServer should have %d resource locks, has %d", n, len(srv.lockMap))
 		}
 	}
 }

--- a/internal/dsync/dsync-server_test.go
+++ b/internal/dsync/dsync-server_test.go
@@ -195,6 +195,14 @@ type lockServer struct {
 	responseDelay int64
 }
 
+func (l *lockServer) reset() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.lockNotFound = false
+	l.responseDelay = 0
+	clear(l.lockMap)
+}
+
 func (l *lockServer) setRefreshReply(refreshed bool) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()

--- a/internal/dsync/lock-args.go
+++ b/internal/dsync/lock-args.go
@@ -37,6 +37,10 @@ type LockArgs struct {
 
 	// Quorum represents the expected quorum for this lock type.
 	Quorum *int `msgp:"omitempty"`
+
+	// TimeoutMillis is the timeout for acquiring the lock in milliseconds.
+	// A value less than or equal to 0 indicates no timeout.
+	TimeoutMillis int64 `msgp:"omitempty"`
 }
 
 // ResponseCode is the response code for a locking request.

--- a/internal/dsync/lock-args_gen.go
+++ b/internal/dsync/lock-args_gen.go
@@ -79,6 +79,12 @@ func (z *LockArgs) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
+		case "TimeoutMillis":
+			z.TimeoutMillis, err = dc.ReadInt64()
+			if err != nil {
+				err = msgp.WrapError(err, "TimeoutMillis")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -92,9 +98,9 @@ func (z *LockArgs) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *LockArgs) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 5
+	// map header, size 6
 	// write "UID"
-	err = en.Append(0x85, 0xa3, 0x55, 0x49, 0x44)
+	err = en.Append(0x86, 0xa3, 0x55, 0x49, 0x44)
 	if err != nil {
 		return
 	}
@@ -157,15 +163,25 @@ func (z *LockArgs) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	}
+	// write "TimeoutMillis"
+	err = en.Append(0xad, 0x54, 0x69, 0x6d, 0x65, 0x6f, 0x75, 0x74, 0x4d, 0x69, 0x6c, 0x6c, 0x69, 0x73)
+	if err != nil {
+		return
+	}
+	err = en.WriteInt64(z.TimeoutMillis)
+	if err != nil {
+		err = msgp.WrapError(err, "TimeoutMillis")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *LockArgs) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 5
+	// map header, size 6
 	// string "UID"
-	o = append(o, 0x85, 0xa3, 0x55, 0x49, 0x44)
+	o = append(o, 0x86, 0xa3, 0x55, 0x49, 0x44)
 	o = msgp.AppendString(o, z.UID)
 	// string "Resources"
 	o = append(o, 0xa9, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73)
@@ -186,6 +202,9 @@ func (z *LockArgs) MarshalMsg(b []byte) (o []byte, err error) {
 	} else {
 		o = msgp.AppendInt(o, *z.Quorum)
 	}
+	// string "TimeoutMillis"
+	o = append(o, 0xad, 0x54, 0x69, 0x6d, 0x65, 0x6f, 0x75, 0x74, 0x4d, 0x69, 0x6c, 0x6c, 0x69, 0x73)
+	o = msgp.AppendInt64(o, z.TimeoutMillis)
 	return
 }
 
@@ -261,6 +280,12 @@ func (z *LockArgs) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
+		case "TimeoutMillis":
+			z.TimeoutMillis, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "TimeoutMillis")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -285,6 +310,7 @@ func (z *LockArgs) Msgsize() (s int) {
 	} else {
 		s += msgp.IntSize
 	}
+	s += 14 + msgp.Int64Size
 	return
 }
 


### PR DESCRIPTION
## Description

As illustrated in https://github.com/minio/minio/issues/20862, a large surge of requests against the same object can overwhelm a single minio server. The root cause for this seems to be the lock acquisition process which currently has no timeout on the server owning the requested object. Lock acquisition is still ongoing on the server even when the client request has timed out or failed.

Once lock acquisition in the client times out, the server will still lock the object and return success, causing the client to spend additional time releasing the object.

In order to make the server recover quickly after requests fail, this commit adds a timeout to acquiring read locks. The timeout is set from the server and is optional. Ideally this would be resolved through context cancellation, but contexts do not seem to be used in the RPC framework.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## How to test this PR?

The change is tested through unit tests. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
