### PR TITLE
Helm chart: allow custom labels on services, service account and PVC

### DIFF
--- a/helm/minio/Chart.yaml
+++ b/helm/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance Object Storage
 name: minio
-version: 5.4.0
+version: 5.4.1
 appVersion: RELEASE.2024-12-18T13-15-44Z
 keywords:
   - minio

--- a/helm/minio/templates/console-service.yaml
+++ b/helm/minio/templates/console-service.yaml
@@ -8,8 +8,11 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if .Values.consoleService.annotations }}
-  annotations: {{- toYaml .Values.consoleService.annotations | nindent 4 }}
+    {{- with .Values.consoleService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.consoleService.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.consoleService.type }}

--- a/helm/minio/templates/post-job.yaml
+++ b/helm/minio/templates/post-job.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- with .Values.postJob.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation

--- a/helm/minio/templates/pvc.yaml
+++ b/helm/minio/templates/pvc.yaml
@@ -9,8 +9,11 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  {{- if .Values.persistence.annotations }}
-  annotations: {{- toYaml .Values.persistence.annotations | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.persistence.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:

--- a/helm/minio/templates/service.yaml
+++ b/helm/minio/templates/service.yaml
@@ -9,8 +9,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     monitoring: "true"
-  {{- if .Values.service.annotations }}
-  annotations: {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/helm/minio/templates/serviceaccount.yaml
+++ b/helm/minio/templates/serviceaccount.yaml
@@ -3,4 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | quote }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -144,6 +144,7 @@ trustedCertsSecret: ""
 persistence:
   enabled: true
   annotations: {}
+  labels: {}
 
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
@@ -181,6 +182,7 @@ service:
   loadBalancerIP: ~
   externalIPs: []
   annotations: {}
+  labels: {}
 
   ## service.loadBalancerSourceRanges Addresses that are allowed when service is LoadBalancer
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
@@ -228,6 +230,7 @@ consoleService:
   loadBalancerIP: ~
   externalIPs: []
   annotations: {}
+  labels: {}
   ## consoleService.loadBalancerSourceRanges Addresses that are allowed when service is LoadBalancer
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   ##
@@ -503,6 +506,7 @@ customCommandJob:
 postJob:
   podAnnotations: {}
   annotations: {}
+  labels: {}
   securityContext:
     enabled: false
     runAsUser: 1000
@@ -594,6 +598,10 @@ serviceAccount:
   ## The name of the service account to use. If 'create' is 'true', a service account with that name
   ## will be created.
   name: "minio-sa"
+  ## Annotations to add to the created service account
+  annotations: {}
+  ## Labels to add to the created service account
+  labels: {}
 
 metrics:
   serviceMonitor:


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Adds the ability in the Helm chart to put custom labels on the remaining resources that did not already support this.

Fixes #21540

## Motivation and Context

The deployment/statefulset and ingress already had the option to add custom labels to the relevant manifests; this commit extends this to the other resources for consistency:

- `service`, `consoleService`, `postJob` and `pvc` already supported custom annotations - added custom labels
- `serviceaccount` supported neither annotations nor labels - added both.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
