### PR TITLE
http/listener: fix bugs and simplify

### DIFF
--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -38,46 +38,39 @@ type httpListener struct {
 	opts        TCPOptions
 	listeners   []net.Listener    // underlying TCP listeners.
 	acceptCh    chan acceptResult // channel where all TCP listeners write accepted connection.
-	ctx         context.Context
+	ctxDoneCh   <-chan struct{}
 	ctxCanceler context.CancelFunc
 }
 
 // start - starts separate goroutine for each TCP listener.  A valid new connection is passed to httpListener.acceptCh.
 func (listener *httpListener) start() {
-	// Closure to send acceptResult to acceptCh.
-	// It returns true if the result is sent else false if returns when doneCh is closed.
-	send := func(result acceptResult) bool {
-		select {
-		case listener.acceptCh <- result:
-			// Successfully written to acceptCh
-			return true
-		case <-listener.ctx.Done():
-			return false
-		}
-	}
-
-	// Closure to handle TCPListener until done channel is closed.
-	handleListener := func(idx int, listener net.Listener) {
+	// Closure to handle listener until httpListener.ctxDoneCh channel is closed.
+	handleListener := func(idx int, ln net.Listener) {
 		for {
-			conn, err := listener.Accept()
-			send(acceptResult{conn, err, idx})
+			conn, err := ln.Accept()
+			select {
+			case listener.acceptCh <- acceptResult{conn, err, idx}:
+			case <-listener.ctxDoneCh:
+				return
+			}
 		}
 	}
 
-	// Start separate goroutine for each TCP listener to handle connection.
-	for idx, tcpListener := range listener.listeners {
-		go handleListener(idx, tcpListener)
+	// Start separate goroutine for each listener to handle connection.
+	for idx, ln := range listener.listeners {
+		go handleListener(idx, ln)
 	}
 }
 
 // Accept - reads from httpListener.acceptCh for one of previously accepted TCP connection and returns the same.
 func (listener *httpListener) Accept() (conn net.Conn, err error) {
 	select {
-	case result, ok := <-listener.acceptCh:
-		if ok {
-			return deadlineconn.New(result.conn).WithReadDeadline(listener.opts.IdleTimeout).WithWriteDeadline(listener.opts.IdleTimeout), result.err
+	case result := <-listener.acceptCh:
+		if result.err != nil {
+			return nil, result.err
 		}
-	case <-listener.ctx.Done():
+		return deadlineconn.New(result.conn).WithReadDeadline(listener.opts.IdleTimeout).WithWriteDeadline(listener.opts.IdleTimeout), result.err
+	case <-listener.ctxDoneCh:
 	}
 	return nil, syscall.EINVAL
 }
@@ -87,10 +80,12 @@ func (listener *httpListener) Close() (err error) {
 	listener.ctxCanceler()
 
 	for i := range listener.listeners {
-		listener.listeners[i].Close()
+		if cerr := listener.listeners[i].Close(); cerr != nil && err == nil {
+			err = cerr
+		}
 	}
 
-	return nil
+	return err
 }
 
 // Addr - net.Listener interface compatible method returns net.Addr.  In case of multiple TCP listeners, it returns '0.0.0.0' as IP address.
@@ -113,6 +108,7 @@ func (listener *httpListener) Addr() (addr net.Addr) {
 
 // Addrs - returns all address information of TCP listeners.
 func (listener *httpListener) Addrs() (addrs []net.Addr) {
+	addrs = make([]net.Addr, 0, len(listener.listeners))
 	for i := range listener.listeners {
 		addrs = append(addrs, listener.listeners[i].Addr())
 	}
@@ -154,6 +150,10 @@ func newHTTPListener(ctx context.Context, serverAddrs []string, opts TCPOptions)
 	listeners := make([]net.Listener, 0, len(serverAddrs))
 	listenErrs = make([]error, len(serverAddrs))
 
+	if opts.Trace == nil {
+		opts.Trace = func(msg string) {} // Noop if not defined.
+	}
+
 	// Unix listener with special TCP options.
 	listenCfg := net.ListenConfig{
 		Control: setTCPParametersFn(opts),
@@ -162,17 +162,12 @@ func newHTTPListener(ctx context.Context, serverAddrs []string, opts TCPOptions)
 	for i, serverAddr := range serverAddrs {
 		l, e := listenCfg.Listen(ctx, "tcp", serverAddr)
 		if e != nil {
-			if opts.Trace != nil {
-				opts.Trace(fmt.Sprint("listenCfg.Listen: ", e))
-			}
+			opts.Trace("listenCfg.Listen: " + e.Error())
 
 			listenErrs[i] = e
 			continue
 		}
-
-		if opts.Trace != nil {
-			opts.Trace(fmt.Sprint("adding listener to ", l.Addr()))
-		}
+		opts.Trace("adding listener to " + l.Addr().String())
 
 		listeners = append(listeners, l)
 	}
@@ -182,15 +177,15 @@ func newHTTPListener(ctx context.Context, serverAddrs []string, opts TCPOptions)
 		return
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
 	listener = &httpListener{
-		listeners: listeners,
-		acceptCh:  make(chan acceptResult, len(listeners)),
-		opts:      opts,
+		listeners:   listeners,
+		acceptCh:    make(chan acceptResult, len(listeners)),
+		opts:        opts,
+		ctxDoneCh:   ctx.Done(),
+		ctxCanceler: cancel,
 	}
-	listener.ctx, listener.ctxCanceler = context.WithCancel(ctx)
-	if opts.Trace != nil {
-		opts.Trace(fmt.Sprint("opening ", len(listener.listeners), " listeners"))
-	}
+	opts.Trace(fmt.Sprintf("opening %d listeners", len(listener.listeners)))
 	listener.start()
 
 	return

--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"syscall"
 	"time"
 
@@ -94,12 +95,11 @@ func (listener *httpListener) Addr() (addr net.Addr) {
 	}
 
 	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
-		if ip := net.ParseIP("0.0.0.0"); ip != nil {
-			tcpAddr.IP = ip
+		return &net.TCPAddr{
+			IP:   net.IPv4zero,
+			Port: tcpAddr.Port,
+			Zone: tcpAddr.Zone,
 		}
-
-		addr = tcpAddr
-		return addr
 	}
 	panic("unknown address type on listener")
 }
@@ -174,6 +174,7 @@ func newHTTPListener(ctx context.Context, serverAddrs []string, opts TCPOptions)
 		// No listeners initialized, no need to continue
 		return
 	}
+	listeners = slices.Clip(listeners)
 
 	ctx, cancel := context.WithCancel(ctx)
 	listener = &httpListener{

--- a/internal/http/listener.go
+++ b/internal/http/listener.go
@@ -80,12 +80,10 @@ func (listener *httpListener) Close() (err error) {
 	listener.ctxCanceler()
 
 	for i := range listener.listeners {
-		if cerr := listener.listeners[i].Close(); cerr != nil && err == nil {
-			err = cerr
-		}
+		listener.listeners[i].Close()
 	}
 
-	return err
+	return nil
 }
 
 // Addr - net.Listener interface compatible method returns net.Addr.  In case of multiple TCP listeners, it returns '0.0.0.0' as IP address.


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
1. Store `ctx.Done` channel in a struct instead of a `ctx`. See: https://go.dev/blog/context-and-structs
2. Return from `handleListener` on `ctx` cancellation preventing goroutines leaks
3. Simplify `handleListener` by removing `send` closure. The `handleListener` is inlined by the compiler
4. Return first error from `Close`
5. Preallocate slice in `Addrs`
6. Reduce duplication in handling `opts.Trace`
7. Prevent original listener address from being modified in `Addr` call
8. Clip unused elements from listeners slice in the constructor

## Motivation and Context
Fix bugs and simplify code

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
