### PR TITLE
[ILM] fix: add region config to s3 client on ilm s3 backend #21364

### DIFF
--- a/cmd/warm-backend-s3.go
+++ b/cmd/warm-backend-s3.go
@@ -163,6 +163,7 @@ func newWarmBackendS3(conf madmin.TierS3, tier string) (*warmBackendS3, error) {
 		Creds:     creds,
 		Secure:    u.Scheme == "https",
 		Transport: globalRemoteTargetTransport,
+		Region:    conf.Region,
 	}
 	client, err := minio.New(u.Host, opts)
 	if err != nil {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes #21364 by adding `Region` to the Minio client options.

## Motivation and Context
The prior code did not set the region for the Minio client, which caused issues with S3-compatible storage providers that require a region to be set.

I'm not sure how to integrate the existing tests to properly test this; Minio would accept any requests with region not configured on client side, causing the effect to be invisible.

Also note that this may cause issues with existing Minio deployments as the connection detail would be changed.

## How to test this PR?

You may run a two Minio servers:

- One for ILM S3 backend, with region configured to non-default
- One for using the ILM.

And add the first one to the second one as an ILM tier, as shown in the linked issue. I was able to test this PR locally and was able to successfully add a Ncloud Storage as a remote tier.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
