### PR TITLE
Bump Go version in toolchain directive to 1.24.8

### DIFF
--- a/cmd/admin-router.go
+++ b/cmd/admin-router.go
@@ -296,7 +296,7 @@ func registerAdminRouter(router *mux.Router, enableConfigOps bool) {
 		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam").HandlerFunc(adminMiddleware(adminAPI.ImportIAM, noGZFlag))
 		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/import-iam-v2").HandlerFunc(adminMiddleware(adminAPI.ImportIAMV2, noGZFlag))
 
-		// IDentity Provider configuration APIs
+		// Identity Provider configuration APIs
 		adminRouter.Methods(http.MethodPut).Path(adminVersion + "/idp-config/{type}/{name}").HandlerFunc(adminMiddleware(adminAPI.AddIdentityProviderCfg))
 		adminRouter.Methods(http.MethodPost).Path(adminVersion + "/idp-config/{type}/{name}").HandlerFunc(adminMiddleware(adminAPI.UpdateIdentityProviderCfg))
 		adminRouter.Methods(http.MethodGet).Path(adminVersion + "/idp-config/{type}").HandlerFunc(adminMiddleware(adminAPI.ListIdentityProviderCfg))

--- a/cmd/metrics-resource.go
+++ b/cmd/metrics-resource.go
@@ -151,7 +151,7 @@ func init() {
 		cpuLoad1:          "CPU load average 1min",
 		cpuLoad5:          "CPU load average 5min",
 		cpuLoad15:         "CPU load average 15min",
-		cpuLoad1Perc:      "CPU load average 1min (perentage)",
+		cpuLoad1Perc:      "CPU load average 1min (percentage)",
 		cpuLoad5Perc:      "CPU load average 5min (percentage)",
 		cpuLoad15Perc:     "CPU load average 15min (percentage)",
 	}

--- a/cmd/metrics-v3-handler.go
+++ b/cmd/metrics-v3-handler.go
@@ -228,7 +228,7 @@ func (h *metricsV3Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// it's the last part of the path. e.g. /bucket/api/<bucket-name>
 		bucketIdx := strings.LastIndex(pathComponents, "/")
 		buckets = append(buckets, pathComponents[bucketIdx+1:])
-		// remove bucket from pathComponents as it is dyanamic and
+		// remove bucket from pathComponents as it is dynamic and
 		// hence not included in the collector path.
 		pathComponents = pathComponents[:bucketIdx]
 	}

--- a/cmd/net_test.go
+++ b/cmd/net_test.go
@@ -82,7 +82,7 @@ func TestSortIPs(t *testing.T) {
 			ipList:       []string{"127.0.0.1"},
 			sortedIPList: []string{"127.0.0.1"},
 		},
-		// Non parsable ip is assumed to be hostame and gets preserved
+		// Non parsable ip is assumed to be hostname and gets preserved
 		// as the left most elements, regardless of IP based sorting.
 		{
 			ipList:       []string{"hostname", "127.0.0.1", "192.168.1.106"},

--- a/cmd/object-api-listobjects_test.go
+++ b/cmd/object-api-listobjects_test.go
@@ -853,7 +853,7 @@ func _testListObjects(obj ObjectLayer, instanceType string, t1 TestErrHandler, v
 		{"test-bucket-list-object", "", "", "", -1, resultCases[0], nil, true},
 		// Testing for very large value of maxKey, this should set maxKeys to listObjectsLimit (20).
 		{"test-bucket-list-object", "", "", "", 1234567890, resultCases[0], nil, true},
-		// Testing for trancated value (21-24).
+		// Testing for truncated value (21-24).
 		{"test-bucket-list-object", "", "", "", 5, resultCases[1], nil, true},
 		{"test-bucket-list-object", "", "", "", 4, resultCases[2], nil, true},
 		{"test-bucket-list-object", "", "", "", 3, resultCases[3], nil, true},
@@ -1167,7 +1167,7 @@ func testListObjectVersions(obj ObjectLayer, instanceType string, t1 TestErrHand
 		}
 	}
 
-	// Formualting the result data set to be expected from ListObjects call inside the tests,
+	// Formulating the result data set to be expected from ListObjects call inside the tests,
 	// This will be used in testCases and used for asserting the correctness of ListObjects output in the tests.
 
 	resultCases := []ListObjectsInfo{
@@ -1591,7 +1591,7 @@ func testListObjectVersions(obj ObjectLayer, instanceType string, t1 TestErrHand
 		{"test-bucket-list-object", "", "", "", -1, resultCases[0], nil, true},
 		// Testing for very large value of maxKey, this should set maxKeys to listObjectsLimit (18).
 		{"test-bucket-list-object", "", "", "", 1234567890, resultCases[0], nil, true},
-		// Testing for trancated value (19-22).
+		// Testing for truncated value (19-22).
 		{"test-bucket-list-object", "", "", "", 5, resultCases[1], nil, true},
 		{"test-bucket-list-object", "", "", "", 4, resultCases[2], nil, true},
 		{"test-bucket-list-object", "", "", "", 3, resultCases[3], nil, true},

--- a/docs/debugging/inspect/go.mod
+++ b/docs/debugging/inspect/go.mod
@@ -2,7 +2,7 @@ module github.com/minio/minio/docs/debugging/inspect
 
 go 1.23.0
 
-toolchain go1.24.2
+toolchain go1.24.8
 
 require (
 	github.com/klauspost/compress v1.17.11

--- a/docs/debugging/pprofgoparser/go.mod
+++ b/docs/debugging/pprofgoparser/go.mod
@@ -1,3 +1,5 @@
 module github.com/minio/minio/docs/debugging/pprofgoparser
 
 go 1.21
+
+toolchain go1.24.8

--- a/docs/debugging/reorder-disks/go.mod
+++ b/docs/debugging/reorder-disks/go.mod
@@ -2,4 +2,6 @@ module github.com/minio/minio/docs/debugging/reorder-disks
 
 go 1.21
 
+toolchain go1.24.8
+
 require github.com/minio/pkg/v3 v3.0.1

--- a/docs/debugging/s3-verify/go.mod
+++ b/docs/debugging/s3-verify/go.mod
@@ -2,7 +2,7 @@ module github.com/minio/minio/docs/debugging/s3-verify
 
 go 1.23.0
 
-toolchain go1.24.2
+toolchain go1.24.8
 
 require github.com/minio/minio-go/v7 v7.0.83
 

--- a/docs/debugging/xattr/go.mod
+++ b/docs/debugging/xattr/go.mod
@@ -2,6 +2,8 @@ module github.com/minio/minio/docs/debugging/xattr
 
 go 1.21
 
+toolchain go1.24.8
+
 require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/xattr v0.4.9

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/minio/minio
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.8
 
 // Install tools using 'go install tool'.
 tool (


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Update to the latest version of Go 1.24

I have added toolchain to all `go.mod` files because recursive security scanners will search for any go.mod file and report it.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
