### PR TITLE
fix: mark peer offline when err returns but not reach the ctx deadline.

### DIFF
--- a/internal/rest/client.go
+++ b/internal/rest/client.go
@@ -324,7 +324,7 @@ func (c *Client) CallWithHTTPMethod(ctx context.Context, httpMethod, rpcMethod s
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		if xnet.IsNetworkOrHostDown(err, expectTimeouts) {
+		if xnet.IsNetworkOrHostDown(err, expectTimeouts && ctx.Err() != nil) {
 			if !c.NoMetrics {
 				atomic.AddUint64(&globalStats.errs, 1)
 			}
@@ -360,7 +360,7 @@ func (c *Client) CallWithHTTPMethod(ctx context.Context, httpMethod, rpcMethod s
 		// Limit the ReadAll(), just in case, because of a bug, the server responds with large data.
 		b, err := io.ReadAll(io.LimitReader(resp.Body, c.MaxErrResponseSize))
 		if err != nil {
-			if xnet.IsNetworkOrHostDown(err, expectTimeouts) {
+			if xnet.IsNetworkOrHostDown(err, expectTimeouts && ctx.Err() != nil) {
 				if !c.NoMetrics {
 					atomic.AddUint64(&globalStats.errs, 1)
 				}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Mark peer offline when err returns but not reach the ctx deadline.

## Motivation and Context
In a high-latency network environment, MinIO will not mark a peer that has already down as offline. I have set up a 3 node MinIO cluster. When I run the following command on node3: 
```
tc qdisc add dev eth0 root netem delay 12000ms  # Inject network latency fault
```
and then stop the service on that node. I found that other nodes do not mark node3 as offline. The dial error(`dial tcp xx.xx.xx.xx:9000: i/o timeout`) caused by network latency (dial timeout is 10s) are considered ordinary timeout errors. I think that when the deadline of the incoming context has not yet been reached, this should be regarded as a network error and the node should be marked offline.

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
