### PR TITLE
fix: when claim-based OIDC is configured, treat unknown roleArn as claim-based auth

### DIFF
--- a/cmd/sts-handlers.go
+++ b/cmd/sts-handlers.go
@@ -414,19 +414,28 @@ func (sts *stsAPIHandlers) AssumeRoleWithSSO(w http.ResponseWriter, r *http.Requ
 	//
 	// Currently, we do not support multiple claim based IDPs, as there is no
 	// defined parameter to disambiguate the intended IDP in this STS request.
-	//
-	// Skip RoleArn existence check when policy mapping is based on a JWT claim.
-	// This is required to support clients (like the AWS CLI or SDKs) that enforce providing a RoleArn,
-	// even though it's not used in claim-based identity mode.
 	roleArn := openid.DummyRoleARN
 	roleArnStr := r.Form.Get(stsRoleArn)
-	if roleArnStr != "" && strings.TrimSpace(iamPolicyClaimNameOpenID()) == "" {
+	isRolePolicyProvider := roleArnStr != ""
+	if isRolePolicyProvider {
 		var err error
 		roleArn, _, err = globalIAMSys.GetRolePolicy(roleArnStr)
 		if err != nil {
-			writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue,
-				fmt.Errorf("Error processing %s parameter: %v", stsRoleArn, err))
-			return
+			// If there is no claim-based provider configured, then an
+			// unrecognized roleArn is an error
+			if strings.TrimSpace(iamPolicyClaimNameOpenID()) == "" {
+				writeSTSErrorResponse(ctx, w, ErrSTSInvalidParameterValue,
+					fmt.Errorf("Error processing %s parameter: %v", stsRoleArn, err))
+				return
+			}
+			// If there *is* a claim-based provider configured, then
+			// treat an unrecognized roleArn the same as no roleArn
+			// at all.  This is to support clients like the AWS SDKs
+			// or CLI that will not allow an AssumeRoleWithWebIdentity
+			// call without a RoleARN parameter - for these cases the
+			// user can supply a dummy ARN, which Minio will ignore.
+			roleArn = openid.DummyRoleARN
+			isRolePolicyProvider = false
 		}
 	}
 
@@ -455,7 +464,7 @@ func (sts *stsAPIHandlers) AssumeRoleWithSSO(w http.ResponseWriter, r *http.Requ
 	}
 
 	var policyName string
-	if roleArnStr != "" && globalIAMSys.HasRolePolicy() && strings.TrimSpace(iamPolicyClaimNameOpenID()) == "" {
+	if isRolePolicyProvider {
 		// If roleArn is used, we set it as a claim, and use the
 		// associated policy when credentials are used.
 		claims[roleArnClaim] = roleArn.String()


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

RoleARN is a required parameter in AssumeRoleWithWebIdentity, according to the standard AWS implementation, and the official AWS SDKs and CLI will not allow you to assume a role from a JWT without also specifying a RoleARN.  This meant that it was not possible to use the official SDKs for claim-based OIDC with Minio (minio/minio#21421), since Minio required you to _omit_ the RoleARN in this case.

minio/minio#21468 attempted to fix this by disabling the validation of the RoleARN when a claim-based provider was configured, but this had the side effect of making it impossible to have a mixture of claim-based and role-based OIDC providers configured at the same time - every authentication would be treated as claim-based, ignoring the RoleARN entirely.

This is an alternative fix, whereby:

- _if_ the `RoleARN` is one that Minio knows about, then use the associated role policy
- if the `RoleARN` is not recognised, but there is a claim-based provider configured, then ignore the role ARN and attempt authentication with the claim-based provider
- if the `RoleARN` is not recognised, and there is _no_ claim-based provider, then return an error.

## Motivation and Context

Necessary to allow claim-based and role-based OIDC providers to co-exist in the same minio instance.
## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here) #21468
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
