### PR TITLE
Reject un-parsable if-unmodified-since dates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,8 @@ linters:
         text: should have a package comment
       - path: (.+)\.go$
         text: error strings should not be capitalized or end with punctuation or a newline
+      - path: (.+)\.go$
+        text: avoid meaningless package names
     paths:
       - third_party$
       - builtin$

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -2432,7 +2432,7 @@ func testAPICopyObjectHandler(obj ObjectLayer, instanceType, bucketName string, 
 			copyModifiedHeader: "Mon, 02 Jan 2217 15:04:05 +00:00",
 			accessKey:          credentials.AccessKey,
 			secretKey:          credentials.SecretKey,
-			expectedRespStatus: http.StatusOK,
+			expectedRespStatus: http.StatusBadRequest,
 		},
 		// Test case - 15, copy metadata from newObject1 with satisfying unmodified header.
 		15: {
@@ -2462,7 +2462,7 @@ func testAPICopyObjectHandler(obj ObjectLayer, instanceType, bucketName string, 
 			copyUnmodifiedHeader: "Mon, 02 Jan 2007 15:04:05 +00:00",
 			accessKey:            credentials.AccessKey,
 			secretKey:            credentials.SecretKey,
-			expectedRespStatus:   http.StatusOK,
+			expectedRespStatus:   http.StatusBadRequest,
 		},
 		// Test case - 18, copy metadata from newObject1 with null versionId
 		18: {

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1496,9 +1496,7 @@ func (s *TestSuiteCommon) TestHeadOnObjectLastModified(c *check) {
 	request.Header.Set("If-Unmodified-Since", "Mon, 02 Jan 2006 15:04:05 +00:00")
 	response, err = s.client.Do(request)
 	c.Assert(err, nil)
-	// Since the "If-Modified-Since" header was ahead in time compared to the actual
-	// modified time of the object expecting the response status to be http.StatusNotModified.
-	c.Assert(response.StatusCode, http.StatusOK)
+	c.Assert(response.StatusCode, http.StatusBadRequest)
 }
 
 // TestHeadOnBucket - Validates response for HEAD on the bucket.

--- a/internal/amztime/parse.go
+++ b/internal/amztime/parse.go
@@ -55,7 +55,9 @@ var httpTimeFormats = []string{
 	// situations where for example aws-sdk-java doesn't
 	// send the correct format.
 	http.TimeFormat,
+	time.RFC1123, // Same, but allows all timezones.
 	"Mon, 2 Jan 2006 15:04:05 GMT",
+	"Mon, 2 Jan 2006 15:04:05 MST",
 }
 
 // ParseHeader parses http.TimeFormat with an acceptable


### PR DESCRIPTION
## Description

.. But also allow fields to be sent in different timezones. This should make "If-Unmodified-Since" and "If-Modified-Since" more reliable.

Behaviour after:

```
λ mc get -debug -H="If-Unmodified-Since: Thu, 03 Jul 2025 03:40:28 UTC" myminio/testbucket/mc.exe .
...
mc: <DEBUG> GET /testbucket/mc.exe HTTP/1.1
Host: 127.0.0.1:9000
User-Agent: MinIO (windows; amd64) minio-go/v7.0.90 mc/DEVELOPMENT.GOGET
Accept-Encoding: identity
Authorization: AWS4-HMAC-SHA256 Credential=minio/20250703/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
If-Unmodified-Since: Thu, 03 Jul 2025 03:40:28 UTC
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20250703T092223Z

mc: <DEBUG> HTTP/1.1 412 Precondition Failed
...
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>PreconditionFailed</Code><Message>At least one of the pre-conditions you specified did not hold</Message><Key>mc.exe</Key><BucketName>testbucket</BucketName><Resource>/testbucket/mc.exe</Resource><RequestId>184EB36332A79950</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>

λ mc get -debug -H="If-Unmodified-Since: XXX, 03 Jul 2025 03:40:28 UTC" myminio/testbucket/mc.exe .

mc: <DEBUG> GET /testbucket/mc.exe HTTP/1.1
Host: 127.0.0.1:9000
User-Agent: MinIO (windows; amd64) minio-go/v7.0.90 mc/DEVELOPMENT.GOGET
Accept-Encoding: identity
Authorization: AWS4-HMAC-SHA256 Credential=minio/20250703/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
If-Unmodified-Since: XXX, 03 Jul 2025 03:40:28 UTC
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20250703T092718Z

mc: <DEBUG> HTTP/1.1 400 Bad Request
....

<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>BadRequest</Code><Message>400 BadRequest</Message><Key>mc.exe</Key><BucketName>testbucket</BucketName><Resource>/testbucket/mc.exe</Resource><RequestId>184EB3A7DFBB0214</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>
```

Before both of these would just cause the field to be ignored.

Fixes #21416

## How to test this PR?

See above...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
