### PR TITLE
fix: make securityContext and SCC optional for OpenShift compatibility

### DIFF
--- a/helm/minio/templates/securitycontextconstraints.yaml
+++ b/helm/minio/templates/securitycontextconstraints.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.securityContext.enabled .Values.persistence.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+{{- if and .Values.securityContext.enabled .Values.persistence.enabled (.Capabilities.APIVersions.Has "security.openshift.io/v1") (not .Values.openshift) }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/helm/minio/templates/statefulset.yaml
+++ b/helm/minio/templates/statefulset.yaml
@@ -11,6 +11,7 @@
 {{ $accessMode := .Values.persistence.accessMode }}
 {{ $storageClass := .Values.persistence.storageClass }}
 {{ $psize := .Values.persistence.size }}
+{{ $isOpenshift := or .Values.openshift (and (.Capabilities.APIVersions.Has "security.openshift.io/v1") (ne .Values.openshift false)) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -83,9 +84,15 @@ spec:
       {{- end }}
       {{- if and .Values.securityContext.enabled .Values.persistence.enabled }}
       securityContext:
-        {{- omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
-      {{- end }}
-      {{- if .Values.serviceAccount.create }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+        {{- if .Values.securityContext.runAsNonRoot }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        {{- end }}
+        {{- if not $isOpenshift }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       containers:

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -271,6 +271,11 @@ tolerations: []
 affinity: {}
 topologySpreadConstraints: []
 
+## OpenShift configuration
+## If set to "true", disables the creation of SecurityContextConstraints and omits specific
+## user/group IDs from the SecurityContext, allowing OpenShift to automatically assign them.
+openshift: false
+
 ## Add stateful containers to have security context, if enabled MinIO will run as this
 ## user and group NOTE: securityContext is only enabled if persistence.enabled=true
 securityContext:


### PR DESCRIPTION
OpenShift assigns random UIDs to pods for security. The current chart forces runAsUser: 1000 and creates a custom SCC, which causes permission denied errors.

This patch introduces an 'openshift' flag (auto-detectable) that omits specific IDs allowing the cluster to assign them automatically.

Fixes #21652

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR improves OpenShift compatibility by making the security context configuration optional.

Changes implemented:

Added a new openshift flag in values.yaml (defaults to false).

Updated templates/statefulset.yaml to automatically detect OpenShift capabilities or use the override flag. When active, it omits runAsUser, runAsGroup, and fsGroup, allowing the cluster to inject the required randomized UIDs.

Updated templates/securitycontextconstraints.yaml to skip the creation of custom SCCs when running in OpenShift mode, relying on the cluster's default secure SCCs instead.

## Motivation and Context
OpenShift assigns random UIDs to pods for security. The current chart forces runAsUser: 1000 and creates a custom SecurityContextConstraints (SCC), which causes permission denied errors or requires Cluster Admin privileges to deploy.

This patch allows the chart to run "OpenShift-native" without elevated privileges.

Fixes #21652

## How to test this PR?
To verify the fix, run helm template locally:

Regression Test (Default behavior): Run the following command and verify that runAsUser: 1000 is present (preserving backward compatibility for standard K8s):
```bash
helm template . --set mode=distributed | grep "runAsUser: 1000"
```
OpenShift Fix Verification: Run with the flag enabled and verify that runAsUser is absent (allowing OpenShift to handle it):
```bash
helm template . --set mode=distributed --set openshift=true | grep "runAsUser: 1000"
```
(Should return empty)

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
