### PR TITLE
Extract all files from encrypted stream with inspect

### DIFF
--- a/internal/store/queuestore.go
+++ b/internal/store/queuestore.go
@@ -156,7 +156,7 @@ func (store *QueueStore[I]) multiWrite(key Key, items []I) (err error) {
 
 // write - writes an item to the directory.
 func (store *QueueStore[I]) write(key Key, item I) error {
-	// Marshalls the item.
+	// Marshals the item.
 	eventData, err := json.Marshal(item)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Allow multiple private keys and extract all files from streams.

Place files in folder with `.enc` removed.

## Motivation and Context

Make arbitrary streams easier to handle. Including `mc support upload`.

## How to test this PR?

Extract inspect streams.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
