### PR TITLE
fix(docker): cicd image

### DIFF
--- a/Dockerfile.cicd
+++ b/Dockerfile.cicd
@@ -1,3 +1,3 @@
-FROM minio/minio:edge
+FROM minio/minio:latest
 
 CMD ["minio", "server", "/data"]

--- a/docker-buildx.sh
+++ b/docker-buildx.sh
@@ -4,8 +4,8 @@ sudo sysctl net.ipv6.conf.all.disable_ipv6=0
 
 remote=$(git remote get-url upstream)
 if test "$remote" != "git@github.com:minio/minio.git"; then
-	echo "Script requires that the 'upstream' remote is set to git@github.com:minio/minio.git"
-	exit 1
+  echo "Script requires that the 'upstream' remote is set to git@github.com:minio/minio.git"
+  exit 1
 fi
 
 git remote update upstream && git checkout master && git rebase upstream/master
@@ -13,24 +13,29 @@ git remote update upstream && git checkout master && git rebase upstream/master
 release=$(git describe --abbrev=0 --tags)
 
 docker buildx build --push --no-cache \
-	--build-arg RELEASE="${release}" \
-	-t "minio/minio:latest" \
-	-t "minio/minio:latest-cicd" \
-	-t "quay.io/minio/minio:latest" \
-	-t "quay.io/minio/minio:latest-cicd" \
-	-t "minio/minio:${release}" \
-	-t "quay.io/minio/minio:${release}" \
-	--platform=linux/arm64,linux/amd64,linux/ppc64le \
-	-f Dockerfile.release .
+    --build-arg RELEASE="${release}" \
+    -t "minio/minio:latest" \
+    -t "quay.io/minio/minio:latest" \
+    -t "minio/minio:${release}" \
+    -t "quay.io/minio/minio:${release}" \
+    --platform=linux/arm64,linux/amd64,linux/ppc64le \
+    -f Dockerfile.release .
+
+docker buildx build --push --no-cache \
+    --build-arg RELEASE="${release}" \
+    -t "minio/minio:latest-cicd" \
+    -t "quay.io/minio/minio:latest-cicd" \
+    --platform=linux/arm64,linux/amd64,linux/ppc64le \
+    -f Dockerfile.cicd .
 
 docker buildx prune -f
 
 docker buildx build --push --no-cache \
-	--build-arg RELEASE="${release}" \
-	-t "minio/minio:${release}-cpuv1" \
-	-t "quay.io/minio/minio:${release}-cpuv1" \
-	--platform=linux/arm64,linux/amd64,linux/ppc64le \
-	-f Dockerfile.release.old_cpu .
+    --build-arg RELEASE="${release}" \
+    -t "minio/minio:${release}-cpuv1" \
+    -t "quay.io/minio/minio:${release}-cpuv1" \
+    --platform=linux/arm64,linux/amd64,linux/ppc64le \
+    -f Dockerfile.release.old_cpu .
 
 docker buildx prune -f
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Changes the CMD of the `latest-cicd` image to `["minio", "server" "/data"]` like it used to be in the `edge-cicd` image.

## Motivation and Context
The `edge-cicd` image was created to make it easier to work with minio in the cicd pipelines.
In GitHub Actions the command is not something you can change for containers/services and thus the `edge-cicd` image was created to enable usage of the minio image in Github pipelines.

## How to test this PR?
Same way you test other docker image builds.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression #21506 
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)

