### PR TITLE
sts: allow client-provided intermediate CAs

### DIFF
--- a/cmd/sts-errors.go
+++ b/cmd/sts-errors.go
@@ -81,6 +81,7 @@ const (
 	ErrSTSMalformedPolicyDocument
 	ErrSTSInsecureConnection
 	ErrSTSInvalidClientCertificate
+	ErrSTSTooManyIntermediateCAs
 	ErrSTSNotInitialized
 	ErrSTSIAMNotInitialized
 	ErrSTSUpstreamError
@@ -143,6 +144,11 @@ var stsErrCodes = stsErrorCodeMap{
 	ErrSTSInvalidClientCertificate: {
 		Code:           "InvalidClientCertificate",
 		Description:    "The provided client certificate is invalid. Retry with a different certificate.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrSTSTooManyIntermediateCAs: {
+		Code:           "TooManyIntermediateCAs",
+		Description:    "The provided client certificate contains too many intermediate CA certificates",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrSTSNotInitialized: {

--- a/cmd/stserrorcode_string.go
+++ b/cmd/stserrorcode_string.go
@@ -18,15 +18,16 @@ func _() {
 	_ = x[ErrSTSMalformedPolicyDocument-7]
 	_ = x[ErrSTSInsecureConnection-8]
 	_ = x[ErrSTSInvalidClientCertificate-9]
-	_ = x[ErrSTSNotInitialized-10]
-	_ = x[ErrSTSIAMNotInitialized-11]
-	_ = x[ErrSTSUpstreamError-12]
-	_ = x[ErrSTSInternalError-13]
+	_ = x[ErrSTSTooManyIntermediateCAs-10]
+	_ = x[ErrSTSNotInitialized-11]
+	_ = x[ErrSTSIAMNotInitialized-12]
+	_ = x[ErrSTSUpstreamError-13]
+	_ = x[ErrSTSInternalError-14]
 }
 
-const _STSErrorCode_name = "STSNoneSTSAccessDeniedSTSMissingParameterSTSInvalidParameterValueSTSWebIdentityExpiredTokenSTSClientGrantsExpiredTokenSTSInvalidClientGrantsTokenSTSMalformedPolicyDocumentSTSInsecureConnectionSTSInvalidClientCertificateSTSNotInitializedSTSIAMNotInitializedSTSUpstreamErrorSTSInternalError"
+const _STSErrorCode_name = "STSNoneSTSAccessDeniedSTSMissingParameterSTSInvalidParameterValueSTSWebIdentityExpiredTokenSTSClientGrantsExpiredTokenSTSInvalidClientGrantsTokenSTSMalformedPolicyDocumentSTSInsecureConnectionSTSInvalidClientCertificateSTSTooManyIntermediateCAsSTSNotInitializedSTSIAMNotInitializedSTSUpstreamErrorSTSInternalError"
 
-var _STSErrorCode_index = [...]uint16{0, 7, 22, 41, 65, 91, 118, 145, 171, 192, 219, 236, 256, 272, 288}
+var _STSErrorCode_index = [...]uint16{0, 7, 22, 41, 65, 91, 118, 145, 171, 192, 219, 244, 261, 281, 297, 313}
 
 func (i STSErrorCode) String() string {
 	if i < 0 || i >= STSErrorCode(len(_STSErrorCode_index)-1) {


### PR DESCRIPTION
## Description
This commit allows clients to provide a set of intermediate CA certificates (up to `MaxIntermediateCAs`) that the server will use as intermediate CAs when verifying the trust chain from the client leaf certificate up to one trusted root CA.

This is required if the client leaf certificate is not issued by a trusted CA directly but by an intermediate CA. Without this commit, MinIO rejects such certificates.

## Motivation and Context
sts , mtls

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
