### PR TITLE
Fix buffered streams missing final entries 

### DIFF
--- a/internal/grid/connection.go
+++ b/internal/grid/connection.go
@@ -1634,10 +1634,9 @@ func (c *Connection) handleMuxServerMsg(ctx context.Context, m message) {
 	}
 	if m.Flags&FlagEOF != 0 {
 		if v.cancelFn != nil && m.Flags&FlagPayloadIsErr == 0 {
-			// We must obtain the lock before calling cancelFn
+			// We must obtain the lock before closing
 			// Otherwise others may pick up the error before close is called.
 			v.respMu.Lock()
-			v.cancelFn(errStreamEOF)
 			v.closeLocked()
 			v.respMu.Unlock()
 		} else {


### PR DESCRIPTION
On buffered streams the final entries could be missing, if a lot are delivered when stream ends.

Fixes end-of-stream cancelling return of final entries by canceling with the StreamEOF error.

Backport.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
