### PR TITLE
add networkpolicy for job and add possibility to define egress ports

### DIFF
--- a/helm/minio/templates/networkpolicy.yaml
+++ b/helm/minio/templates/networkpolicy.yaml
@@ -16,11 +16,51 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.minioAPIPort }}
+          protocol: TCP
         - port: {{ .Values.minioConsolePort }}
+          protocol: TCP
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:
             matchLabels:
               {{ template "minio.name" . }}-client: "true"
       {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+      {{- with .Values.networkPolicy.egress.to }}
+      to:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+  {{- end }}
+---
+kind: NetworkPolicy
+apiVersion: {{ template "minio.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "minio.fullname" . }}-post-job
+  labels:
+    app: {{ template "minio.name" . }}-post-job
+    chart: {{ template "minio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "minio.name" . }}-job
+      release: {{ .Release.Name }}
+  egress:
+    - ports:
+        - port: {{ .Values.minioAPIPort }}
+          protocol: TCP
+        - port: {{ .Values.minioConsolePort }}
+          protocol: TCP
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+      {{- with .Values.networkPolicy.egress.to }}
+      to:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -200,9 +200,11 @@ service:
 ingress:
   enabled: false
   ingressClassName: ~
-  labels: {}
+  labels:
+    {}
     # node-role.kubernetes.io/ingress: platform
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.allow-http: "false"
@@ -241,9 +243,11 @@ consoleService:
 consoleIngress:
   enabled: false
   ingressClassName: ~
-  labels: {}
+  labels:
+    {}
     # node-role.kubernetes.io/ingress: platform
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.allow-http: "false"
@@ -391,7 +395,8 @@ makeUserJob:
 
 ## List of service accounts to be created after minio install
 ##
-svcaccts: []
+svcaccts:
+  []
   ## accessKey, secretKey and parent user to be assigned to the service accounts
   ## Add new service accounts as explained here https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#service-accounts
   # - accessKey: console-svcacct
@@ -430,7 +435,8 @@ makeServiceAccountJob:
 
 ## List of buckets to be created after minio install
 ##
-buckets: []
+buckets:
+  []
   #   # Name of the bucket
   # - name: bucket1
   #   # Policy to be set on the
@@ -479,13 +485,15 @@ customCommandJob:
     requests:
       memory: 128Mi
   ## Additional volumes to add to the post-job.
-  extraVolumes: []
+  extraVolumes:
+    []
     # - name: extra-policies
     #   configMap:
     #     name: my-extra-policies-cm
   ## Additional volumeMounts to add to the custom commands container when
   ## running the post-job.
-  extraVolumeMounts: []
+  extraVolumeMounts:
+    []
     # - name: extra-policies
     #   mountPath: /mnt/extras/
   # Command to run after the main command on exit
@@ -542,10 +550,35 @@ networkPolicy:
   # Specifies whether the policies created will be standard Network Policies (flavor: kubernetes)
   # or Cilium Network Policies (flavor: cilium)
   flavor: kubernetes
+  # allows external access to the minio api
   allowExternal: true
+  ## @params networkPolicy.egress configuration of the egress traffic
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing minio to connect to external data sources from kubernetes cluster.
+    ##
+    enabled: false
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## - port: 80
+    ## - port: 443
+    ## - port: 53
+    ##   protocol: UDP
+    ##
+    ports: []
+    ## @param networkPolicy.egress.to Allow egress traffic to specific destinations
+    ## Add destinations to the egress by specifying - ipBlock: <CIDR>
+    ## E.X.
+    ## to:
+    ##  - namespaceSelector:
+    ##    matchExpressions:
+    ##    - {key: role, operator: In, values: [minio]}
+    ##
+    to: []
   # only when using flavor: cilium
   egressEntities:
-   - kube-apiserver
+    - kube-apiserver
 
 ## PodDisruptionBudget settings
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
@@ -573,7 +606,8 @@ metrics:
     # for node metrics
     relabelConfigs: {}
     # for cluster metrics
-    relabelConfigsCluster: {}
+    relabelConfigsCluster:
+      {}
       # metricRelabelings:
       #   - regex: (server|pod)
       #     action: labeldrop


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This adds a new network policy for the minio-job and possibility to define egress ports.

## Motivation and Context

As on some deployments, where strict networkpolicies apply the job is not allowed to connect to minio, if not specifically defined. Additionally the option for egress is needed, if DNS resolution or other ports are denied by default and have to be specifically allowed. Very helpful, when using minio along with kube-protmehteus-stack and loki.

## How to test this PR?

Deploying minio via helm and triggering the minio-job in a namespace with various network restrictions.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
