### PR TITLE
fix(helm): do not suspend versioning by default for buckets, only set versioning if specified(21349)

### DIFF
--- a/helm/minio/templates/_helper_create_bucket.txt
+++ b/helm/minio/templates/_helper_create_bucket.txt
@@ -94,6 +94,8 @@ createBucket() {
 				echo "Suspending versioning for '$BUCKET'"
 				${MC} version suspend myminio/$BUCKET
 			fi
+		else
+		    echo "No versioning action for '$BUCKET'" 
 		fi
 	else
 		echo "Bucket '$BUCKET' versioning unchanged."
@@ -117,6 +119,5 @@ connectToMinio $scheme
 {{ $global := . }}
 # Create the buckets
 {{- range .Values.buckets }}
-createBucket {{ tpl .name $global }} {{ .policy | default "none" | quote }} {{ .purge | default false }} {{ .versioning | default false }} {{ .objectlocking | default false }}
-{{- end }}
+createBucket {{ tpl .name $global }} {{ .policy | default "none" | quote }} {{ .purge | default false }} {{ .versioning | default "" }} {{ .objectlocking | default false }}{{- end }}
 {{- end }}


### PR DESCRIPTION
Refs #21349

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This change updates the Helm chart so that bucket versioning is only set if explicitly configured in the values file. Previously, the chart would always suspend versioning unless it was enabled, which unintentionally altered the default state of new buckets. Now, the chart does not alter bucket versioning unless a value is specified, preventing unintended versioning changes and preserving the unversioned default.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
