### PR TITLE
fix(api): Don't send multiple responses for one request

### DIFF
--- a/cmd/api-response_test.go
+++ b/cmd/api-response_test.go
@@ -18,8 +18,12 @@
 package cmd
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/klauspost/compress/gzhttp"
 )
 
 // Tests object location.
@@ -120,5 +124,91 @@ func TestGetURLScheme(t *testing.T) {
 	gotScheme = getURLScheme(tls)
 	if gotScheme != httpsScheme {
 		t.Errorf("Expected %s, got %s", httpsScheme, gotScheme)
+	}
+}
+
+func TestTrackingResponseWriter(t *testing.T) {
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+	trw.WriteHeader(123)
+	if !trw.headerWritten {
+		t.Fatal("headerWritten was not set by WriteHeader call")
+	}
+
+	_, err := trw.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Write unexpectedly failed: %v", err)
+	}
+
+	// Check that WriteHeader and Write were called on the underlying response writer
+	resp := rw.Result()
+	if resp.StatusCode != 123 {
+		t.Fatalf("unexpected status: %v", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response body failed: %v", err)
+	}
+	if string(body) != "hello" {
+		t.Fatalf("response body incorrect: %v", string(body))
+	}
+
+	// Check that Unwrap works
+	if trw.Unwrap() != rw {
+		t.Fatalf("Unwrap returned wrong result: %v", trw.Unwrap())
+	}
+}
+
+func TestHeadersAlreadyWritten(t *testing.T) {
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+
+	if headersAlreadyWritten(trw) {
+		t.Fatal("headers have not been written yet")
+	}
+
+	trw.WriteHeader(123)
+	if !headersAlreadyWritten(trw) {
+		t.Fatal("headers were written")
+	}
+}
+
+func TestHeadersAlreadyWrittenWrapped(t *testing.T) {
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+	wrap1 := &gzhttp.NoGzipResponseWriter{ResponseWriter: trw}
+	wrap2 := &gzhttp.NoGzipResponseWriter{ResponseWriter: wrap1}
+
+	if headersAlreadyWritten(wrap2) {
+		t.Fatal("headers have not been written yet")
+	}
+
+	wrap2.WriteHeader(123)
+	if !headersAlreadyWritten(wrap2) {
+		t.Fatal("headers were written")
+	}
+}
+
+func TestWriteResponseHeadersNotWritten(t *testing.T) {
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+
+	writeResponse(trw, 299, []byte("hello"), "application/foo")
+
+	resp := rw.Result()
+	if resp.StatusCode != 299 {
+		t.Fatal("response wasn't written")
+	}
+}
+
+func TestWriteResponseHeadersWritten(t *testing.T) {
+	rw := httptest.NewRecorder()
+	rw.Code = -1
+	trw := &trackingResponseWriter{ResponseWriter: rw, headerWritten: true}
+
+	writeResponse(trw, 200, []byte("hello"), "application/foo")
+
+	if rw.Code != -1 {
+		t.Fatalf("response was written when it shouldn't have been (Code=%v)", rw.Code)
 	}
 }

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -218,6 +218,8 @@ func s3APIMiddleware(f http.HandlerFunc, flags ...s3HFlag) http.HandlerFunc {
 	handlerName := getHandlerName(f, "objectAPIHandlers")
 
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		w = &trackingResponseWriter{ResponseWriter: w}
+
 		// Wrap the actual handler with the appropriate tracing middleware.
 		var tracedHandler http.HandlerFunc
 		if handlerFlags.has(traceHdrsS3HFlag) {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This change introduces a ResponseWriter which tracks whether a response has already been sent. This is used to prevent a response being sent if something already has (e.g. by a preconditions check function).

## Motivation and Context

In some cases multiple responses are being sent for one request, causing the API server to incorrectly drop connections.
Fixes #21633.

## How to test this PR?

See the reproduction steps in #21633. This issue no longer reproducible with this change in place.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
