### PR TITLE
Allow FTPS to force TLS

### DIFF
--- a/docs/debugging/inspect/go.mod
+++ b/docs/debugging/inspect/go.mod
@@ -1,7 +1,8 @@
 module github.com/minio/minio/docs/debugging/inspect
 
-go 1.23
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/klauspost/compress v1.17.11


### PR DESCRIPTION
## Description

Fixes #21249

Example params: `-ftp=force-tls=true -ftp="tls-private-key=ftp/private.key" -ftp="tls-public-cert=ftp/public.crt"`

If MinIO is set up for TLS those certs will be used.

## How to test this PR?

Add `-ftp=force-tls=true` to startup.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
