### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -23,8 +23,8 @@ jobs:
         go-version: [1.24.x]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/go-healing.yml
+++ b/.github/workflows/go-healing.yml
@@ -23,8 +23,8 @@ jobs:
         go-version: [1.24.x]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -23,8 +23,8 @@ jobs:
         go-version: [1.24.x]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/go-resiliency.yml
+++ b/.github/workflows/go-resiliency.yml
@@ -23,8 +23,8 @@ jobs:
         go-version: [1.24.x]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,8 @@ jobs:
         go-version: [1.24.x]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/iam-integrations.yaml
+++ b/.github/workflows/iam-integrations.yaml
@@ -75,8 +75,8 @@ jobs:
             openid: "http://127.0.0.1:5556/dex"
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
@@ -129,13 +129,13 @@ jobs:
     name: Test IAM import in new cluster with missing entities
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
       - name: Checkout minio-iam-testing
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: minio/minio-iam-testing
           path: minio-iam-testing
@@ -146,13 +146,13 @@ jobs:
     name: Test IAM import in new cluster with opendid configurations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
       - name: Checkout minio-iam-testing
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: minio/minio-iam-testing
           path: minio-iam-testing

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1
         with:
           project-url: https://github.com/orgs/miniohq/projects/2
           github-token: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '365'

--- a/.github/workflows/mint.yml
+++ b/.github/workflows/mint.yml
@@ -24,10 +24,10 @@ jobs:
           sudo -S rm -rf ${GITHUB_WORKSPACE}
           mkdir ${GITHUB_WORKSPACE}
       - name: checkout-step
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup-go-step
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
 

--- a/.github/workflows/replication.yaml
+++ b/.github/workflows/replication.yaml
@@ -24,8 +24,8 @@ jobs:
         go-version: [1.24.x]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/root-disable.yml
+++ b/.github/workflows/root-disable.yml
@@ -24,8 +24,8 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -13,7 +13,7 @@ jobs:
     name: runner / shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: luizm/action-sh-checker@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Check spelling of repo
       uses: crate-ci/typos@master

--- a/.github/workflows/upgrade-ci-cd.yaml
+++ b/.github/workflows/upgrade-ci-cd.yaml
@@ -24,8 +24,8 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
           cached: false


### PR DESCRIPTION
## Community Contribution License  
All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0).  
By creating this pull request I represent that I have the right to license the contributions to the project maintainers under the Apache 2 license.

## Description  
This PR updates outdated GitHub Action versions to ensure compatibility and security. Specific changes include updating dependencies in various workflows to version `v6`.

## Motivation and Context  
The update aims to maintain alignment with the latest GitHub Actions, ensuring stability, security, and improved functionality across workflows that use outdated versions of actions.

## How to test this PR?  
Tests will be executed in the CI pipeline of the pull request.

## Types of changes  
- [ ] Optimization (provides speedup with no functional changes)

## Checklist:  
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)  
- [ ] Unit tests added/updated  
- [ ] Internal documentation updated  
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)