### PR TITLE
Update README with Docker and Helm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ MinIO has no planned or scheduled releases for this repository.
 While a new release may be cut at any time, there is no timeline for when a subsequent release may occur.
 All existing releases remain accessible through Github or at https://dl.min.io/server/minio/release/ .
 
+The following sections provide instructions for building against the `master` branch for deployments that require access to the latest changes:
+
+- [Install from Source](#install-from-source)
+- [Build Docker Image](#build-docker-image)
+
 ## Install from Source
 
 Use the following commands to compile and run a standalone MinIO server from source.
@@ -70,6 +75,39 @@ For application developers, see <https://docs.min.io/community/minio-object-stor
 > [!NOTE]
 > Production environments using compiled-from-source MinIO binaries do so at their own risk.
 > The AGPLv3 license provides no warranties nor liabilites for any such usage.
+
+## Build Docker Image
+
+You can use the `docker build .` command to build a Docker image on your local host machine.
+You must first [build MinIO](#install-from-source) and ensure the `minio` binary exists in the project root.
+
+The following command builds the Docker image using the default `Dockerfile` in the root project directory with the repository and image tag `myminio:minio`
+
+```sh
+docker build -t myminio:minio .
+```
+
+Use `docker image ls` to confirm the image exists in your local repository.
+You can run the server using standard Docker invocation:
+
+```sh
+docker run -p 9000:9000 -p 9001:9001 myminio:minio server /tmp/minio --console-address :9001
+```
+
+Complete documentation for building Docker containers, managing custom images, or loading images into orchestration platforms is out of scope for this documentation.
+You can modify the `Dockerfile` and `dockerscripts/socker-entrypoint.sh` as-needed to reflect your specific image requirements.
+
+See the [MinIO Container](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html#deploy-minio-container) documentation for more guidance on running MinIO within a Container image.
+
+## Install using Helm Charts
+
+There are two paths for installing MinIO onto Kubernetes infrastructure:
+
+- Use the [MinIO Operator](https://github.com/minio/operator)
+- Use the community-maintained [Helm charts](https://github.com/minio/minio/tree/master/helm/minio)
+
+See the [MinIO Documentation](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html) for guidance on deploying using the Operator.
+The Community Helm chart has instructions in the folder-level README.
 
 ## Test MinIO Connectivity
 


### PR DESCRIPTION
Added instructions for building Docker image and using Helm charts.

This closes the loop on supported methods for deploying MinIO with latest changes.
