### PR TITLE
Redact sensitive fields from DescribeBatchJob

### DIFF
--- a/cmd/batch-expire.go
+++ b/cmd/batch-expire.go
@@ -289,6 +289,16 @@ type BatchJobExpire struct {
 
 var _ yaml.Unmarshaler = &BatchJobExpire{}
 
+// RedactSensitive will redact any sensitive information in b.
+func (b *BatchJobExpire) RedactSensitive() {
+	if b == nil {
+		return
+	}
+	if b.NotificationCfg.Token != "" {
+		b.NotificationCfg.Token = redactedText
+	}
+}
+
 // UnmarshalYAML - BatchJobExpire extends default unmarshal to extract line, col information.
 func (r *BatchJobExpire) UnmarshalYAML(val *yaml.Node) error {
 	type expireJob BatchJobExpire

--- a/cmd/batch-expire.go
+++ b/cmd/batch-expire.go
@@ -290,12 +290,12 @@ type BatchJobExpire struct {
 var _ yaml.Unmarshaler = &BatchJobExpire{}
 
 // RedactSensitive will redact any sensitive information in b.
-func (b *BatchJobExpire) RedactSensitive() {
-	if b == nil {
+func (r *BatchJobExpire) RedactSensitive() {
+	if r == nil {
 		return
 	}
-	if b.NotificationCfg.Token != "" {
-		b.NotificationCfg.Token = redactedText
+	if r.NotificationCfg.Token != "" {
+		r.NotificationCfg.Token = redactedText
 	}
 }
 

--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -77,22 +77,22 @@ type BatchJobRequest struct {
 }
 
 // RedactSensitive will redact any sensitive information in b.
-func (b *BatchJobRequest) RedactSensitive() {
-	b.Replicate.RedactSensitive()
-	b.Expire.RedactSensitive()
-	b.KeyRotate.RedactSensitive()
+func (j *BatchJobRequest) RedactSensitive() {
+	j.Replicate.RedactSensitive()
+	j.Expire.RedactSensitive()
+	j.KeyRotate.RedactSensitive()
 }
 
 // RedactSensitive will redact any sensitive information in b.
-func (b *BatchJobReplicateV1) RedactSensitive() {
-	if b == nil {
+func (r *BatchJobReplicateV1) RedactSensitive() {
+	if r == nil {
 		return
 	}
-	if b.Target.Creds.SecretKey != "" {
-		b.Target.Creds.SecretKey = redactedText
+	if r.Target.Creds.SecretKey != "" {
+		r.Target.Creds.SecretKey = redactedText
 	}
-	if b.Target.Creds.SessionToken != "" {
-		b.Target.Creds.SessionToken = redactedText
+	if r.Target.Creds.SessionToken != "" {
+		r.Target.Creds.SessionToken = redactedText
 	}
 }
 

--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -97,17 +97,7 @@ func (b *BatchJobReplicateV1) RedactSensitive() {
 }
 
 // RedactSensitive will redact any sensitive information in b.
-func (b *BatchJobKeyRotateV1) RedactSensitive() {}
-
-// RedactSensitive will redact any sensitive information in b.
-func (b *BatchJobExpire) RedactSensitive() {
-	if b == nil {
-		return
-	}
-	if b.NotificationCfg.Token != "" {
-		b.NotificationCfg.Token = redactedText
-	}
-}
+func (r *BatchJobKeyRotateV1) RedactSensitive() {}
 
 func notifyEndpoint(ctx context.Context, ri *batchJobInfo, endpoint, token string) error {
 	if endpoint == "" {


### PR DESCRIPTION
## Description

Redacts the following if set:

* replicate/credentials/secretKey
* replicate/credentials/sessionToken
* expire/notify/token

I didn't find any more sensitive fields.

BatchJobStatus and ListBatchJobs does not include any of these AFAICT.

Of course endpoint requires admin creds in the first place, but there isn't too much value in returning them, so we might as well keep them hidden.

Please confirm that this is only used for `mc` and not programatically.

## How to test this PR?

`mc batch describe ...`

## Types of changes
- [x] Extra safety
- [x] Potentially breaking change. Please check
