### PR TITLE
return error for AppendObject() API

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -392,9 +392,6 @@ func registerAPIRouter(router *mux.Router) {
 			HeadersRegexp(xhttp.AmzWriteOffsetBytes, "").
 			HandlerFunc(s3APIMiddleware(errorResponseHandler))
 
-		router.Methods(http.MethodPut).Path("/{object:.+}").
-			HandlerFunc(s3APIMiddleware(api.PutObjectHandler, traceHdrsS3HFlag))
-
 		// PutObject
 		router.Methods(http.MethodPut).Path("/{object:.+}").
 			HandlerFunc(s3APIMiddleware(api.PutObjectHandler, traceHdrsS3HFlag))

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -387,6 +387,14 @@ func registerAPIRouter(router *mux.Router) {
 			HeadersRegexp(xhttp.AmzSnowballExtract, "true").
 			HandlerFunc(s3APIMiddleware(api.PutObjectExtractHandler, traceHdrsS3HFlag))
 
+		// AppendObject to be rejected
+		router.Methods(http.MethodPut).Path("/{object:.+}").
+			HeadersRegexp(xhttp.AmzWriteOffsetBytes, "").
+			HandlerFunc(s3APIMiddleware(errorResponseHandler))
+
+		router.Methods(http.MethodPut).Path("/{object:.+}").
+			HandlerFunc(s3APIMiddleware(api.PutObjectHandler, traceHdrsS3HFlag))
+
 		// PutObject
 		router.Methods(http.MethodPut).Path("/{object:.+}").
 			HandlerFunc(s3APIMiddleware(api.PutObjectHandler, traceHdrsS3HFlag))

--- a/cmd/metacache-stream.go
+++ b/cmd/metacache-stream.go
@@ -758,7 +758,7 @@ func (r *metacacheReader) Close() error {
 	return nil
 }
 
-// metacacheBlockWriter collects blocks and provides a callaback to store them.
+// metacacheBlockWriter collects blocks and provides a callback to store them.
 type metacacheBlockWriter struct {
 	wg           sync.WaitGroup
 	streamErr    error

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -181,6 +181,9 @@ const (
 	AmzChecksumTypeFullObject = "FULL_OBJECT"
 	AmzChecksumTypeComposite  = "COMPOSITE"
 
+	// S3 Express API related constant reject it.
+	AmzWriteOffsetBytes = "x-amz-write-offset-bytes"
+
 	// Post Policy related
 	AmzMetaUUID = "X-Amz-Meta-Uuid"
 	AmzMetaName = "X-Amz-Meta-Name"


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
return error for AppendObject() API

## Motivation and Context
AiStor already supports AppendObject() 
return errors appropriately so that
SDKs can continue to handle this gracefully
for OSS MinIO.

## How to test this PR?
Call AppendObject() API from minio-go must get an
error 501 Not Implemented.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
