### PR TITLE
Fix: Change TTFB metric type to histogram

### DIFF
--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -1543,7 +1543,8 @@ func getS3TTFBDistributionMD() MetricDescription {
 		Subsystem: ttfbSubsystem,
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls",
-		Type:      gaugeMetric,
+		Type:      histogramMetric, 
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0},
 	}
 }
 
@@ -1553,7 +1554,8 @@ func getBucketTTFBDistributionMD() MetricDescription {
 		Subsystem: ttfbSubsystem,
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls per bucket",
-		Type:      gaugeMetric,
+		Type:      histogramMetric, 
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}, 
 	}
 }
 

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -319,6 +319,7 @@ type MetricDescription struct {
 	Name      MetricName      `json:"MetricName"`
 	Help      string          `json:"Help"`
 	Type      MetricTypeV2    `json:"Type"`
+	Buckets   []float64       `json:"Buckets,omitempty"` 
 }
 
 // MetricV2 captures the details for a metric
@@ -1544,7 +1545,7 @@ func getS3TTFBDistributionMD() MetricDescription {
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls",
 		Type:      histogramMetric, 
-		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0},
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}
 	}
 }
 
@@ -1555,7 +1556,7 @@ func getBucketTTFBDistributionMD() MetricDescription {
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls per bucket",
 		Type:      histogramMetric, 
-		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}, 
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}
 	}
 }
 

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -319,7 +319,7 @@ type MetricDescription struct {
 	Name      MetricName      `json:"MetricName"`
 	Help      string          `json:"Help"`
 	Type      MetricTypeV2    `json:"Type"`
-	Buckets   []float64       `json:"Buckets,omitempty"` 
+	Buckets   []float64       `json:"Buckets,omitempty"`
 }
 
 // MetricV2 captures the details for a metric
@@ -1544,8 +1544,8 @@ func getS3TTFBDistributionMD() MetricDescription {
 		Subsystem: ttfbSubsystem,
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls",
-		Type:      histogramMetric, 
-		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}
+		Type:      histogramMetric,
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0},
 	}
 }
 
@@ -1555,8 +1555,8 @@ func getBucketTTFBDistributionMD() MetricDescription {
 		Subsystem: ttfbSubsystem,
 		Name:      ttfbDistribution,
 		Help:      "Distribution of time to first byte across API calls per bucket",
-		Type:      histogramMetric, 
-		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0}
+		Type:      histogramMetric,
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.0, 5.0},
 	}
 }
 

--- a/cmd/metrics-v2_gen.go
+++ b/cmd/metrics-v2_gen.go
@@ -9,9 +9,9 @@ import (
 // MarshalMsg implements msgp.Marshaler
 func (z *MetricDescription) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 5
+	// map header, size 6
 	// string "Namespace"
-	o = append(o, 0x85, 0xa9, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65)
+	o = append(o, 0x86, 0xa9, 0x4e, 0x61, 0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65)
 	o = msgp.AppendString(o, string(z.Namespace))
 	// string "Subsystem"
 	o = append(o, 0xa9, 0x53, 0x75, 0x62, 0x73, 0x79, 0x73, 0x74, 0x65, 0x6d)
@@ -25,6 +25,12 @@ func (z *MetricDescription) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Type"
 	o = append(o, 0xa4, 0x54, 0x79, 0x70, 0x65)
 	o = msgp.AppendString(o, string(z.Type))
+	// string "Buckets"
+	o = append(o, 0xa7, 0x42, 0x75, 0x63, 0x6b, 0x65, 0x74, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Buckets)))
+	for za0001 := range z.Buckets {
+		o = msgp.AppendFloat64(o, z.Buckets[za0001])
+	}
 	return
 }
 
@@ -92,6 +98,25 @@ func (z *MetricDescription) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Type = MetricTypeV2(zb0005)
 			}
+		case "Buckets":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Buckets")
+				return
+			}
+			if cap(z.Buckets) >= int(zb0006) {
+				z.Buckets = (z.Buckets)[:zb0006]
+			} else {
+				z.Buckets = make([]float64, zb0006)
+			}
+			for za0001 := range z.Buckets {
+				z.Buckets[za0001], bts, err = msgp.ReadFloat64Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Buckets", za0001)
+					return
+				}
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -106,7 +131,7 @@ func (z *MetricDescription) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *MetricDescription) Msgsize() (s int) {
-	s = 1 + 10 + msgp.StringPrefixSize + len(string(z.Namespace)) + 10 + msgp.StringPrefixSize + len(string(z.Subsystem)) + 5 + msgp.StringPrefixSize + len(string(z.Name)) + 5 + msgp.StringPrefixSize + len(z.Help) + 5 + msgp.StringPrefixSize + len(string(z.Type))
+	s = 1 + 10 + msgp.StringPrefixSize + len(string(z.Namespace)) + 10 + msgp.StringPrefixSize + len(string(z.Subsystem)) + 5 + msgp.StringPrefixSize + len(string(z.Name)) + 5 + msgp.StringPrefixSize + len(z.Help) + 5 + msgp.StringPrefixSize + len(string(z.Type)) + 8 + msgp.ArrayHeaderSize + (len(z.Buckets) * (msgp.Float64Size))
 	return
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This pull request changes the metric type for `ttfb_seconds_distribution` from a `gauge` to a `histogram` as per Prometheus best practices. This ensures that the metric can be used effectively with the `histogram_quantile` function.

## Motivation and Context
Currently, the `ttfb_seconds_distribution` metric uses a `gauge` type, which is not compatible with Prometheus' `histogram_quantile` function. This change aligns with the correct usage of a `histogram` for time-related distributions in Prometheus.

## How to test this PR?
1. Pull the changes locally.
2. Start MinIO and monitor the `ttfb_seconds_distribution` metric in Prometheus.
3. Use the `histogram_quantile` function on the metric to verify it works correctly with the new histogram type.
4. Run existing unit tests to verify no other functionality is broken.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
