### PR TITLE
fix: SFTP auth bypass with no pub key in LDAP

### DIFF
--- a/cmd/sftp-server_test.go
+++ b/cmd/sftp-server_test.go
@@ -147,6 +147,8 @@ func (s *TestSuiteIAM) SFTPPublicKeyAuthentication(c *check) {
 	}
 }
 
+// A user without an sshpubkey attribute in LDAP (here: fahim) should not be
+// able to authenticate.
 func (s *TestSuiteIAM) SFTPPublicKeyAuthNoPubKey(c *check) {
 	keyBytes, err := os.ReadFile("./testdata/dillon_test_key.pub")
 	if err != nil {
@@ -344,5 +346,4 @@ func (s *TestSuiteIAM) SFTPValidLDAPLoginWithPassword(c *check) {
 			c.Fatal("Password authentication failed for user (fahim):", err)
 		}
 	}
-
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

If a user attempts to authenticate with a key, but does not have an
sshpubkey attrib in LDAP, the server allows the connection - this means
the server trusted the key without reason. This is now fixed and a test
is added for validation.


## Motivation and Context

Externally reported.

## How to test this PR?

Test is included.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
