### PR TITLE
fix: invalid checksum on site replication with conforming checksum types

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -3797,14 +3797,13 @@ func getCRCMeta(oi ObjectInfo, partNum int, h http.Header) (cs map[string]string
 	meta := make(map[string]string)
 	cs, isMP = oi.decryptChecksums(partNum, h)
 	for k, v := range cs {
-		cksum := hash.NewChecksumString(k, v)
-		if cksum == nil {
+		if k == xhttp.AmzChecksumType {
 			continue
 		}
-		if cksum.Valid() {
-			meta[cksum.Type.Key()] = v
-			meta[xhttp.AmzChecksumType] = cs[xhttp.AmzChecksumType]
-			meta[xhttp.AmzChecksumAlgo] = cksum.Type.String()
+		cktype := hash.ChecksumStringToType(k)
+		if cktype.IsSet() {
+			meta[cktype.Key()] = v
+			meta[xhttp.AmzChecksumAlgo] = cktype.String()
 		}
 	}
 	return meta, isMP

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1161,6 +1161,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 				Err:    fmt.Errorf("checksum type mismatch. got %q (%s) expected %q (%s)", checksumType.String(), checksumType.ObjType(), opts.WantChecksum.Type.String(), opts.WantChecksum.Type.ObjType()),
 			}
 		}
+		checksumType |= hash.ChecksumMultipart | hash.ChecksumIncludesMultipart
 	}
 
 	var checksumCombined []byte

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -221,6 +221,10 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		opts.WantChecksum = &hash.Checksum{Type: checksumType}
 	}
 
+	if opts.WantChecksum != nil {
+		opts.WantChecksum.Type |= hash.ChecksumMultipart | hash.ChecksumIncludesMultipart
+	}
+
 	newMultipartUpload := objectAPI.NewMultipartUpload
 
 	res, err := newMultipartUpload(ctx, bucket, object, opts)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This is a port of AIStor 1189 and 568

Please check very carefully @shtripat and @harshavardhana since you were the original authors of that code. Anything missing? 

## Motivation and Context

https://github.com/minio/minio/issues/21534

## How to test this PR?

Successfully ran `minio/docs/site-replication/run-replication-with-checksum-header.sh`, and also functional tests in minio-go. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
