### PR TITLE
fix: honor renamePart's PathNotFound

### DIFF
--- a/cmd/xl-storage.go
+++ b/cmd/xl-storage.go
@@ -2976,7 +2976,7 @@ func (s *xlStorage) RenamePart(ctx context.Context, srcVolume, srcPath, dstVolum
 			return errFileAccessDenied
 		}
 		err = osErrToFileErr(err)
-		if errors.Is(err, errFileNotFound) {
+		if errors.Is(err, errFileNotFound) || errors.Is(err, errFileAccessDenied) {
 			return errUploadIDNotFound
 		}
 		return err


### PR DESCRIPTION
fix: honor renamePart's PathNotFound

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix #21377
that error trigger this:
https://github.com/minio/minio/blob/95c65f4e8f889bbf5b000d097cb2a2a6b5196377/cmd/os-reliable.go#L153-L157

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
