### PR TITLE
ftp: Enable trailing headers, just like sftp

### DIFF
--- a/cmd/ftp-server-driver.go
+++ b/cmd/ftp-server-driver.go
@@ -382,9 +382,10 @@ func (driver *ftpDriver) getMinIOClient(ctx *ftp.Context) (*minio.Client, error)
 	}
 
 	return minio.New(driver.endpoint, &minio.Options{
-		Creds:     credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
-		Secure:    globalIsTLS,
-		Transport: tr,
+		Creds:           credentials.NewStaticV4(ui.Credentials.AccessKey, ui.Credentials.SecretKey, ""),
+		Secure:          globalIsTLS,
+		Transport:       tr,
+		TrailingHeaders: true,
 	})
 }
 


### PR DESCRIPTION
## Description
Fixes:  #20912
Initial PR #20914
On this PR `TrailingHeaders: true` updated to the ui credentials too

## How to test this PR?
FTP upload


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


