### PR TITLE
fix: ListObjectsV2 empty prefix common prefix issue

### DIFF
--- a/cmd/metacache-entries.go
+++ b/cmd/metacache-entries.go
@@ -160,8 +160,7 @@ func (e *metaCacheEntry) matches(other *metaCacheEntry, strict bool) (prefer *me
 func (e metaCacheEntry) isInDir(dir, separator string) bool {
 	if len(dir) == 0 {
 		// Root
-		idx := strings.Index(e.name, separator)
-		return idx == -1 || idx == len(e.name)-len(separator)
+		return true
 	}
 	ext := strings.TrimPrefix(e.name, dir)
 	if len(ext) != len(e.name) {

--- a/cmd/metacache-entries_test.go
+++ b/cmd/metacache-entries_test.go
@@ -210,6 +210,34 @@ func Test_metaCacheEntry_isInDir(t *testing.T) {
 			sep:      slashSeparator,
 			want:     true,
 		},
+		{
+			testName: "root-subdir-file",
+			entry:    "documents/file1.txt",
+			dir:      "",
+			sep:      slashSeparator,
+			want:     true,
+		},
+		{
+			testName: "root-subdir-deeper-file",
+			entry:    "documents/subfolder/file3.txt",
+			dir:      "",
+			sep:      slashSeparator,
+			want:     true,
+		},
+		{
+			testName: "root-images-file",
+			entry:    "images/photo1.jpg",
+			dir:      "",
+			sep:      slashSeparator,
+			want:     true,
+		},
+		{
+			testName: "root-videos-file",
+			entry:    "videos/movie1.mp4",
+			dir:      "",
+			sep:      slashSeparator,
+			want:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -2058,7 +2058,7 @@ func TestListObjectsV2EmptyPrefixCommonPrefix(t *testing.T) {
 
 func testListObjectsV2EmptyPrefixCommonPrefix(obj ObjectLayer, instanceType string, t1 TestErrHandler) {
 	t, _ := t1.(*testing.T)
-	
+
 	bucket := "test-bucket-empty-prefix-common-prefix"
 	err := obj.MakeBucket(context.Background(), bucket, MakeBucketOptions{})
 	if err != nil {
@@ -2067,7 +2067,7 @@ func testListObjectsV2EmptyPrefixCommonPrefix(obj ObjectLayer, instanceType stri
 
 	testObjects := []string{
 		"documents/file1.txt",
-		"documents/file2.txt", 
+		"documents/file2.txt",
 		"images/photo1.jpg",
 		"images/photo2.jpg",
 		"videos/movie1.mp4",
@@ -2082,7 +2082,7 @@ func testListObjectsV2EmptyPrefixCommonPrefix(obj ObjectLayer, instanceType stri
 			t.Fatalf("%s: %s", instanceType, err.Error())
 		}
 	}
-	
+
 	result, err := obj.ListObjectsV2(context.Background(), bucket, "", "", "/", 1000, false, "")
 	if err != nil {
 		t.Fatalf("%s: Expected to pass, but failed with: %s", instanceType, err.Error())
@@ -2090,17 +2090,22 @@ func testListObjectsV2EmptyPrefixCommonPrefix(obj ObjectLayer, instanceType stri
 
 	expectedPrefixes := []string{"documents/", "images/", "videos/"}
 	expectedObjects := []string{"root-file.txt"}
-	
+
 	if len(result.Prefixes) != len(expectedPrefixes) {
-		t.Errorf("%s: Expected %d prefixes, got %d. Expected: %v, Got: %v", 
+		t.Errorf("%s: Expected %d prefixes, got %d. Expected: %v, Got: %v",
 			instanceType, len(expectedPrefixes), len(result.Prefixes), expectedPrefixes, result.Prefixes)
 	}
 
 	for i, expectedPrefix := range expectedPrefixes {
 		if i >= len(result.Prefixes) || result.Prefixes[i] != expectedPrefix {
-			t.Errorf("%s: Expected prefix %d to be '%s', but got '%s'", 
-				instanceType, i, expectedPrefix, 
-				func() string { if i < len(result.Prefixes) { return result.Prefixes[i] }; return "<missing>" }())
+			t.Errorf("%s: Expected prefix %d to be '%s', but got '%s'",
+				instanceType, i, expectedPrefix,
+				func() string {
+					if i < len(result.Prefixes) {
+						return result.Prefixes[i]
+					}
+					return "<missing>"
+				}())
 		}
 	}
 
@@ -2110,12 +2115,17 @@ func testListObjectsV2EmptyPrefixCommonPrefix(obj ObjectLayer, instanceType stri
 
 	for i, expectedObj := range expectedObjects {
 		if i >= len(result.Objects) || result.Objects[i].Name != expectedObj {
-			t.Errorf("%s: Expected object %d to be '%s', but got '%s'", 
+			t.Errorf("%s: Expected object %d to be '%s', but got '%s'",
 				instanceType, i, expectedObj,
-				func() string { if i < len(result.Objects) { return result.Objects[i].Name }; return "<missing>" }())
+				func() string {
+					if i < len(result.Objects) {
+						return result.Objects[i].Name
+					}
+					return "<missing>"
+				}())
 		}
 	}
 
-	t.Logf("%s: ListObjectsV2 empty prefix test passed. Found %d prefixes and %d objects", 
+	t.Logf("%s: ListObjectsV2 empty prefix test passed. Found %d prefixes and %d objects",
 		instanceType, len(result.Prefixes), len(result.Objects))
 }


### PR DESCRIPTION
When prefix is empty and delimiter is set (typically '/'), MinIO was not returning root-level common prefixes because the isInDir filtering logic was incorrectly excluding entries like 'documents/file1.txt' before they could be processed by fileInfos to extract the common prefix 'documents/'.

This change fixes the isInDir method to include all entries when the directory (prefix) is empty, allowing the fileInfos function to properly calculate common prefixes for root-level directories.

Fixes #21446 - where ListObjectsV2 with empty prefix and delimiter='/' would not return CommonPrefixes for root-level directories, making MinIO incompatible with AWS S3 behavior.

Also adds unit tests covering the missing edge cases to prevent future regressions.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes isInDir method to return true for all entries when prefix is empty, enabling proper common prefix extraction for ListObjectsV2.

## Motivation and Context
Resolves AWS S3 compatibility issue where MinIO's ListObjectsV2 API doesn't 
return common prefixes for root-level directories when using empty prefix 
with delimiter='/'. This affects directory browsing functionality in S3 clients.

## How to test this PR?
1. Create objects in root-level directories: `documents/file1.txt`, `images/photo1.jpg`
2. Call ListObjectsV2 with prefix="" and delimiter="/"
3. Verify CommonPrefixes includes `["documents/", "images/"]`
4. Run unit tests: `go test -run TestListObjectsV2EmptyPrefixCommonPrefix`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
