### PR TITLE
Quick patch for Snowball AutoExtract: #20883

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2347,7 +2347,7 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 
 		if r.Header.Get(xhttp.AmzBucketReplicationStatus) == replication.Replica.String() {
 			if s3Err = isPutActionAllowed(ctx, getRequestAuthType(r), bucket, object, r, policy.ReplicateObjectAction); s3Err != ErrNone {
-				return err
+				return errors.New(errorCodes.ToAPIErr(s3Err).Code)
 			}
 			metadata[ReservedMetadataPrefixLower+ReplicaStatus] = replication.Replica.String()
 			metadata[ReservedMetadataPrefixLower+ReplicaTimestamp] = UTCNow().Format(time.RFC3339Nano)

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2307,7 +2307,11 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 
 	putObjectTar := func(reader io.Reader, info os.FileInfo, object string) error {
 		size := info.Size()
-
+		// Check for every object if put is allowed. See #https://github.com/minio/minio/issues/20883
+		if s3Err = isPutActionAllowed(ctx, getRequestAuthType(r), bucket, object, r, policy.PutObjectAction); s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return errors.New(errorCodes.ToAPIErr(s3Err).Code)
+		}
 		metadata := map[string]string{
 			xhttp.AmzStorageClass: sc, // save same storage-class as incoming stream.
 		}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2238,7 +2238,7 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 	if opts.prefixAll != "" {
 		opts.prefixAll = trimLeadingSlash(pathJoin(opts.prefixAll, slashSeparator))
 	}
-	// Check if put is allow for empty or Snowball prefix see #https://github.com/minio/minio/issues/20883
+	// Check if put is allow for specified prefix.
 	if s3Err = isPutActionAllowed(ctx, rAuthType, bucket, opts.prefixAll, r, policy.PutObjectAction); s3Err != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 		return
@@ -2307,7 +2307,6 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 
 	putObjectTar := func(reader io.Reader, info os.FileInfo, object string) error {
 		size := info.Size()
-		// Check for every object if put is allowed. See #https://github.com/minio/minio/issues/20883
 		if s3Err = isPutActionAllowed(ctx, getRequestAuthType(r), bucket, object, r, policy.PutObjectAction); s3Err != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 			return errors.New(errorCodes.ToAPIErr(s3Err).Code)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The object name or prefix on Put requests with `X-Amz-Meta-Snowball-Auto-Extract=true` is erroneously checked for permission. Because in reality the url object name is ignored and the extraction targets `bucket/`.

Fixes #20883

## Motivation and Context

I believe there are two ways of fixing this:
 - if not present , default `X-Amz-Meta-Minio-Snowball-Prefix` to the client's request prefix/object. Would this break S3 compatibility!? I didn't check that...
 - Ignoring the request object/prefix [**implemented here**]
 
 Inferring from: https://blog.min.io/minio-optimizes-small-objects/ it seems that only the bucket part of the request should be taken into account.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
