### PR TITLE
Fix nil pointer deref in PeerPolicyMappingHandler

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -1441,7 +1441,7 @@ func (c *SiteReplicationSys) PeerPolicyMappingHandler(ctx context.Context, mappi
 			if foundGroupDN, underBaseDN, err = globalIAMSys.LDAPConfig.GetValidatedGroupDN(nil, entityName); err != nil {
 				iamLogIf(ctx, err)
 			} else if foundGroupDN == nil || !underBaseDN {
-				err = errNoSuchGroup
+				return wrapSRErr(errNoSuchGroup)
 			}
 			entityName = foundGroupDN.NormDN
 		} else {
@@ -1449,7 +1449,7 @@ func (c *SiteReplicationSys) PeerPolicyMappingHandler(ctx context.Context, mappi
 			if foundUserDN, err = globalIAMSys.LDAPConfig.GetValidatedDNForUsername(entityName); err != nil {
 				iamLogIf(ctx, err)
 			} else if foundUserDN == nil {
-				err = errNoSuchUser
+				return wrapSRErr(errNoSuchUser)
 			}
 			entityName = foundUserDN.NormDN
 		}


### PR DESCRIPTION
## Description

The following lines will attempt to de-reference the nil value. Instead just return the error at once.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression #19758
