### PR TITLE
fix: track object and bucket for exipreAll

### DIFF
--- a/cmd/batch-handlers.go
+++ b/cmd/batch-handlers.go
@@ -997,7 +997,16 @@ func (ri *batchJobInfo) updateAfter(ctx context.Context, api ObjectLayer, durati
 // a single action. e.g batch-expire has an option to expire all versions of an
 // object which matches the given filters.
 func (ri *batchJobInfo) trackMultipleObjectVersions(info expireObjInfo, success bool) {
+	if ri == nil {
+		return
+	}
+
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+
 	if success {
+		ri.Bucket = info.Bucket
+		ri.Object = info.Name
 		ri.Objects += int64(info.NumVersions) - info.DeleteMarkerCount
 		ri.DeleteMarkers += info.DeleteMarkerCount
 	} else {


### PR DESCRIPTION
fix: track object and bucket for exipreAll

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

1. avoid the mutex count issue
2. track the object and bucket for exipreAll

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
