### PR TITLE
Fix support for legacy compression env variables

### DIFF
--- a/internal/config/compress/compress.go
+++ b/internal/config/compress/compress.go
@@ -93,9 +93,12 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 		return cfg, err
 	}
 
-	compress := env.Get(EnvCompressState, kvs.Get(config.Enable))
+	compress := env.Get(EnvCompressState, "")
 	if compress == "" {
-		compress = env.Get(EnvCompress, "")
+		compress = env.Get(EnvCompressEnableLegacy, "")
+		if compress == "" {
+			compress = env.Get(EnvCompress, kvs.Get(config.Enable))
+		}
 	}
 	cfg.Enabled, err = config.ParseBool(compress)
 	if err != nil {
@@ -109,9 +112,9 @@ func LookupConfig(kvs config.KVS) (Config, error) {
 		return cfg, nil
 	}
 
-	allowEnc := env.Get(EnvCompressAllowEncryption, kvs.Get(AllowEncrypted))
+	allowEnc := env.Get(EnvCompressAllowEncryption, "")
 	if allowEnc == "" {
-		allowEnc = env.Get(EnvCompressAllowEncryptionLegacy, "")
+		allowEnc = env.Get(EnvCompressAllowEncryptionLegacy, kvs.Get(AllowEncrypted))
 	}
 
 	cfg.AllowEncrypted, err = config.ParseBool(allowEnc)

--- a/internal/config/compress/legacy.go
+++ b/internal/config/compress/legacy.go
@@ -30,6 +30,7 @@ const (
 
 	// These envs were wrong but we supported them for a long time
 	// so keep them here to support existing deployments.
+	EnvCompressEnableLegacy          = "MINIO_COMPRESS_ENABLE"
 	EnvCompressAllowEncryptionLegacy = "MINIO_COMPRESS_ALLOW_ENCRYPTION"
 	EnvCompressExtensionsLegacy      = "MINIO_COMPRESS_EXTENSIONS"
 	EnvCompressMimeTypesLegacy2      = "MINIO_COMPRESS_MIME_TYPES"


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Commit b6eb8dff649b0f46c12d24e89aa11254fb0132fa renamed compression setting environment variables to follow consistent style.

Although it preserved backward compatibility for the most part (i.e. it handled `MINIO_COMPRESS_ALLOW_ENCRYPTION`, `MINIO_COMPRESS_EXTENSIONS`, and `MINIO_COMPRESS_MIME_TYPES`), `MINIO_COMPRESS_ENABLE` was left behind.

Additionally, due to incorrect fallback ordering, and `DefaultKVS` containing `enable=off allow_encryption=off` (so `kvs.Get` should've been tried last), that commit broke `MINIO_COMPRESS_ALLOW_ENCRYPTION` (even though it appeared to be handled), and even older `MINIO_COMPRESS`, too.

The legacy MIME types and extensions variables take precedence over both config and new variables, so they don't need fixing.

## Motivation and Context

We've had docker compose files using `MINIO_COMPRESS_ENABLE` from a long time ago, and accidentally noticed that compression was not actually enabled in new deployments.

## How to test this PR?

Use this docker-compose.yml file:

```yaml
services:
  minio:
    image: minio/minio
    environment:
      MINIO_ROOT_USER: "test"
      MINIO_ROOT_PASSWORD: "testtest123"
      MINIO_COMPRESS_ENABLE: "on"
    entrypoint: ["minio", "server", "/data"]
```

```
sudo docker compose exec minio sh -c 'export MC_DISABLE_PAGER=true; truncate -s 100M /tmp/100M && mc alias set local http://localhost:9000/ test testtest123 && mc mb  local/test && mc put /tmp/100M local/test/100M.bin && du -sh /data'
```

Then build the image locally with `make docker`, replace `image: ` with the image you've just built locally, and try again.

On current MinIO version, this will return `101M /data`, indicating that the all-zeroes 100 megabyte file was not compressed. On the fixed version, it will be `88K	/data`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (b6eb8dff649b0f46c12d24e89aa11254fb0132fa)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
