### PR TITLE
wait for metadata reads on minDisks+1 for HEAD/GET when data==parity

### DIFF
--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -828,6 +828,13 @@ func (er erasureObjects) getObjectFileInfo(ctx context.Context, bucket, object s
 		minDisks = er.setDriveCount - er.defaultParityCount
 	}
 
+	if minDisks == er.setDriveCount/2 {
+		// when data and parity are same we must atleast
+		// wait for response from 1 extra drive to avoid
+		// split-brain.
+		minDisks++
+	}
+
 	calcQuorum := func(metaArr []FileInfo, errs []error) (FileInfo, []FileInfo, []StorageAPI, time.Time, string, error) {
 		readQuorum, _, err := objectQuorumFromMeta(ctx, metaArr, errs, er.defaultParityCount)
 		if err != nil {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
wait for metadata reads on minDisks+1 for HEAD/GET when data==parity

## Motivation and Context
fixes a regression since #19741

Possibly resolves #20215

## How to test this PR?
Requires a setup where data equals parity; a 4-drive configuration with a single file can reproduce this. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
