### PR TITLE
kms: add `MINIO_KMS_REPLICATE_KEYID` option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/minio/minio
 
 go 1.23
 
+toolchain go1.23.6
+
 require (
 	cloud.google.com/go/storage v1.46.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
## Description
This commit adds the `MINIO_KMS_REPLICATE_KEYID` env. variable. By default - if not specified or not set to `off` - MinIO will replicate the KMS key ID of an object.

If `MINIO_KMS_REPLICATE_KEYID=off`, MinIO does not include the object's KMS Key ID when replicating an object. However, it always sets the SSE-KMS encryption header. This ensures that the object gets encrypted using SSE-KMS. The target site chooses the KMS key ID that gets used based on the site and bucket config.

## Motivation and Context
KMS

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
