### PR TITLE
Fix healing probability for skipped folders

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -664,6 +664,11 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 					into.addChild(h)
 					continue
 				}
+				// Adjust the probability of healing.
+				// This first removes lowest x from the mod check and makes it x times more likely.
+				// So if duudc = 10 and we want heal check every 50 cycles, we check
+				// if (cycle/10) % (50/10) == 0, which would make heal checks run once every 50 cycles,
+				// if the objects are pre-selected as 1:10.
 				folder.objectHealProbDiv = dataUsageUpdateDirCycles
 			}
 			f.updateCurrentPath(folder.name)

--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -664,6 +664,7 @@ func (f *folderScanner) scanFolder(ctx context.Context, folder cachedFolder, int
 					into.addChild(h)
 					continue
 				}
+				folder.objectHealProbDiv = dataUsageUpdateDirCycles
 			}
 			f.updateCurrentPath(folder.name)
 			stopFn := globalScannerMetrics.log(scannerMetricScanFolder, f.root, folder.name)


### PR DESCRIPTION
## Description

We must update the heal probability when selectively skipping folders.

Thanks to @vadmeste for pinpointing the issue!

## How to test this PR?

Check heal call frequency. A test for this may be coming up.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
