### PR TITLE
Expand Event Notification Data

### DIFF
--- a/cmd/event-notification.go
+++ b/cmd/event-notification.go
@@ -212,6 +212,7 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 				Key:       keyName,
 				VersionID: args.Object.VersionID,
 				Sequencer: uniqueID,
+				Size:      args.Object.Size,
 			},
 		},
 		Source: event.Source{


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Currently Minio does not send the size of a deleted object via events. This pull request adds the size parameter for these events, enabling consistent tracking of bucket usage, facilitating more accurate monitoring and reporting.

## Motivation and Context
We are currently logging all object updates via webhooks and need to track the size of each object uploaded/deleted to calculate bandwidth usages per bucket, as of now, we are able to log the upload event sizes in real-time via webhook events, however are not able to with the deletion events.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
