### PR TITLE
fix: use amqp.ParseURL to parse amqp url

### DIFF
--- a/internal/config/notify/parse.go
+++ b/internal/config/notify/parse.go
@@ -34,6 +34,7 @@ import (
 	"github.com/minio/minio/internal/logger"
 	"github.com/minio/pkg/v3/env"
 	xnet "github.com/minio/pkg/v3/net"
+	"github.com/rabbitmq/amqp091-go"
 )
 
 const (
@@ -1705,7 +1706,7 @@ func GetNotifyAMQP(amqpKVS map[string]config.KVS) (map[string]target.AMQPArgs, e
 		if k != config.Default {
 			urlEnv = urlEnv + config.Default + k
 		}
-		url, err := xnet.ParseURL(env.Get(urlEnv, kv.Get(target.AmqpURL)))
+		url, err := amqp091.ParseURI(env.Get(urlEnv, kv.Get(target.AmqpURL)))
 		if err != nil {
 			return nil, err
 		}
@@ -1771,7 +1772,7 @@ func GetNotifyAMQP(amqpKVS map[string]config.KVS) (map[string]target.AMQPArgs, e
 		}
 		amqpArgs := target.AMQPArgs{
 			Enable:            enabled,
-			URL:               *url,
+			URL:               url,
 			Exchange:          env.Get(exchangeEnv, kv.Get(target.AmqpExchange)),
 			RoutingKey:        env.Get(routingKeyEnv, kv.Get(target.AmqpRoutingKey)),
 			ExchangeType:      env.Get(exchangeTypeEnv, kv.Get(target.AmqpExchangeType)),

--- a/internal/event/target/amqp.go
+++ b/internal/event/target/amqp.go
@@ -38,21 +38,21 @@ import (
 
 // AMQPArgs - AMQP target arguments.
 type AMQPArgs struct {
-	Enable            bool     `json:"enable"`
-	URL               xnet.URL `json:"url"`
-	Exchange          string   `json:"exchange"`
-	RoutingKey        string   `json:"routingKey"`
-	ExchangeType      string   `json:"exchangeType"`
-	DeliveryMode      uint8    `json:"deliveryMode"`
-	Mandatory         bool     `json:"mandatory"`
-	Immediate         bool     `json:"immediate"`
-	Durable           bool     `json:"durable"`
-	Internal          bool     `json:"internal"`
-	NoWait            bool     `json:"noWait"`
-	AutoDeleted       bool     `json:"autoDeleted"`
-	PublisherConfirms bool     `json:"publisherConfirms"`
-	QueueDir          string   `json:"queueDir"`
-	QueueLimit        uint64   `json:"queueLimit"`
+	Enable            bool        `json:"enable"`
+	URL               amqp091.URI `json:"url"`
+	Exchange          string      `json:"exchange"`
+	RoutingKey        string      `json:"routingKey"`
+	ExchangeType      string      `json:"exchangeType"`
+	DeliveryMode      uint8       `json:"deliveryMode"`
+	Mandatory         bool        `json:"mandatory"`
+	Immediate         bool        `json:"immediate"`
+	Durable           bool        `json:"durable"`
+	Internal          bool        `json:"internal"`
+	NoWait            bool        `json:"noWait"`
+	AutoDeleted       bool        `json:"autoDeleted"`
+	PublisherConfirms bool        `json:"publisherConfirms"`
+	QueueDir          string      `json:"queueDir"`
+	QueueLimit        uint64      `json:"queueLimit"`
 }
 
 // AMQP input constants.


### PR DESCRIPTION
fix: use amqp.ParseURL to parse amqp url

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix #21525

Looks like our parse can't support vhost here.


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
