### PR TITLE
Revert `dns.msgUnPath`, fixes #21541

### DIFF
--- a/internal/config/dns/dns_path.go
+++ b/internal/config/dns/dns_path.go
@@ -49,16 +49,9 @@ func dnsJoin(labels ...string) string {
 
 // msgUnPath converts a etcd path to domainName.
 func msgUnPath(s string) string {
-	l := strings.Split(s, etcdPathSeparator)
-	if l[len(l)-1] == "" {
-		l = l[:len(l)-1]
+	ks := strings.Split(strings.Trim(s, etcdPathSeparator), etcdPathSeparator)
+	for i, j := 0, len(ks)-1; i < j; i, j = i+1, j-1 {
+		ks[i], ks[j] = ks[j], ks[i]
 	}
-	if len(l) < 2 {
-		return s
-	}
-	// start with 1, to strip /skydns
-	for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
-		l[i], l[j] = l[j], l[i]
-	}
-	return dnsJoin(l[1 : len(l)-1]...)
+	return strings.Join(ks, ".")
 }

--- a/internal/config/dns/etcd_dns_test.go
+++ b/internal/config/dns/etcd_dns_test.go
@@ -48,12 +48,27 @@ func TestPath(t *testing.T) {
 
 func TestUnPath(t *testing.T) {
 	result1 := msgUnPath("/skydns/local/cluster/staging/service/")
-	if result1 != "service.staging.cluster.local." {
+	if result1 != "service.staging.cluster.local.skydns" {
 		t.Errorf("Failure to get domain from etcd key (with a trailing '/'), expect: 'service.staging.cluster.local.', actually get: '%s'", result1)
 	}
 
 	result2 := msgUnPath("/skydns/local/cluster/staging/service")
-	if result2 != "service.staging.cluster.local." {
+	if result2 != "service.staging.cluster.local.skydns" {
 		t.Errorf("Failure to get domain from etcd key (without trailing '/'), expect: 'service.staging.cluster.local.' actually get: '%s'", result2)
+	}
+
+	result3 := msgUnPath("/singleleveldomain/")
+	if result3 != "singleleveldomain" {
+		t.Errorf("Failure to get domain from etcd key (with leading and trailing '/'), expect: 'singleleveldomain.' actually get: '%s'", result3)
+	}
+
+	result4 := msgUnPath("/singleleveldomain")
+	if result4 != "singleleveldomain" {
+		t.Errorf("Failure to get domain from etcd key (without trailing '/'), expect: 'singleleveldomain.' actually get: '%s'", result4)
+	}
+
+	result5 := msgUnPath("singleleveldomain")
+	if result5 != "singleleveldomain" {
+		t.Errorf("Failure to get domain from etcd key (without leading and trailing '/'), expect: 'singleleveldomain.' actually get: '%s'", result5)
 	}
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
As reported in #21541, a bug was introduced in https://github.com/minio/minio/pull/20487/commits/a84cbabd48ecb8966b7b2467f80790d9773e39eb where the function `msgUnPath` was rewritten and it's behaviour changed. Before it was simply swapping the segments of the split string, whereas now it is also skipping the first one (normally `/skydns`). Additionally, the case where there's nothing to split in the key panics!

<details>
<summary> diff  msgUnPath </summary>

```diff
--- a/internal/config/dns/dns_path.go
+++ b/internal/config/dns/dns_path.go
@@ -47,18 +47,11 @@ func dnsJoin(labels ...string) string {
        return dns.Fqdn(strings.Join(labels, "."))
 }
 
-// msgUnPath converts a etcd path to domainName.
+// msgUnPath converts a etcd path to domainname.
 func msgUnPath(s string) string {
-       l := strings.Split(s, etcdPathSeparator)
-       if l[len(l)-1] == "" {
-               l = l[:len(l)-1]
+       ks := strings.Split(strings.Trim(s, etcdPathSeparator), etcdPathSeparator)
+       for i, j := 0, len(ks)-1; i < j; i, j = i+1, j-1 {
+               ks[i], ks[j] = ks[j], ks[i]
        }
-       if len(l) < 2 {
-               return s
-       }
-       // start with 1, to strip /skydns
-       for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
-               l[i], l[j] = l[j], l[i]
-       }
-       return dnsJoin(l[1 : len(l)-1]...)
-}
+       return strings.Join(ks, ".")
+}
```
</details>

 - I added 3 unit-tests to exercise the cases of a single _unsplitable_ string is passed to `msgUnPath`. 
 - Modifies existing test cases to match old implementation behavior (not skipping first element)
 - Reverts implementation
 
## Motivation and Context

This was found when trying out the federated setup. 

## How to test this PR?

Steps to reproduce this can be found in https://github.com/minio/minio/issues/21541

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression (https://github.com/minio/minio/pull/20487/commits/a84cbabd48ecb8966b7b2467f80790d9773e39eb)
- [x] Unit tests added/updated
