### PR TITLE
Helm: Add option for controlling the serviceAccount's automountServiceAccountToken parameter

### DIFF
--- a/helm/minio/templates/serviceaccount.yaml
+++ b/helm/minio/templates/serviceaccount.yaml
@@ -3,4 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | quote }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -594,6 +594,7 @@ serviceAccount:
   ## The name of the service account to use. If 'create' is 'true', a service account with that name
   ## will be created.
   name: "minio-sa"
+  automountServiceAccountToken: true
 
 metrics:
   serviceMonitor:


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR adds an option to configure Kubernete's `automountServiceAccountToken` parameter for the service account created by the helm chart.

## Motivation and Context
Disabling the automatic mounting of service account tokens if they aren't needed is considered good practice, according to CIS benchmarks. Since Kubernete's default is `true`, I also set the option to `true` to not introduce a breaking change.

## How to test this PR?
```sh
helm template .
```
```yaml
# Source: minio/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "minio-sa"
automountServiceAccountToken: true
```
```sh
helm template . --set-string serviceAccount.automountServiceAccountToken=false
```
```yaml
# Source: minio/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: "minio-sa"
automountServiceAccountToken: false
```

## Types of changes
- [No] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [No] Optimization (provides speedup with no functional changes)
- [No] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [No] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [Not needed] Unit tests added/updated
- [Not needed] Internal documentation updated
- [Not needed] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
