### PR TITLE
Add config option to allow enabling bucket notifications on replication

### DIFF
--- a/cmd/event-notification.go
+++ b/cmd/event-notification.go
@@ -241,9 +241,12 @@ func (args eventArgs) ToEvent(escape bool) event.Event {
 }
 
 func sendEvent(args eventArgs) {
-	// avoid generating a notification for REPLICA creation event.
+	// avoid generating a notification for REPLICA creation event unless
+	// replication events have been explicitly enabled.
 	if _, ok := args.ReqParams[xhttp.MinIOSourceReplicationRequest]; ok {
-		return
+		if !globalAPIConfig.isReplicationEventsEnabled() {
+			return
+		}
 	}
 
 	args.Object.Size, _ = args.Object.GetActualSize()

--- a/cmd/handler-api.go
+++ b/cmd/handler-api.go
@@ -56,6 +56,7 @@ type apiConfig struct {
 	gzipObjects                 bool
 	rootAccess                  bool
 	syncEvents                  bool
+	replicationEvents           bool
 	objectMaxVersions           int64
 }
 
@@ -186,6 +187,7 @@ func (t *apiConfig) init(cfg api.Config, setDriveCounts []int, legacy bool) {
 	t.gzipObjects = cfg.GzipObjects
 	t.rootAccess = cfg.RootAccess
 	t.syncEvents = cfg.SyncEvents
+	t.replicationEvents = cfg.ReplicationEvents
 	t.objectMaxVersions = cfg.ObjectMaxVersions
 
 	if t.staleUploadsCleanupInterval != cfg.StaleUploadsCleanupInterval {
@@ -405,6 +407,13 @@ func (t *apiConfig) isSyncEventsEnabled() bool {
 	defer t.mu.RUnlock()
 
 	return t.syncEvents
+}
+
+func (t *apiConfig) isReplicationEventsEnabled() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.replicationEvents
 }
 
 func (t *apiConfig) getObjectMaxVersions() int64 {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -147,6 +147,7 @@ delete_cleanup_interval         (duration)  set to change intervals when deleted
 odirect                         (boolean)   set to enable or disable O_DIRECT for writes under special conditions. NOTE: do not disable O_DIRECT without prior testing (default: 'on')
 root_access                     (boolean)   turn 'off' root credential access for all API calls including s3, admin operations (default: 'on')
 sync_events                     (boolean)   set to enable synchronous bucket notifications (default: 'off')
+replication_events              (boolean)   set to enable bucket notifications on events from replication (default: 'off')
 object_max_versions             (number)    set max allowed number of versions per object (default: '9223372036854775807')
 ```
 
@@ -167,6 +168,7 @@ MINIO_API_DELETE_CLEANUP_INTERVAL         (duration)  set to change intervals wh
 MINIO_API_ODIRECT                         (boolean)   set to enable or disable O_DIRECT for writes under special conditions. NOTE: do not disable O_DIRECT without prior testing (default: 'on')
 MINIO_API_ROOT_ACCESS                     (boolean)   turn 'off' root credential access for all API calls including s3, admin operations (default: 'on')
 MINIO_API_SYNC_EVENTS                     (boolean)   set to enable synchronous bucket notifications (default: 'off')
+MINIO_API_REPLICATION_EVENTS              (boolean)   set to enable bucket notifications on events from replication (default: 'off')
 MINIO_API_OBJECT_MAX_VERSIONS             (number)    set max allowed number of versions per object (default: '9223372036854775807')
 ```
 

--- a/internal/config/api/api.go
+++ b/internal/config/api/api.go
@@ -50,6 +50,7 @@ const (
 	apiGzipObjects                 = "gzip_objects"
 	apiRootAccess                  = "root_access"
 	apiSyncEvents                  = "sync_events"
+	apiReplicationEvents           = "replication_events"
 	apiObjectMaxVersions           = "object_max_versions"
 
 	EnvAPIRequestsMax             = "MINIO_API_REQUESTS_MAX"
@@ -71,8 +72,9 @@ const (
 	EnvAPIODirect                     = "MINIO_API_ODIRECT"
 	EnvAPIDisableODirect              = "MINIO_API_DISABLE_ODIRECT"
 	EnvAPIGzipObjects                 = "MINIO_API_GZIP_OBJECTS"
-	EnvAPIRootAccess                  = "MINIO_API_ROOT_ACCESS" // default config.EnableOn
-	EnvAPISyncEvents                  = "MINIO_API_SYNC_EVENTS" // default "off"
+	EnvAPIRootAccess                  = "MINIO_API_ROOT_ACCESS"        // default config.EnableOn
+	EnvAPISyncEvents                  = "MINIO_API_SYNC_EVENTS"        // default "off"
+	EnvAPIReplicationEvents           = "MINIO_API_REPLICATION_EVENTS" // default "off"
 	EnvAPIObjectMaxVersions           = "MINIO_API_OBJECT_MAX_VERSIONS"
 	EnvAPIObjectMaxVersionsLegacy     = "_MINIO_OBJECT_MAX_VERSIONS"
 )
@@ -158,6 +160,10 @@ var (
 			Value: config.EnableOff,
 		},
 		config.KV{
+			Key:   apiReplicationEvents,
+			Value: config.EnableOff,
+		},
+		config.KV{
 			Key:   apiObjectMaxVersions,
 			Value: "9223372036854775807",
 		},
@@ -182,6 +188,7 @@ type Config struct {
 	GzipObjects                 bool          `json:"gzip_objects"`
 	RootAccess                  bool          `json:"root_access"`
 	SyncEvents                  bool          `json:"sync_events"`
+	ReplicationEvents           bool          `json:"replication_events"`
 	ObjectMaxVersions           int64         `json:"object_max_versions"`
 }
 
@@ -323,6 +330,7 @@ func LookupConfig(kvs config.KVS) (cfg Config, err error) {
 	cfg.StaleUploadsExpiry = staleUploadsExpiry
 
 	cfg.SyncEvents = env.Get(EnvAPISyncEvents, kvs.Get(apiSyncEvents)) == config.EnableOn
+	cfg.ReplicationEvents = env.Get(EnvAPIReplicationEvents, kvs.Get(apiReplicationEvents)) == config.EnableOn
 
 	maxVerStr := env.Get(EnvAPIObjectMaxVersions, "")
 	if maxVerStr == "" {

--- a/internal/config/api/help.go
+++ b/internal/config/api/help.go
@@ -111,6 +111,12 @@ var (
 			Type:        "boolean",
 		},
 		config.HelpKV{
+			Key:         apiReplicationEvents,
+			Description: "set to enable bucket notifications on events from replication" + defaultHelpPostfix(apiReplicationEvents),
+			Optional:    true,
+			Type:        "boolean",
+		},
+		config.HelpKV{
 			Key:         apiObjectMaxVersions,
 			Description: "set max allowed number of versions per object" + defaultHelpPostfix(apiObjectMaxVersions),
 			Optional:    true,


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add a new configuration option that may be set to "on" to enable bucket events whose source is replication.

Presently they are disabled via a simple `if` statement: https://github.com/minio/minio/blob/master/cmd/event-notification.go#L244-L247


## Motivation and Context

This is a feature that is part of S3 that has been disabled in MinIO by customer request.  However it is a useful feature for triggering independent actions in non-clustered applications.


## How to test this PR?

### Info

I've included a docker compose file that runs:

* 2 minio instances to send events
* a rabbitmq instance to receive minio events
* an init script container that sets up buckets, events, and replication
* a test script that prints messages from rabbitmq
* a test script that puts an object into a minio instance to trigger the notifications
    * this test script exits with code 1 when it is finished to bring down the stack

[docker-compose.yml.txt](https://github.com/user-attachments/files/20466379/docker-compose.yml.txt)
(had to add .txt for github)

### Execution

using the compose file attached to this pr:

```sh
# 1. Build the pr branch image
make build
docker build -t fx-minio-test .

# 2. run the test stack with the feature enabled
MINIO_API_REPLICATION_EVENTS=on docker compose up --no-attach rabbitmq --abort-on-container-failure
docker compose down

# 3. run the test stack with the feature disabled
MINIO_API_REPLICATION_EVENTS=off docker compose up --no-attach rabbitmq --abort-on-container-failure
docker compose down


# 4. cleanup
docker image rm fx-minio-test:latest
```

### Expected Output

[logs with feature enabled](https://github.com/user-attachments/files/20466381/enabled.log)

[logs with feature disabled](https://github.com/user-attachments/files/20466385/disabled.log)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
