### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/internal/s3select/sql/record.go
+++ b/internal/s3select/sql/record.go
@@ -134,7 +134,7 @@ func IterToValue(iter simdjson.Iter) (interface{}, error) {
 			}
 			dst = append(dst, v)
 		}
-		return dst, err
+		return dst, nil
 	case simdjson.TypeNull:
 		return nil, nil
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

The return value err here must be nil.  Return nil instead of error directly.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
