### PR TITLE
typo: return actual error from RemoveRemoteTargetsForEndpoint

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -2591,11 +2591,11 @@ func (c *SiteReplicationSys) RemoveRemoteTargetsForEndpoint(ctx context.Context,
 		}
 		targets, terr := globalBucketTargetSys.ListBucketTargets(ctx, t.SourceBucket)
 		if terr != nil {
-			return err
+			return terr
 		}
 		tgtBytes, terr := json.Marshal(&targets)
 		if terr != nil {
-			return err
+			return terr
 		}
 		if _, err = globalBucketMetadataSys.Update(ctx, t.SourceBucket, bucketTargetsFile, tgtBytes); err != nil {
 			return err


### PR DESCRIPTION
Sorry if not applicable, but maybe in this place we should return actual error?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
