### PR TITLE
feat(helm): support minAvailable and templated name in podDisruptionBudget

### DIFF
--- a/helm/minio/templates/poddisruptionbudget.yaml
+++ b/helm/minio/templates/poddisruptionbudget.yaml
@@ -6,11 +6,16 @@ apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: minio
+  name: {{ template "minio.fullname" . }}
   labels:
     app: {{ template "minio.name" . }}
 spec:
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "minio.name" . }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -585,7 +585,8 @@ networkPolicy:
 ##
 podDisruptionBudget:
   enabled: false
-  maxUnavailable: 1
+  maxUnavailable: ~
+  minAvailable: ~
 
 ## Specify the service account to use for the MinIO pods. If 'create' is set to 'false'
 ## and 'name' is left unspecified, the account 'default' will be used.


### PR DESCRIPTION
## Description

This pull request updates the PodDisruptionBudget configuration in the MinIO Helm chart, improving flexibility by supporting both the `minAvailable` and `maxUnavailable` settings.

It also update the `metadata.name` field to use a templated value.
The name field could be a breaking change. If we prefer to keep the hardcoded value, I can revert the change.
However, I thought it would be better to align with the other manifests.

`maxUnavailable` setting was previously hardcoded with the value '1'. Now, if the value is not explicitly set, it will no longer be applied. This change should also be considered a potential breaking change.

## Motivation and Context


## How to test this PR?

```sh
helm template minio . --set podDisruptionBudget.enabled=true
```
```yaml
---
# Source: minio/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: minio
  labels:
    app: minio
spec:
  selector:
    matchLabels:
      app: minio
```

```sh
helm template minio . \
--set podDisruptionBudget.enabled=true \
--set podDisruptionBudget.maxUnavailable=2 \
--set podDisruptionBudget.minAvailable=1
```
```yaml
---
# Source: minio/templates/poddisruptionbudget.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: minio
  labels:
    app: minio
spec:
  minAvailable: 1
  maxUnavailable: 2
  selector:
    matchLabels:
      app: minio
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
