### PR TITLE
Fix typo in values.yaml from 'pof' to 'pod'

### DIFF
--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -29,7 +29,8 @@ mcImage:
   pullPolicy: IfNotPresent
 
 ## minio mode, i.e. standalone or distributed
-mode: distributed ## other supported values are "standalone"
+## supported values are "standalone" and "distributed" (default: "standalone")
+mode: distributed
 
 ## Additional labels to include with deployment or statefulset
 additionalLabels: {}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -105,7 +105,7 @@ rootPassword: ""
 ## others depend on enabled status of corresponding sections.
 existingSecret: ""
 
-## Directory on the MinIO pof
+## Directory on the MinIO pod
 certsPath: "/etc/minio/certs/"
 configPathmc: "/etc/minio/mc/"
 

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -235,7 +235,7 @@ consoleService:
   #   - 10.10.10.0/24
   loadBalancerSourceRanges: []
 
-  ## servconsoleServiceice.externalTrafficPolicy minio service external traffic policy
+  ## consoleService.externalTrafficPolicy minio service external traffic policy
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
@@ -283,7 +283,7 @@ securityContext:
 containerSecurityContext:
   readOnlyRootFilesystem: false
 
-# Additational pod annotations
+# Additional pod annotations
 podAnnotations: {}
 
 # Additional pod labels


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes a typo in helm `values.yml`


## Motivation and Context
I caught this while configuring minio for my local homelab.


## How to test this PR?
NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
