### PR TITLE
fix: update metric descriptions to specify current MinIO server instance

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -386,7 +386,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(minioNamespace, "capacity_raw", "total"),
-			"Total capacity online in the cluster",
+			"Total capacity online in current MinIO server instance",
 			nil, nil),
 		prometheus.GaugeValue,
 		float64(GetTotalCapacity(server.Disks)),
@@ -396,7 +396,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(minioNamespace, "capacity_raw_free", "total"),
-			"Total free capacity online in the cluster",
+			"Total free capacity online in current MinIO server instance",
 			nil, nil),
 		prometheus.GaugeValue,
 		float64(GetTotalCapacityFree(server.Disks)),
@@ -408,7 +408,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(minioNamespace, "capacity_usable", "total"),
-			"Total usable capacity online in the cluster",
+			"Total usable capacity online in current MinIO server instance",
 			nil, nil),
 		prometheus.GaugeValue,
 		float64(GetTotalUsableCapacity(server.Disks, sinfo)),
@@ -418,7 +418,7 @@ func storageMetricsPrometheus(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName(minioNamespace, "capacity_usable_free", "total"),
-			"Total free usable capacity online in the cluster",
+			"Total free usable capacity online in current MinIO server instance",
 			nil, nil),
 		prometheus.GaugeValue,
 		float64(GetTotalUsableCapacityFree(server.Disks, sinfo)),


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Below code:
```
	server := getLocalServerProperty(globalEndpoints, &http.Request{
		Host: globalLocalNodeName,
	}, true)

```

server.Disks store the local disk from the current minio server, the description should keep the same as 
https://github.com/minio/minio/blob/master/cmd/metrics.go#L427-L435


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
