### PR TITLE
Adds a new environment variable MINIO_CONSOLE_LICENSE_HIDE  to disabl…

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -200,6 +200,11 @@ func minioConfigToConsoleFeatures() {
 		os.Setenv("CONSOLE_SECURE_REFERRER_POLICY", valueRefer)
 	}
 
+	// Hide license popup if requested
+	if value := env.Get(config.EnvConsoleLicenseHide, ""); value != "" {
+		os.Setenv("CONSOLE_LICENSE_HIDE", value)
+	}
+
 	globalSubnetConfig.ApplyEnv()
 }
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -76,6 +76,7 @@ const (
 	EnvMinIOPrometheusExtraLabels = "MINIO_PROMETHEUS_EXTRA_LABELS"
 	EnvMinIOPrometheusAuthToken   = "MINIO_PROMETHEUS_AUTH_TOKEN"
 	EnvConsoleDebugLogLevel       = "MINIO_CONSOLE_DEBUG_LOGLEVEL"
+	EnvConsoleLicenseHide         = "MINIO_CONSOLE_LICENSE_HIDE"
 
 	EnvUpdate = "MINIO_UPDATE"
 


### PR DESCRIPTION
## Description
Adds a new environment variable `MINIO_CONSOLE_LICENSE_HIDE` to disable the license popup in the MinIO web console.

## Changes
- Added `EnvConsoleLicenseHide` constant in `internal/config/constants.go`
- Added logic in `cmd/common-main.go` to pass the environment variable to console

## Usage
Set `MINIO_CONSOLE_LICENSE_HIDE=true` before starting MinIO to hide the license popup.

## Testing
- Built and tested locally
- No breaking changes to existing functionality
