### PR TITLE
heal: Avoid disabling scanner healing in single and dist erasure mode

### DIFF
--- a/cmd/data-scanner.go
+++ b/cmd/data-scanner.go
@@ -332,7 +332,7 @@ func scanDataFolder(ctx context.Context, disks []StorageAPI, drive *xlStorage, c
 	}
 
 	var skipHeal atomic.Bool
-	if globalIsErasure || cache.Info.SkipHealing {
+	if !globalIsErasure || cache.Info.SkipHealing {
 		skipHeal.Store(true)
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
A typo disabled the scanner healing in erasure mode. Fix it.


## Motivation and Context
Fix the scanner self healing in a erasure and distributed mode

## How to test this PR?
1. Run a multi drives setup
2. Create a bucket and upload an object
3. Remove the object data from one drive
4. Wait until the scanner healing will fix it (it may take few minutes until the scanner picks it)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
