### PR TITLE
helm: Add warning when existingClaim is ignored in distributed mode

### DIFF
--- a/helm/minio/templates/NOTES.txt
+++ b/helm/minio/templates/NOTES.txt
@@ -41,3 +41,22 @@ Note: Since NetworkPolicy is enabled, only pods with label
 {{ template "minio.fullname" . }}-client=true"
 will be able to connect to this minio cluster.
 {{- end }}
+
+{{- if and (eq .Values.mode "distributed") .Values.persistence.existingClaim }}
+
+WARNING: persistence.existingClaim is set but will be ignored in distributed mode.
+
+In distributed mode, MinIO automatically creates multiple PersistentVolumeClaims
+using StatefulSet's volumeClaimTemplates for erasure coding.
+Your specified PVC '{{ .Values.persistence.existingClaim }}' will not be used.
+
+To use your existing PVC:
+  - Switch to standalone mode: --set mode=standalone
+
+To use distributed mode with custom storage:
+  - Specify a StorageClass: --set persistence.storageClass=<your-storage-class>
+
+For more information:
+https://github.com/minio/minio/tree/master/helm/minio#distributed-vs-standalone
+
+{{- end }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -147,6 +147,7 @@ persistence:
 
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
+  ## WARNING: In a distributed mode, this value will be ignored.
   ## If defined, PVC must be created manually before volume will be bound
   existingClaim: ""
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Adds a user-friendly warning message when `persistence.existingClaim` is set but will be ignored due to distributed mode deployment.

## Motivation and Context

### Problem Statement
Users frequently configure `persistence.existingClaim` expecting it to work in distributed mode, but this parameter is silently ignored because:
- Distributed mode uses StatefulSet's `volumeClaimTemplates` 
- Multiple PVCs are required for erasure coding (minimum 4)
- Only a single PVC can be specified via `existingClaim`

This leads to:
- User confusion when their custom PVC is not used
- Unexpected fallback to default StorageClass (e.g., `/var/lib/rancher/k3s/storage` in K3s)
- Difficult debugging with no feedback about ignored configuration
- Potential disk space issues on wrong partitions

**Real-world example:**
I deployed MinIO with a custom PVC pointing to an SSD I had mounted at `/mnt/data`. However, in distributed mode, my `existingClaim` was silently ignored, and MinIO ended up filling the root partition (`/var/lib/rancher/k3s/storage`) instead, causing system issues.

### Solution
#### Changes Made
1. **NOTES.txt**: Added conditional warning block that displays when:
   - `mode: distributed` AND
   - `persistence.existingClaim` is set
   
2. **values.yaml**: Enhanced documentation with clear warning comment explaining the limitation

3. **User guidance**: Provides actionable solutions:
   - Switch to standalone mode to use existingClaim
   - Use distributed mode with custom StorageClass

#### Warning Message Preview
```
WARNING: persistence.existingClaim is set but will be ignored in distributed mode.

In distributed mode, MinIO automatically creates multiple PersistentVolumeClaims
using StatefulSet's volumeClaimTemplates for erasure coding.
Your specified PVC 'my-custom-pvc' will not be used.

To use your existing PVC:
  - Switch to standalone mode: --set mode=standalone

To use distributed mode with custom storage:
  - Specify a StorageClass: --set persistence.storageClass=<your-storage-class>

For more information:
https://github.com/minio/minio/tree/master/helm/minio#distributed-vs-standalone
```

## How to test this PR?
### Helm Lint
```bash
$ helm lint helm/minio
==> Linting helm/minio
1 chart(s) linted, 0 chart(s) failed ✅
```

### Test Cases
| Scenario | Expected | Result |
|----------|----------|--------|
| `mode=distributed` + `existingClaim=my-pvc` | ⚠️ Warning shown | ✅ Pass |
| `mode=standalone` + `existingClaim=my-pvc` | No warning | ✅ Pass |
| `mode=distributed` (no existingClaim) | No warning | ✅ Pass |
| `mode=standalone` + `storageClass=local-path` | No warning | ✅ Pass |

### Test Commands Used
```bash
# Warning appears correctly
helm template test helm/minio \
  --set mode=distributed \
  --set persistence.existingClaim=my-pvc \
  --show-only templates/NOTES.txt

# No warning in standalone mode
helm template test helm/minio \
  --set mode=standalone \
  --set persistence.existingClaim=my-pvc \
  --show-only templates/NOTES.txt

# Lint passes
helm lint helm/minio \
  --set mode=distributed \
  --set persistence.existingClaim=my-pvc
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
