### PR TITLE
Check legalHoldPerm

### DIFF
--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -297,6 +297,9 @@ func checkPutObjectLockAllowed(ctx context.Context, rq *http.Request, bucket, ob
 		if legalHold, lerr = objectlock.ParseObjectLockLegalHoldHeaders(rq.Header); lerr != nil {
 			return mode, retainDate, legalHold, toAPIErrorCode(ctx, lerr)
 		}
+		if legalHoldPermErr != ErrNone {
+			return mode, retainDate, legalHold, legalHoldPermErr
+		}
 	}
 
 	if retentionRequested {


### PR DESCRIPTION
## Description

The provided `legalHoldPermErr` parameter should be checked before accepting legal hold upload.

## How to test this PR?

Upload with legal hold on locked enabled bucket.

May send mint test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
