### PR TITLE
docs: fix typo in comment

### DIFF
--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -2190,7 +2190,7 @@ func (c *SiteReplicationSys) syncToAllPeers(ctx context.Context, addOpts madmin.
 		}
 	}
 
-	// and finally followed by policy mappings for for STS users.
+	// and finally followed by policy mappings for STS users.
 	{
 		// Replicate policy mappings on local to all peers.
 		stsPolicyMap := xsync.NewMapOf[string, MappedPolicy]()


### PR DESCRIPTION
## Summary

Fix duplicated word typo in comment:

- `for for STS` → `for STS` in cmd/site-replication.go