### PR TITLE
fix(docs): update mc admin trace link to MinIO official docs

### DIFF
--- a/docs/debugging/README.md
+++ b/docs/debugging/README.md
@@ -2,7 +2,7 @@
 
 ## HTTP Trace
 
-HTTP tracing can be enabled by using [`mc admin trace`](https://github.com/minio/mc/blob/master/docs/minio-admin-complete-guide.md#command-trace---display-minio-server-http-trace) command.
+HTTP tracing can be enabled by using [`mc admin trace`](https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-trace.html) command.
 
 Example:
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR updates the link in the documentation for mc admin trace, replacing the previous reference with the official MinIO documentation:

- Old link: [GitHub MinIO docs](https://github.com/minio/mc/blob/master/docs/minio-admin-complete-guide.md#command-trace---display-minio-server-http-trace)
- New link: [MinIO official docs](https://min.io/docs/minio/linux/reference/minio-mc-admin/mc-admin-trace.html)

## Motivation and Context
The previous link pointed to GitHub-based documentation, which is no longer the most up-to-date reference. This change ensures that users are directed to the official MinIO documentation for accurate and latest information.
- This PR addresses issue #20940 by ensuring users are directed to the latest official MinIO documentation.


## How to test this PR?
Click on the `mc admin trace` link, and it should redirect to the official MinIO documentation.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
