### PR TITLE
Fix race condition under HTTPStats shared global object (globalHTTPStats)

### DIFF
--- a/cmd/http-stats.go
+++ b/cmd/http-stats.go
@@ -377,12 +377,12 @@ type HTTPStats struct {
 	rejectedRequestsTime    uint64
 	rejectedRequestsHeader  uint64
 	rejectedRequestsInvalid uint64
-	currentS3Requests       HTTPAPIStats
-	totalS3Requests         HTTPAPIStats
-	totalS3Errors           HTTPAPIStats
-	totalS34xxErrors        HTTPAPIStats
-	totalS35xxErrors        HTTPAPIStats
-	totalS3Canceled         HTTPAPIStats
+	currentS3Requests       *HTTPAPIStats
+	totalS3Requests         *HTTPAPIStats
+	totalS3Errors           *HTTPAPIStats
+	totalS34xxErrors        *HTTPAPIStats
+	totalS35xxErrors        *HTTPAPIStats
+	totalS3Canceled         *HTTPAPIStats
 }
 
 func (st *HTTPStats) loadRequestsInQueue() int32 {
@@ -454,5 +454,12 @@ func (st *HTTPStats) updateStats(api string, w *xhttp.ResponseRecorder) {
 
 // Prepare new HTTPStats structure
 func newHTTPStats() *HTTPStats {
-	return &HTTPStats{}
+	return &HTTPStats{
+		currentS3Requests: &HTTPAPIStats{},
+		totalS3Requests:   &HTTPAPIStats{},
+		totalS3Errors:     &HTTPAPIStats{},
+		totalS34xxErrors:  &HTTPAPIStats{},
+		totalS35xxErrors:  &HTTPAPIStats{},
+		totalS3Canceled:   &HTTPAPIStats{},
+	}
 }

--- a/cmd/http-stats_test.go
+++ b/cmd/http-stats_test.go
@@ -28,7 +28,7 @@ import (
 // TestHTTPStatsRaceCondition tests the race condition fix for HTTPStats.
 // This test specifically addresses the race between:
 // - Write operations via updateStats.
-// - Read operations via toServerHTTPStats.
+// - Read operations via toServerHTTPStats(false).
 func TestHTTPStatsRaceCondition(t *testing.T) {
 	httpStats := newHTTPStats()
 	// Simulate the concurrent scenario from the original race condition:

--- a/cmd/http-stats_test.go
+++ b/cmd/http-stats_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	xhttp "github.com/minio/minio/internal/http"
+)
+
+// TestHTTPStatsRaceCondition tests the race condition fix for HTTPStats.
+// This test specifically addresses the race between:
+// - Write operations via updateStats.
+// - Read operations via toServerHTTPStats.
+func TestHTTPStatsRaceCondition(t *testing.T) {
+	httpStats := newHTTPStats()
+	// Simulate the concurrent scenario from the original race condition:
+	// Multiple HTTP request handlers updating stats concurrently,
+	// while background processes are reading the stats for persistence.
+	const numWriters = 100 // Simulate many HTTP request handlers.
+	const numReaders = 50  // Simulate background stats readers.
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	for i := range numWriters {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				switch j % 4 {
+				case 0:
+					httpStats.updateStats("GetObject", &xhttp.ResponseRecorder{})
+				case 1:
+					httpStats.totalS3Requests.Inc("PutObject")
+				case 2:
+					httpStats.totalS3Errors.Inc("DeleteObject")
+				case 3:
+					httpStats.currentS3Requests.Inc("ListObjects")
+				}
+			}
+		}(i)
+	}
+
+	for i := range numReaders {
+		wg.Add(1)
+		go func(readerID int) {
+			defer wg.Done()
+			for range opsPerGoroutine {
+				_ = httpStats.toServerHTTPStats(false)
+				_ = httpStats.totalS3Requests.Load(false)
+				_ = httpStats.currentS3Requests.Load(false)
+				time.Sleep(1 * time.Microsecond)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	finalStats := httpStats.toServerHTTPStats(false)
+	totalRequests := 0
+	for _, v := range finalStats.TotalS3Requests.APIStats {
+		totalRequests += v
+	}
+	if totalRequests == 0 {
+		t.Error("Expected some total requests to be recorded, but got zero")
+	}
+	t.Logf("Total requests recorded: %d", totalRequests)
+	t.Logf("Race condition test passed - no races detected")
+}
+
+// TestHTTPAPIStatsRaceCondition tests concurrent access to HTTPAPIStats specifically.
+func TestHTTPAPIStatsRaceCondition(t *testing.T) {
+	stats := &HTTPAPIStats{}
+	const numGoroutines = 50
+	const opsPerGoroutine = 1000
+
+	var wg sync.WaitGroup
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				stats.Inc("TestAPI")
+			}
+		}(i)
+	}
+
+	for i := range numGoroutines / 2 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for range opsPerGoroutine / 2 {
+				_ = stats.Load(false)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	finalStats := stats.Load(false)
+	expected := numGoroutines * opsPerGoroutine
+	actual := finalStats["TestAPI"]
+	if actual != expected {
+		t.Errorf("Race condition detected: expected %d, got %d (lost %d increments)",
+			expected, actual, expected-actual)
+	}
+}
+
+// TestBucketHTTPStatsRaceCondition tests concurrent access to bucket-level HTTP stats.
+func TestBucketHTTPStatsRaceCondition(t *testing.T) {
+	bucketStats := newBucketHTTPStats()
+	const numGoroutines = 50
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			bucketName := "test-bucket"
+
+			for range opsPerGoroutine {
+				bucketStats.updateHTTPStats(bucketName, "GetObject", nil)
+				recorder := &xhttp.ResponseRecorder{}
+				bucketStats.updateHTTPStats(bucketName, "GetObject", recorder)
+				_ = bucketStats.load(bucketName)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	stats := bucketStats.load("test-bucket")
+	if stats.totalS3Requests == nil {
+		t.Error("Expected bucket stats to be initialized")
+	}
+	t.Logf("Bucket HTTP stats race test passed")
+}

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -197,7 +197,7 @@ func Lookup(s config.Config, rootCAs *x509.CertPool) (l Config, err error) {
 	if err != nil {
 		host = ldapServer
 	}
-	
+
 	l.LDAP = ldap.Config{
 		ServerAddr:    ldapServer,
 		SRVRecordName: getCfgVal(SRVRecordName),


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Fix race condition under HTTPStats shared global object (`globalHTTPStats`). Multiple calls for read and write can be done simultaneously. They would not share the underlying mutex thus creating race conditions.

## Motivation and Context

Good code.

## How to test this PR?

UT.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
