### PR TITLE
fix: move bearerTokenSecret to correct level in Probe spec

### DIFF
--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -75,6 +75,12 @@ metadata:
     {{- end }}
 spec:
   jobName: {{ template "minio.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.interval }}
+  interval: {{ .Values.metrics.serviceMonitor.interval }}
+  {{- end }}
+  {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+  scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+  {{- end }}
   {{- if .Values.tls.enabled }}
   tlsConfig:
     ca:

--- a/helm/minio/templates/servicemonitor.yaml
+++ b/helm/minio/templates/servicemonitor.yaml
@@ -94,19 +94,13 @@ spec:
   {{- if .Values.metrics.serviceMonitor.relabelConfigsCluster }}
     {{- toYaml .Values.metrics.serviceMonitor.relabelConfigsCluster | nindent 2 }}
   {{- end }}
+  {{- if not .Values.metrics.serviceMonitor.public }}
+  bearerTokenSecret:
+    name: {{ template "minio.fullname" . }}-prometheus
+    key: token
+  {{- end }}
   targets:
     staticConfig:
       static:
       - {{ template "minio.fullname" . }}.{{ .Release.Namespace }}
-      {{- if not .Values.metrics.serviceMonitor.public }}
-      {{- if .Values.metrics.serviceMonitor.interval }}
-      interval: {{ .Values.metrics.serviceMonitor.interval }}
-      {{- end }}
-      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-      {{- end }}
-      bearerTokenSecret:
-        name: {{ template "minio.fullname" . }}-prometheus
-        key: token
-      {{- end }}
 {{- end }}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The bearerTokenSecret was incorrectly placed inside the staticConfig section of the Probe targets, which caused invalid manifest generation when serviceMonitor was enabled. According to Prometheus Operator CRD specification, bearerTokenSecret should be at the spec level alongside jobName, prober, and targets.

Also removes redundant interval and scrapeTimeout configurations from staticConfig as they don't belong there.

Fixes #21029


## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
