### PR TITLE
fix: after saveRebalanceStats cancel will be empty

### DIFF
--- a/cmd/erasure-server-pool-rebalance.go
+++ b/cmd/erasure-server-pool-rebalance.go
@@ -98,12 +98,10 @@ type rebalanceInfo struct {
 
 // rebalanceMeta contains information pertaining to an ongoing rebalance operation.
 type rebalanceMeta struct {
-	cancel          context.CancelFunc `msg:"-"` // to be invoked on rebalance-stop
-	lastRefreshedAt time.Time          `msg:"-"`
-	StoppedAt       time.Time          `msg:"stopTs"` // Time when rebalance-stop was issued.
-	ID              string             `msg:"id"`     // ID of the ongoing rebalance operation
-	PercentFreeGoal float64            `msg:"pf"`     // Computed from total free space and capacity at the start of rebalance
-	PoolStats       []*rebalanceStats  `msg:"rss"`    // Per-pool rebalance stats keyed by pool index
+	StoppedAt       time.Time         `msg:"stopTs"` // Time when rebalance-stop was issued.
+	ID              string            `msg:"id"`     // ID of the ongoing rebalance operation
+	PercentFreeGoal float64           `msg:"pf"`     // Computed from total free space and capacity at the start of rebalance
+	PoolStats       []*rebalanceStats `msg:"rss"`    // Per-pool rebalance stats keyed by pool index
 }
 
 var errRebalanceNotStarted = errors.New("rebalance not started")
@@ -312,8 +310,6 @@ func (r *rebalanceMeta) loadWithOpts(ctx context.Context, store objectIO, opts O
 	if _, err = r.UnmarshalMsg(data[4:]); err != nil {
 		return err
 	}
-
-	r.lastRefreshedAt = time.Now()
 
 	return nil
 }
@@ -944,7 +940,7 @@ func (z *erasureServerPools) StartRebalance() {
 		return
 	}
 	ctx, cancel := context.WithCancel(GlobalContext)
-	z.rebalMeta.cancel = cancel // to be used when rebalance-stop is called
+	z.rebalCancel = cancel // to be used when rebalance-stop is called
 	z.rebalMu.Unlock()
 
 	z.rebalMu.RLock()
@@ -987,10 +983,9 @@ func (z *erasureServerPools) StopRebalance() error {
 		return nil
 	}
 
-	if cancel := r.cancel; cancel != nil {
-		// cancel != nil only on pool leaders
-		r.cancel = nil
+	if cancel := z.rebalCancel; cancel != nil {
 		cancel()
+		z.rebalCancel = nil
 	}
 	return nil
 }

--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -53,8 +53,9 @@ type erasureServerPools struct {
 	poolMetaMutex sync.RWMutex
 	poolMeta      poolMeta
 
-	rebalMu   sync.RWMutex
-	rebalMeta *rebalanceMeta
+	rebalMu     sync.RWMutex
+	rebalMeta   *rebalanceMeta
+	rebalCancel context.CancelFunc
 
 	deploymentID     [16]byte
 	distributionAlgo string


### PR DESCRIPTION
fix: after saveRebalanceStats cancel will be empty

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

fix https://github.com/minio/minio/issues/21543#issuecomment-3310109326
After saveRebalanceStats, canceler will be empty.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
