### PR TITLE
fix: token is invalid for admin heal when minio is distErasure at windows

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -1407,7 +1407,7 @@ func (a adminAPIHandlers) HealHandler(w http.ResponseWriter, r *http.Request) {
 		if exists && !nh.hasEnded() && len(nh.currentStatus.Items) > 0 {
 			clientToken := nh.clientToken
 			if globalIsDistErasure {
-				clientToken = fmt.Sprintf("%s:%d", nh.clientToken, GetProxyEndpointLocalIndex(globalProxyEndpoints))
+				clientToken = fmt.Sprintf("%s%s%d", nh.clientToken, getKeySeparator(), GetProxyEndpointLocalIndex(globalProxyEndpoints))
 			}
 			b, err := json.Marshal(madmin.HealStartSuccess{
 				ClientToken:   clientToken,

--- a/cmd/admin-heal-ops.go
+++ b/cmd/admin-heal-ops.go
@@ -260,7 +260,7 @@ func (ahs *allHealState) stopHealSequence(path string) ([]byte, APIError) {
 	} else {
 		clientToken := he.clientToken
 		if globalIsDistErasure {
-			clientToken = fmt.Sprintf("%s:%d", he.clientToken, GetProxyEndpointLocalIndex(globalProxyEndpoints))
+			clientToken = fmt.Sprintf("%s%s%d", he.clientToken, getKeySeparator(), GetProxyEndpointLocalIndex(globalProxyEndpoints))
 		}
 
 		hsp = madmin.HealStopSuccess{
@@ -331,7 +331,7 @@ func (ahs *allHealState) LaunchNewHealSequence(h *healSequence, objAPI ObjectLay
 
 	clientToken := h.clientToken
 	if globalIsDistErasure {
-		clientToken = fmt.Sprintf("%s:%d", h.clientToken, GetProxyEndpointLocalIndex(globalProxyEndpoints))
+		clientToken = fmt.Sprintf("%s%s%d", h.clientToken, getKeySeparator(), GetProxyEndpointLocalIndex(globalProxyEndpoints))
 	}
 
 	if h.clientToken == bgHealingUUID {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Start minio that is distErasure with yaml
```yaml
version: v1
address: ':9000'
pools: # Specify the nodes and drives with pools
  -
    - 'http://127.0.0.1:9000/D:/workspace/go/src/minio/site/{0...1}'
    - 'http://127.0.0.1:9001/D:/workspace/go/src/minio/site/{2...3}'
```
```yaml
version: v1
address: ':9001'
pools: # Specify the nodes and drives with pools
  -
    - 'http://127.0.0.1:9000/D:/workspace/go/src/minio/site/{0...1}'
    - 'http://127.0.0.1:9001/D:/workspace/go/src/minio/site/{2...3}'
```
1. create bucket `mytest`
2. cp some file into `mytest`
3. `mc admin heal minio9000/mytest`

```log
$ mc.exe admin info minio9000
●  127.0.0.1:9000
   Uptime: 1 hour 
   Version: <development>
   Network: 2/2 OK 
   Drives: 2/2 OK 
   Pool: 1

●  127.0.0.1:9001
   Uptime: 1 hour 
   Version: <development>
   Network: 2/2 OK 
   Drives: 2/2 OK 
   Pool: 1

┌──────┬───────────────────────┬─────────────────────┬──────────────┐
│ Pool │ Drives Usage          │ Erasure stripe size │ Erasure sets │
│ 1st  │ 5.4% (total: 1.5 TiB) │ 4                   │ 1            │
└──────┴───────────────────────┴─────────────────────┴──────────────┘

5.2 KiB Used, 1 Bucket, 2 Objects, 12 Versions, 1 Delete Marker
4 drives online, 0 drives offline, EC:2

```

## Motivation and Context

Now we get this:
```
$ mc.exe admin heal minio9000/mytest 
mc.exe: <ERROR> Unable to display heal status. Client token mismatch.
```
For we always return `token:index` back for `globalIsDistErasure:true`
https://github.com/minio/minio/blob/734d1e320a9bff9ba13a9288e91ce9ef4a80d44b/cmd/admin-heal-ops.go#L332-L335
But we just parse token with `_index` here.
https://github.com/minio/minio/blob/712fe1a8dfd64bbc3fde1863cbbf55ae17e7c911/cmd/bucket-listobjects-handlers.go#L230-L244
Window `getKeySeparator()` return `_`
## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
