### PR TITLE
Allow URLs up to 32KB and improve parsing speed

### DIFF
--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -293,12 +293,6 @@ func parseAmzDateHeader(req *http.Request) (time.Time, APIErrorCode) {
 	return time.Time{}, ErrMissingDateHeader
 }
 
-// Bad path components to be rejected by the path validity handler.
-const (
-	dotdotComponent = ".."
-	dotComponent    = "."
-)
-
 func hasBadHost(host string) error {
 	if globalIsCICD && strings.TrimSpace(host) == "" {
 		// under CI/CD test setups ignore empty hosts as invalid hosts

--- a/cmd/generic-handlers.go
+++ b/cmd/generic-handlers.go
@@ -22,11 +22,11 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/dustin/go-humanize"
 	"github.com/minio/minio-go/v7/pkg/s3utils"
@@ -311,21 +311,41 @@ func hasBadHost(host string) error {
 // Check if the incoming path has bad path components,
 // such as ".." and "."
 func hasBadPathComponent(path string) bool {
-	if len(path) > 4096 {
-		// path cannot be greater than Linux PATH_MAX
-		// this is to avoid a busy loop, that can happen
-		// if the caller sends path of following style
-		// a/a/a/a/a/a/a/a...
+	n := len(path)
+	if n > 32<<10 {
+		// At 32K we are beyond reasonable.
 		return true
 	}
-	path = filepath.ToSlash(strings.TrimSpace(path)) // For windows '\' must be converted to '/'
-	for _, p := range strings.Split(path, SlashSeparator) {
-		switch strings.TrimSpace(p) {
-		case dotdotComponent:
+	i := 0
+	// Skip leading slashes (for sake of Windows \ is included as well)
+	for i < n && (path[i] == SlashSeparatorChar || path[i] == '\\') {
+		i++
+	}
+
+	for i < n {
+		// Find the next segment
+		start := i
+		for i < n && path[i] != SlashSeparatorChar && path[i] != '\\' {
+			i++
+		}
+
+		// Trim whitespace of segment
+		segmentStart, segmentEnd := start, i
+		for segmentStart < segmentEnd && unicode.IsSpace(rune(path[segmentStart])) {
+			segmentStart++
+		}
+		for segmentEnd > segmentStart && unicode.IsSpace(rune(path[segmentEnd-1])) {
+			segmentEnd--
+		}
+
+		// Check for ".." or "."
+		switch {
+		case segmentEnd-segmentStart == 2 && path[segmentStart] == '.' && path[segmentStart+1] == '.':
 			return true
-		case dotComponent:
+		case segmentEnd-segmentStart == 1 && path[segmentStart] == '.':
 			return true
 		}
+		i++
 	}
 	return false
 }


### PR DESCRIPTION
## Description

Before/after...
```
Benchmark_hasBadPathComponent/long-32          	   43936	     27232 ns/op	 146.89 MB/s	   32768 B/op	       1 allocs/op
Benchmark_hasBadPathComponent/long-32          	   89971	     13242 ns/op	 302.07 MB/s	       0 B/op	       0 allocs/op
```

Fixes #20873

## How to test this PR?

Included benchmark, otherwise see #20873

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Optimization (provides speedup with no functional changes)
- [x] Fixes a regression from #19466
- [x] Unit tests added/updated