### PR TITLE
ilm: Expect objects with only free versions when scanning

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -1036,6 +1036,9 @@ type actionsAccountingFn func(oi ObjectInfo, sz, actualSz int64, sizeS *sizeSumm
 // The metadata will be compared to consensus on the object layer before any changes are applied.
 // If no metadata is supplied, -1 is returned if no action is taken.
 func (i *scannerItem) applyActions(ctx context.Context, objAPI ObjectLayer, objInfos []ObjectInfo, lr lock.Retention, sizeS *sizeSummary, fn actionsAccountingFn) {
+	if len(objInfos) == 0 {
+		return
+	}
 	healActions := func(oi ObjectInfo, actualSz int64) int64 {
 		size := actualSz
 		if i.heal.enabled {

--- a/cmd/data-scanner_test.go
+++ b/cmd/data-scanner_test.go
@@ -245,6 +245,12 @@ func TestApplyNewerNoncurrentVersionsLimit(t *testing.T) {
 			wants:       nil,
 			wantExpired: []ObjectToDelete{{ObjectV: ObjectV{ObjectName: obj, VersionID: allVersExpObjInfos[0].VersionID}}},
 		},
+		{
+			// When no versions are present, in practice this could be an object with only free versions
+			objInfos:    nil,
+			wants:       nil,
+			wantExpired: nil,
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("TestApplyNewerNoncurrentVersionsLimit-%d", i), func(t *testing.T) {

--- a/internal/bucket/lifecycle/evaluator.go
+++ b/internal/bucket/lifecycle/evaluator.go
@@ -146,6 +146,9 @@ loop:
 
 // Eval will return a lifecycle event for each object in objs
 func (e *Evaluator) Eval(objs []ObjectOpts) ([]Event, error) {
+	if len(objs) == 0 {
+		return nil, nil
+	}
 	if len(objs) != objs[0].NumVersions {
 		return nil, fmt.Errorf("number of versions mismatch, expected %d, got %d", objs[0].NumVersions, len(objs))
 	}

--- a/internal/bucket/lifecycle/evaluator_test.go
+++ b/internal/bucket/lifecycle/evaluator_test.go
@@ -144,6 +144,12 @@ func TestNewerNoncurrentVersions(t *testing.T) {
 			t.Fatalf("test-%d: got %v, want %v", i+1, gotEvents[i], wantEvents[i])
 		}
 	}
+
+	// Test with zero versions
+	events, err := evaluator.Eval(nil)
+	if len(events) != 0 || err != nil {
+		t.Fatal("expected no events nor error")
+	}
 }
 
 func TestEmptyEvaluator(t *testing.T) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Objects which have been deleted completely but only have free versions tracking tiered object content left behind will have zero regular versions. When scanner visits such objects and attempts to apply lifecycle policy on them, the policy evaluation method Evaluator.Eval panics due to out of bound access in the empty slice.
The fix is to return early when there are no 'regular' versions left, both in applyActions method in scanner and in Evaluator.Eval method in lifecycle package.

## Motivation and Context
Unit tests have been added to cover empty ObjectInfo slice situations.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
