### PR TITLE
fix: incorrect poolID when after decommission adding pools

### DIFF
--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -563,13 +563,11 @@ func newPoolMeta(z *erasureServerPools, prevMeta poolMeta) poolMeta {
 	// or this is a fresh installation (or an existing
 	// installation with pool removed)
 	newMeta.Version = poolMetaVersion
-	idx := -1
-	for _, pool := range z.serverPools {
+	for idx, pool := range z.serverPools {
 		var skip bool
 		for _, currentPool := range prevMeta.Pools {
 			// Preserve any current pool status.
 			if currentPool.CmdLine == pool.endpoints.CmdLine {
-				idx++
 				currentPool.ID = idx
 				newMeta.Pools = append(newMeta.Pools, currentPool)
 				skip = true
@@ -579,7 +577,6 @@ func newPoolMeta(z *erasureServerPools, prevMeta poolMeta) poolMeta {
 		if skip {
 			continue
 		}
-		idx++
 		newMeta.Pools = append(newMeta.Pools, PoolStatus{
 			CmdLine:    pool.endpoints.CmdLine,
 			ID:         idx,

--- a/cmd/erasure-server-pool-decom.go
+++ b/cmd/erasure-server-pool-decom.go
@@ -563,11 +563,14 @@ func newPoolMeta(z *erasureServerPools, prevMeta poolMeta) poolMeta {
 	// or this is a fresh installation (or an existing
 	// installation with pool removed)
 	newMeta.Version = poolMetaVersion
-	for idx, pool := range z.serverPools {
+	idx := -1
+	for _, pool := range z.serverPools {
 		var skip bool
 		for _, currentPool := range prevMeta.Pools {
 			// Preserve any current pool status.
 			if currentPool.CmdLine == pool.endpoints.CmdLine {
+				idx++
+				currentPool.ID = idx
 				newMeta.Pools = append(newMeta.Pools, currentPool)
 				skip = true
 				break
@@ -576,6 +579,7 @@ func newPoolMeta(z *erasureServerPools, prevMeta poolMeta) poolMeta {
 		if skip {
 			continue
 		}
+		idx++
 		newMeta.Pools = append(newMeta.Pools, PoolStatus{
 			CmdLine:    pool.endpoints.CmdLine,
 			ID:         idx,

--- a/internal/config/identity/ldap/config.go
+++ b/internal/config/identity/ldap/config.go
@@ -197,7 +197,7 @@ func Lookup(s config.Config, rootCAs *x509.CertPool) (l Config, err error) {
 	if err != nil {
 		host = ldapServer
 	}
-	
+
 	l.LDAP = ldap.Config{
 		ServerAddr:    ldapServer,
 		SRVRecordName: getCfgVal(SRVRecordName),


### PR DESCRIPTION
fix: incorrect poolID when after decommission adding pools

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix https://github.com/minio/minio/issues/21583
after decommision, reload meta, poolID is incorrect.
Here we can ensure `1st` and no duplicate poolIDs.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
